### PR TITLE
fix: removement of 0th phase in Scenario class

### DIFF
--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -185,6 +185,22 @@ class Scenario(Term):
             self.series_dict[name] = copy.deepcopy(self.series_dict[self.MAIN])
         self.series_dict[name].clear(include_past=include_past)
 
+    def remove(self, name="Main"):
+        """
+        Clear phase information.
+
+        Args:
+            name (str): phase series name
+                - if 'Main', main phase series will be used
+                - if not registered, new phaseseries will be created
+            include_past (bool):
+                - if True, include past phases.
+                - future phase are always included
+        """
+        self.clear(name=name, include_past=True)
+        # Delete 0th phase
+        self.series_dict[name].delete(phase="0th")
+
     def summary(self, name=None):
         """
         Summarize the series of phases and return a dataframe.

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -128,6 +128,7 @@ class Scenario(Term):
             - If @model is None, the model of the last phase will be used.
             - Tau will be fixed as the last phase's value.
             - kwargs: Default values are the parameter values of the last phase.
+            - If @end_date and @days are None, the end date will be the last date of the records.
         """
         # Parse arguments
         name = self.MAIN if name == "Main" else name
@@ -137,11 +138,12 @@ class Scenario(Term):
         start_date = self.series_dict[name].next_date()
         if end_date is None:
             if days is None:
-                raise NameError("@end_date or @days must be specified.")
-            if not isinstance(days, int):
+                end_date = self.last_date
+            elif not isinstance(days, int):
                 raise TypeError("@days must be an integer.")
-            end_obj = self.date_obj(start_date) + timedelta(days=days)
-            end_date = end_obj.strftime(self.DATE_FORMAT)
+            else:
+                end_obj = self.date_obj(start_date) + timedelta(days=days)
+                end_date = end_obj.strftime(self.DATE_FORMAT)
         population = population or self.population
         summary_df = self.series_dict[name].summary()
         if model is None:
@@ -187,7 +189,7 @@ class Scenario(Term):
 
     def remove(self, name="Main"):
         """
-        Clear phase information.
+        Remove phase information.
 
         Args:
             name (str): phase series name

--- a/covsirphy/phase/phase_series.py
+++ b/covsirphy/phase/phase_series.py
@@ -226,7 +226,11 @@ class PhaseSeries(Term):
         info_dict = self.to_dict()
         # Convert to dataframe
         df = pd.DataFrame.from_dict(info_dict, orient="index")
-        return df.fillna(self.UNKNOWN)
+        df = df.fillna(self.UNKNOWN)
+        # If empty, add column names
+        if df.empty:
+            return pd.DataFrame(columns=[self.TENSE, self.START, self.END, self.N])
+        return df
 
     def to_dict(self):
         """
@@ -295,7 +299,7 @@ class PhaseSeries(Term):
             if v != 0
         ]
         if not un_date_objects:
-            return list(self.phase_dict.keys())[-1]
+            return list(self.phase_dict.keys())[0]
         return un_date_objects[-1]
 
     def next_date(self):

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -31,3 +31,20 @@ class TestScenario(object):
         assert isinstance(summary_df, pd.DataFrame)
         desc_df = scenario.describe()
         assert isinstance(desc_df, pd.DataFrame)
+
+    def test_add_past_phases(self, jhu_data, population_data):
+        scenario = Scenario(jhu_data, population_data, country="Italy")
+        # With specified end date
+        scenario.remove()
+        scenario.add_phase(end_date="01May2020")
+        scenario.add_phase(end_date="01Jun2020")
+        date_df = scenario.summary()
+        scenario.add_phase()
+        assert len(date_df) == 3
+        # with specified length of the phase
+        scenario.remove()
+        scenario.add_phase(days=30)
+        scenario.add_phase(days=30)
+        scenario.add_phase()
+        length_df = scenario.summary()
+        assert len(length_df) == 3

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -38,8 +38,8 @@ class TestScenario(object):
         scenario.remove()
         scenario.add_phase(end_date="01May2020")
         scenario.add_phase(end_date="01Jun2020")
-        date_df = scenario.summary()
         scenario.add_phase()
+        date_df = scenario.summary()
         assert len(date_df) == 3
         # with specified length of the phase
         scenario.remove()


### PR DESCRIPTION
# Related issues
This is related to #118 

We can add past phases as follows.

```Python
import covsirphy as cs
data_loader = cs.DataLoader("input")
jhu_data = data_loader.jhu(local_file="./input/covid_19_data.csv")
population_data = data_loader.population(local_file="./input/locations_population.csv")
scenario = cs.Scenario(jhu_data, population_data, country="US")
scenario.remove()
scenario.add_phase(end_date="01May2020")
scenario.add_phase(end_date="01Jun2020")
scenario.add_phase()
scenario.summary()
```
or,
```Python
scenario.remove()
scenario.add_phase(days=30)
scenario.add_phase(days=30)
scenario.add_phase()
scenario.summary()
```

When both of `end_date` and `days` are None, the end date will be the last date of the records.