### PR TITLE
update: include initial phase as default

### DIFF
--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -398,14 +398,12 @@ class Scenario(Term):
         df = df.loc[:, columns]
         return df.dropna(how="all", axis=1).fillna(self.UNKNOWN)
 
-    def trend(self, set_phases=True, include_init_phase=True, name="Main",
-              show_figure=True, filename=None, **kwargs):
+    def trend(self, set_phases=True, name="Main", show_figure=True, filename=None, **kwargs):
         """
         Perform S-R trend analysis and set phases.
 
         Args:
             set_phases (bool): if True, set phases automatically with S-R trend analysis
-            include_init_phase (bool): whether use initial phase or not
             name (str): phase series name
             show_figure (bool): if True, show the result as a figure
             filename (str): filename of the figure, or None (show figure)
@@ -413,9 +411,6 @@ class Scenario(Term):
 
         Returns:
             covsirphy.Scenario: self
-
-        Notes:
-            If @set_phase is True and@include_init_phase is False, initial phase will not be included.
         """
         if "n_points" in kwargs.keys():
             raise ValueError(
@@ -434,8 +429,9 @@ class Scenario(Term):
             filename=filename,
             **kwargs
         )
-        if include_init_phase:
-            self._series_dict[name].enable("0th")
+        if "include_init_phase" not in kwargs or kwargs["include_init_phase"]:
+            return self
+        self._series_dict[name].disable("0th")
         return self
 
     def _ensure_past_phases(self, phases=None, name="Main"):

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -417,6 +417,10 @@ class Scenario(Term):
                 "@n_points argument is un-necessary"
                 " because the number of change points will be automatically determined."
             )
+        try:
+            include_init_phase = kwargs.pop("include_init_phase")
+        except KeyError:
+            include_init_phase = True
         self._ensure_name(name)
         sr_df = self.jhu_data.to_sr(
             country=self.country, province=self.province, population=self.population
@@ -429,9 +433,8 @@ class Scenario(Term):
             filename=filename,
             **kwargs
         )
-        if "include_init_phase" not in kwargs or kwargs["include_init_phase"]:
-            return self
-        self._series_dict[name].disable("0th")
+        if not include_init_phase:
+            self._series_dict[name].disable("0th")
         return self
 
     def _ensure_past_phases(self, phases=None, name="Main"):

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -398,7 +398,7 @@ class Scenario(Term):
         df = df.loc[:, columns]
         return df.dropna(how="all", axis=1).fillna(self.UNKNOWN)
 
