### PR TITLE
add: KeyError when not include expected cols

### DIFF
--- a/covsirphy/cleaning/country_data.py
+++ b/covsirphy/cleaning/country_data.py
@@ -84,6 +84,11 @@ class CountryData(CleaningBase):
         df = self._raw.copy()
         # Rename the columns
         df = df.rename(self.var_dict, axis=1)
+        # Confirm the expected columns are in raw data
+        expected_cols = [
+            self.DATE, self.C, self.F, self.R
+        ]
+        self.validate_dataframe(df, name="the raw data", columns=expected_cols)
         # Add province column
         if self.province_col:
             df = df.rename({self.province_col: self.PROVINCE}, axis=1)

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -78,6 +78,11 @@ class JHUData(CleaningBase):
             },
             axis=1
         )
+        # Confirm the expected columns are in raw data
+        expected_cols = [
+            self.DATE, self.COUNTRY, self.PROVINCE, self.C, self.F, self.R
+        ]
+        self.validate_dataframe(df, name="the raw data", columns=expected_cols)
         # Datetime columns
         df[self.DATE] = pd.to_datetime(df[self.DATE])
         # Country
@@ -131,7 +136,8 @@ class JHUData(CleaningBase):
             self
         """
         if not isinstance(country_data, CountryData):
-            raise TypeError("Type of @country_data must be <covsirphy.CountryData>.")
+            raise TypeError(
+                "Type of @country_data must be <covsirphy.CountryData>.")
         # Read new dataset
         country = country_data.country
         new = country_data.cleaned()

--- a/covsirphy/cleaning/oxcgrt.py
+++ b/covsirphy/cleaning/oxcgrt.py
@@ -42,7 +42,7 @@ class OxCGRTData(CleaningBase):
                     - Date (pd.TimeStamp): Observation date
                     - Country (str): country/region name
                     - ISO3 (str): ISO 3166-1 alpha-3, like JPN
-                    - other column names are defined by OxCGRT.COL_DICT
+                    - other column names are defined by OxCGRTData.COL_DICT
         """
         df = self._raw.copy()
         # Rename the columns
@@ -50,6 +50,10 @@ class OxCGRTData(CleaningBase):
         df = df.rename(
             {"CountryName": self.COUNTRY, "Date": self.DATE, "CountryCode": self.ISO3},
             axis=1
+        )
+        # Confirm the expected columns are in raw data
+        self.validate_dataframe(
+            df, name="the raw data", columns=self.OXCGRT_COLS
         )
         # Read date records
         df[self.DATE] = pd.to_datetime(df[self.DATE], format="%Y%m%d")
@@ -85,7 +89,7 @@ class OxCGRTData(CleaningBase):
                     reset index
                 Columns:
                     - Date (pd.TimeStamp): Observation date
-                    - other column names are defined by OxCGRT.COL_DICT
+                    - other column names are defined by OxCGRTData.COL_DICT
         """
         df = self._cleaned_df.copy()
         if country is None and iso3 is None:

--- a/covsirphy/cleaning/population.py
+++ b/covsirphy/cleaning/population.py
@@ -45,6 +45,11 @@ class PopulationData(CleaningBase):
             },
             axis=1
         )
+        # Confirm the expected columns are in raw data
+        expected_cols = [
+            self.COUNTRY, self.PROVINCE, self.N
+        ]
+        self.validate_dataframe(df, name="the raw data", columns=expected_cols)
         # ISO3
         if self.ISO3 not in df.columns:
             df[self.ISO3] = "-"

--- a/covsirphy/cleaning/word.py
+++ b/covsirphy/cleaning/word.py
@@ -136,7 +136,7 @@ class Word(object):
             target (pandas.DataFrame): the dataframe to validate
             name (str): argument name of the dataframe
             time_index (bool): if True, the dataframe must has DatetimeIndex
-            columns (list[str]/None): the columns the dataframe must have
+            columns (list[str] or None): the columns the dataframe must have
             df (pandas.DataFrame): as-is the target
         """
         df = target.copy()
@@ -151,7 +151,9 @@ class Word(object):
             cols_str = ', '.join(
                 [col for col in columns if col not in df.columns]
             )
-            raise KeyError(f"@{name} must have {cols_str}, but not included.")
+            raise KeyError(
+                f"Expected columns were not included in {name}. {cols_str} must be included."
+            )
         return df
 
     @staticmethod


### PR DESCRIPTION
This is related to #42 and #49.
KeyError will be raised when the expected columns are not included in the raw data.
