### PR TITLE
update: use dataset cleaned by data resource

### DIFF
--- a/covsirphy/cleaning/dataloader.py
+++ b/covsirphy/cleaning/dataloader.py
@@ -533,8 +533,10 @@ class DataLoader(Term):
             For some countries, province-level data is included.
         """
         warnings.simplefilter("ignore", ResourceWarning)
-        c_res = covid19dh.covid19(country=None, level=1, verbose=False)
-        p_res = covid19dh.covid19(country=None, level=2, verbose=False)
+        c_res = covid19dh.covid19(
+            country=None, level=1, verbose=False, raw=False)
+        p_res = covid19dh.covid19(
+            country=None, level=2, verbose=False, raw=False)
         try:
             c_df, c_cite = c_res
             p_df, p_cite = p_res


### PR DESCRIPTION
## Related issues
This is related to #210 and #212 

## What was chaged?
Rather than raw records, records cleaned by COVID-19 Data Hub will be used.