-    def trend(self, set_phases=True, include_init_phase=False, name="Main",
+    def trend(self, set_phases=True, include_init_phase=True, name="Main",
               show_figure=True, filename=None, **kwargs):
         """
         Perform S-R trend analysis and set phases.

--- a/covsirphy/phase/phase_series.py
+++ b/covsirphy/phase/phase_series.py
@@ -374,7 +374,6 @@ class PhaseSeries(Term):
         self.clear(include_past=True)
         _, end_dates = finder.date_range()
         [self.add(end_date=end_date) for end_date in end_dates]
-        self.disable("0th")
         return self
 
     def simulate(self, record_df, y0_dict=None):

--- a/example/usage_phases.ipynb
+++ b/example/usage_phases.ipynb
@@ -170,8 +170,8 @@
     "# Set phase with S-R trend analysis\n",
     "scenario.trend(set_phases=True)\n",
     "scenario.summary()\n",
-    "# If necessary, initial (0th) phase can be disabled.\n",
-    "scenario.disable(phases=[\"0th\"])"
+    "# If necessary, initial (0th) phase can be disabled\n",
+    "# scenario.disable(phases=[\"0th\"])"
    ]
   },
   {
@@ -190,8 +190,8 @@
    },
    "outputs": [],
    "source": [
-    "# Before: 3rd is 16Jun2020-23Jun2020, 4th is 24Jun2020-04Jul2020\n",
-    "# After: 3rd is 16Jun2020-04Jul2020, 4th is the same as old 5th\n",
+    "# Before: 3rd is 12Jun2020-19Jun2020, 4th is 20Jun2020-29Jun2020\n",
+    "# After: 3rd is 12Jun2020-29Jun2020, 4th is the same as old 5th\n",
     "scenario.combine(phases=[\"3rd\", \"4th\"])\n",
     "scenario.summary()"
    ]
@@ -219,7 +219,7 @@
    "metadata": {},
    "source": [
     "## (Optional) Separate phases manually\n",
-    "Because point of $(x, y) = (S, R)$ jumped on 30May2020, we will separete the 1st phase with this change point and reset phase names."
+    "Because point of $(x, y) = (S, R)$ jumped on 29May2020, we will separete the 1st phase with this change point and reset phase names."
    ]
   },
   {
@@ -230,9 +230,9 @@
    },
    "outputs": [],
    "source": [
-    "# Before: 1st is 20May2020-05Jun2020\n",
-    "# After: 1st is 20May2020-29May2020, 2nd is 30May2020-05Jun2020\n",
-    "scenario.separate(date=\"30May2020\", phase=\"1st\")\n",
+    "# Before: 1st is 20May2020-02Jun2020\n",
+    "# After: 1st is 20May2020-28May2020, 2nd is 29May2020-02Jun2020\n",
+    "scenario.separate(date=\"29May2020\", phase=\"1st\")\n",
     "scenario.summary()"
    ]
   },
@@ -251,8 +251,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## (Optional) Delete phases manually\n",
-    "Because 1st phase seems un-stable, delete the 1st phase and reset the phase names."
+    "## (Optional) Disable phases manually\n",
+    "Phases can be disable for parameter eatimation. Disabled phases can be enabled with `Scenario.enable()` method."
    ]
   },
   {
@@ -261,8 +261,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Remove 1st phase\n",
-    "scenario.delete(phases=[\"1st\"])\n",
+    "# Disable 0th phase\n",
+    "scenario.disable(phases=[\"0th\"])\n",
     "scenario.summary()"
    ]
   },
@@ -273,6 +273,17 @@
    "outputs": [],
    "source": [
     "scenario.trend(set_phases=False)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Enable 0th phase\n",
+    "scenario.enable(phases=[\"0th\"])\n",
+    "scenario.summary()"
    ]
   },
   {
@@ -300,14 +311,16 @@
    "outputs": [],
    "source": [
     "# Set 0th phase to set the start date of 1st phase\n",
-    "scenario.add(end_date=\"29May2020\")\n",
-    "# Add 1st phase and delete 0th phase\n",
-    "scenario.add(end_date=\"05Jun2020\").delete(phases=[\"0th\"])\n",
+    "scenario.add(end_date=\"19May2020\")\n",
+    "# Add 1st phase and disable 0th phase\n",
+    "scenario.add(end_date=\"28May2020\").disable(phases=[\"0th\"])\n",
     "# Add 2nd phase\n",
-    "scenario.add(end_date=\"15Jun2020\")\n",
+    "scenario.add(end_date=\"02Jun2020\")\n",
     "# Add 3rd phase\n",
-    "scenario.add(end_date=\"04Jul2020\")\n",
-    "# Add 4th phase to the last of the records\n",
+    "scenario.add(end_date=\"11Jun2020\")\n",
+    "# Add 4th phase\n",
+    "scenario.add(end_date=\"29Jun2020\")\n",
+    "# Add 5th phase to the last of the records\n",
     "scenario.add().summary()"
    ]
   },

--- a/example/usage_phases.ipynb
+++ b/example/usage_phases.ipynb
@@ -10,12 +10,12 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": 3
+   "version": "3.8.5-final"
   },
   "orig_nbformat": 2,
   "kernelspec": {
-   "name": "python_defaultSpec_1595604802490",
-   "display_name": "Python 3.8.2 64-bit ('.venv': venv)"
+   "name": "python_defaultSpec_1599558577601",
+   "display_name": "Python 3.8.5 64-bit ('covid19-sir': pipenv)"
   }
  },
  "nbformat": 4,
@@ -167,29 +167,11 @@
    },
    "outputs": [],
    "source": [
-    "# Set phase with S-R trend analysis and delete initial (0th) phase\n",
+    "# Set phase with S-R trend analysis\n",
     "scenario.trend(set_phases=True)\n",
-    "# This is the same as\n",
-    "# scenario.trend(set_phases=True, include_init_phase=True)\n",
-    "# scenario.delete(phases=[\"0th\"])"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "We found five change points from 01May2020 to 20Jul2020. This means that there 6 phases (Initial, 1st, 2nd,...5th). Here, we removed Initial (0th) phase because the number of cases is small in 0th phase and may not show SIR-like trend."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "tags": []
-   },
-   "outputs": [],
-   "source": [
-    "scenario.summary()"
+    "scenario.summary()\n",
+    "# If necessary, initial (0th) phase can be disabled.\n",
+    "scenario.disable(phases=[\"0th\"])"
    ]
   },
   {

--- a/example/usage_phases.ipynb
+++ b/example/usage_phases.ipynb
@@ -14,7 +14,7 @@
   },
   "orig_nbformat": 2,
   "kernelspec": {
-   "name": "python_defaultSpec_1599558577601",
+   "name": "python_defaultSpec_1599558922114",
    "display_name": "Python 3.8.5 64-bit ('covid19-sir': pipenv)"
   }
  },

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -89,7 +89,6 @@ class TestPhaseSeries(object):
         series.trend(sr_df)
         series.trend(sr_df, show_figure=False)
         # Summary
-        assert not series.unit("0th")
         assert len(series) == 7
         # Last phase
         assert series.unit(phase="last") == series.unit(phase="6th")

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -123,8 +123,7 @@ class TestPhaseSeries(object):
         series.trend(sr_df, show_figure=False)
         assert len(series) == 7
         # Deletion of 0th phase is the same as disabling 0th phase
-        series.disable("0th")
-        assert not series.unit("0th")
+        series.delete("0th")
         series.enable("0th")
         assert len(series) == 7
         assert "5th" in series.to_dict()

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -89,7 +89,7 @@ class TestPhaseSeries(object):
         series.trend(sr_df, show_figure=False)
         # Summary
         assert not series.unit("0th")
-        assert len(series) == 6
+        assert len(series) == 7
         # Last phase
         assert series.unit(phase="last") == series.unit(phase="6th")
         # Un-registered phase
@@ -120,20 +120,20 @@ class TestPhaseSeries(object):
         sr_df = jhu_data.to_sr(country=country, population=population)
         series = PhaseSeries("01Apr2020", "01Aug2020", population)
         series.trend(sr_df, show_figure=False)
-        assert len(series) == 6
+        assert len(series) == 7
         # Deletion of 0th phase is the same as disabling 0th phase
-        series.enable("0th")
-        series.delete("0th")
-        assert len(series) == 6
-        assert "5th" in series.to_dict()
+        series.disable("0th")
         assert not series.unit("0th")
+        series.enable("0th")
+        assert len(series) == 7
+        assert "5th" in series.to_dict()
         # Delete phase (not the last registered phase)
         new_second = PhaseUnit(
             series.unit("2nd").start_date,
             series.unit("3rd").end_date,
             series.unit("2nd").population)
         series.delete("3rd")
-        assert len(series) == 5
+        assert len(series) == 7
         assert series.unit("2nd") == new_second
         # Delete the last phase
         old_last = series.unit("last")

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -132,7 +132,7 @@ class TestPhaseSeries(object):
             series.unit("3rd").end_date,
             series.unit("2nd").population)
         series.delete("3rd")
-        assert len(series) == 7
+        assert len(series) == 6
         assert series.unit("2nd") == new_second
         # Delete the last phase
         old_last = series.unit("last")

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -121,12 +121,12 @@ class TestPhaseSeries(object):
         sr_df = jhu_data.to_sr(country=country, population=population)
         series = PhaseSeries("01Apr2020", "01Aug2020", population)
         series.trend(sr_df, show_figure=False)
-        assert len(series) == 7
+        assert len(series) == 6
         # Deletion of 0th phase is the same as disabling 0th phase
         series.disable("0th")
         assert not series.unit("0th")
         series.enable("0th")
-        assert len(series) == 7
+        assert len(series) == 6
         assert "5th" in series.to_dict()
         # Delete phase (not the last registered phase)
         new_second = PhaseUnit(
@@ -134,7 +134,7 @@ class TestPhaseSeries(object):
             series.unit("3rd").end_date,
             series.unit("2nd").population)
         series.delete("3rd")
-        assert len(series) == 7
+        assert len(series) == 6
         assert series.unit("2nd") == new_second
         # Delete the last phase
         old_last = series.unit("last")

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -90,7 +90,7 @@ class TestPhaseSeries(object):
         series.trend(sr_df, show_figure=False)
         # Summary
         assert not series.unit("0th")
-        assert len(series) == 6
+        assert len(series) == 7
         # Last phase
         assert series.unit(phase="last") == series.unit(phase="6th")
         # Un-registered phase
@@ -121,12 +121,12 @@ class TestPhaseSeries(object):
         sr_df = jhu_data.to_sr(country=country, population=population)
         series = PhaseSeries("01Apr2020", "01Aug2020", population)
         series.trend(sr_df, show_figure=False)
-        assert len(series) == 6
+        assert len(series) == 7
         # Deletion of 0th phase is the same as disabling 0th phase
         series.disable("0th")
         assert not series.unit("0th")
         series.enable("0th")
-        assert len(series) == 6
+        assert len(series) == 7
         assert "5th" in series.to_dict()
         # Delete phase (not the last registered phase)
         new_second = PhaseUnit(
@@ -134,7 +134,7 @@ class TestPhaseSeries(object):
             series.unit("3rd").end_date,
             series.unit("2nd").population)
         series.delete("3rd")
-        assert len(series) == 6
+        assert len(series) == 7
         assert series.unit("2nd") == new_second
         # Delete the last phase
         old_last = series.unit("last")

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -73,6 +73,7 @@ class TestPhaseSeries(object):
     @pytest.mark.parametrize("country", ["Japan"])
     def test_trend(self, jhu_data, population_data, country):
         warnings.simplefilter("ignore", category=UserWarning)
+        warnings.simplefilter("ignore", category=DeprecationWarning)
         # Setting
         population = population_data.value(country)
         sr_df = jhu_data.to_sr(country=country, population=population)
@@ -89,7 +90,7 @@ class TestPhaseSeries(object):
         series.trend(sr_df, show_figure=False)
         # Summary
         assert not series.unit("0th")
-        assert len(series) == 7
+        assert len(series) == 6
         # Last phase
         assert series.unit(phase="last") == series.unit(phase="6th")
         # Un-registered phase

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -127,9 +127,9 @@ class TestScenario(object):
             snl.trend(show_figure=False, n_points=3)
         # Disable/enable
         length = len(snl["Main"])
-        snl.enable(phases=["0th"], name="Main")
-        assert len(snl["Main"]) == length + 1
         snl.disable(phases=["0th"], name="Main")
+        assert len(snl["Main"]) == length - 1
+        snl.enable(phases=["0th"], name="Main")
         assert len(snl["Main"]) == length
         with pytest.raises(TypeError):
             snl.enable(phases="0th", name="Main")


### PR DESCRIPTION
## Related issues
This is related to #228 

## Fix bugs
"include_initial_phase" of `Scenario.trend() will be True as default.