### PR TITLE
update: decorator for deprecation

### DIFF
--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -17,7 +17,7 @@ from covsirphy.ode import ModelBaseCommon, ModelBase
 from covsirphy.ode import SIR, SIRD, SIRF, SIRFV, SEWIRF
 from covsirphy.phase import PhaseData, ODEData, Estimator
 from covsirphy.phase import SRData, Trend
-from covsirphy.util import line_plot, jpn_map, StopWatch
+from covsirphy.util import line_plot, jpn_map, StopWatch, error
 # Deprecated
 from covsirphy.cleaning import Population
 
@@ -37,7 +37,7 @@ __all__ = [
     "ModelBaseCommon", "ModelBase",
     "SIR", "SIRD", "SIRF", "SIRFV", "SEWIRF",
     "PhaseData", "ODEData", "Estimator", "SRData", "Trend",
-    "line_plot", "jpn_map", "StopWatch",
+    "line_plot", "jpn_map", "StopWatch", "error",
     # Deprecated
     "Population",
 ]

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -5,7 +5,6 @@ import copy
 from datetime import timedelta
 from inspect import signature
 import sys
-import warnings
 import matplotlib
 if not hasattr(sys, "ps1"):
     matplotlib.use("Agg")
@@ -18,6 +17,7 @@ from covsirphy.util import line_plot, box_plot
 from covsirphy.analysis.phase_series import PhaseSeries
 from covsirphy.analysis.simulator import ODESimulator
 from covsirphy.analysis.sr_change import ChangeFinder
+from covsirphy.util.error import deprecate
 
 
 class Scenario(Word):
@@ -388,21 +388,8 @@ class Scenario(Word):
             )
         estimator.accuracy(**kwargs)
 
+    @deprecate(old="Scenario.predict()", new="Scenario.simulate()")
     def predict(self, **kwargs):
-        """
-        Old method. Please use Scenario.simulate().
-
-        Args:
-            kwargs: keyword arguments of Scenario.simulate()
-
-        Returns:
-            (pandas.DataFrame)
-        """
-        warnings.warn(
-            "Please use Scenario simulate() rather than Scenario.predict()",
-            DeprecationWarning,
-            stacklevel=2
-        )
         return self.simulate(**kwargs)
 
     def simulate(self, name="Main", y0_dict=None, show_figure=True, filename=None):

--- a/covsirphy/cleaning/population.py
+++ b/covsirphy/cleaning/population.py
@@ -1,10 +1,10 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import warnings
 import numpy as np
 import pandas as pd
 from covsirphy.cleaning.cbase import CleaningBase
+from covsirphy.util.error import deprecate
 
 
 class PopulationData(CleaningBase):
@@ -170,14 +170,6 @@ class PopulationData(CleaningBase):
 
 
 class Population(PopulationData):
-    """
-    This is deprecated and please use PopulationData class.
-    """
-
+    @deprecate(old="Population()", new="PopulationData()")
     def __init__(self, filename):
         super().__init__(filename)
-        warnings.warn(
-            "Please use PopulationData() class rather than Population()",
-            DeprecationWarning,
-            stacklevel=2
-        )

--- a/covsirphy/util/error.py
+++ b/covsirphy/util/error.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import warnings
+
+
+def deprecate(old, new=None):
+    """
+    Decorator to raise deprecation warning.
+
+    Args:
+        old (str): description of the old method/function
+        new (str): description of the new method/function
+    """
+    def _deprecate(func):
+        def wrapper(*args, **kwargs):
+            if new is None:
+                comment = f"{old} is deprecated"
+            else:
+                comment = f"Please use {new} rather than {old}"
+            warnings.warn(
+                comment,
+                DeprecationWarning,
+                stacklevel=2
+            )
+            return func(*args, **kwargs)
+        return wrapper
+    return _deprecate


### PR DESCRIPTION
(Refactoring)

Add `deprecate` decorator in error.py
This enables us to show deprecation warning with easy way.

```Python
from covsirphy.util.error import deprecate
...
    @deprecate(old="old method name", new="new method name")
    def ...
```