### PR TITLE
add: kaggle.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -134,3 +134,6 @@ example/output/
 
 # Editor
 .vscode
+
+# Kaggle
+kaggle.json


### PR DESCRIPTION
Added `kaggle.json` to .gitignore to avoid uploading Kaggle API keys to the repository.
This is related to #26 and #27 