### PR TITLE
An alternative method (input.py) can be used to download the datasets…

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,13 @@ pipenv install --dev
 ```
 
 ## Recommended datasets
-Datasets are not included in this repository, but we can download the following recommended datasets from Kaggle and GitHub. Please read Bash code `input.sh` in the top directory of this repository.
+Datasets are not included in this repository, but we can download the following recommended datasets from Kaggle and GitHub. 
+
+The necessary datasets can easily be obtained using two different: a bash script (`ìnput.sh`) or a python script (`input.py`). The bash script will not work for Windows OS. You need to setup your Kaggle account properly for both methods. Please follow the steps [provided here to ensure that you can authenticate with the Kaggle API](https://stackoverflow.com/questions/55934733/documentation-for-kaggle-api-within-python#:~:text=Here%20are%20the%20steps%20involved%20in%20using%20the%20Kaggle%20API%20from%20Python.&text=Go%20to%20your%20Kaggle%20account,json%20will%20be%20downloaded).
+
+If you choose to use the python script, note that simply putting the `kaggle.json` in the same folder as `input.py` before executing it will allow `input.py` to find it (not necessary to modify environment variables).
+
+Please read Bash code `input.sh` in the top directory of this repository to better understand its usage.
 
 ### Kaggle
 Kaggle API key and Kaggle package are necessary. Please read [How to Use Kaggle: Public API](https://www.kaggle.com/docs/api).

--- a/input.py
+++ b/input.py
@@ -1,0 +1,41 @@
+import os, glob, shutil, requests
+cwd = os.getcwd()
+# Put your kaggle.json in the same folder as input.py
+os.environ["KAGGLE_CONFIG_DIR"] = cwd+"/"
+from kaggle.api.kaggle_api_extended import KaggleApi
+
+api = KaggleApi()
+api.authenticate()
+path_ = cwd+"/input/"
+
+shutil.rmtree(path_)
+
+api.dataset_download_files('dgrechka/covid19-global-forecasting-locations-population', 
+            path=path_+"/", 
+            unzip=True)
+
+api.dataset_download_files('sudalairajkumar/novel-corona-virus-2019-dataset', 
+            path=path_+"/", 
+            unzip=True)
+
+api.dataset_download_files('lisphilar/covid19-dataset-in-japan', 
+            path=path_+"/", 
+            unzip=True)
+
+file_list = glob.glob(path_+'/*')
+file_list_keep = file_list
+file_list_keep = [ele for ele in file_list_keep if not "time_series_covid_19_" in ele]
+file_list_keep = [ele for ele in file_list_keep if not "COVID19_line_list_data.csv" in ele]
+file_list_keep = [ele for ele in file_list_keep if not "COVID19_open_line_list.csv" in ele]
+for file_ in file_list:
+    if file_ not in file_list_keep:
+        os.remove(file_)
+
+OxCGRT_files = ["https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv", "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest_allchanges.csv", "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest_responses.csv", "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest_withnotes.csv"]
+
+if not os.path.exists(path_+"oxcgrt/"):
+    os.makedirs(path_+"oxcgrt/")
+
+for oxcgrt_file in OxCGRT_files:
+    r = requests.get(oxcgrt_file, allow_redirects=True)
+    open(path_+"oxcgrt/"+oxcgrt_file.rsplit('/', 1)[-1], 'wb').write(r.content)


### PR DESCRIPTION
… instead of input.sh. This method will work on all OSes while input.sh will not work on Windows.
 
This is an implementation of the problem/solution highlighted in #26 .
@lisphilar could you please check that:
1. Changes to the README instructions regarding `input.py` are clear enough ?
2. That the `input.py` file works for you the same way `input.sh` works for you ?