### PR TITLE
fix: population-pyramid path in input.py script

### DIFF
--- a/input.py
+++ b/input.py
@@ -30,13 +30,16 @@ shutil.rmtree(path_)
 kaggle_datasets = [
     "sudalairajkumar/novel-corona-virus-2019-dataset",
     "dgrechka/covid19-global-forecasting-locations-population",
-    "hotessy/population-pyramid-2019",
     "marcoferrante/covid19-prevention-in-italy",
     "lisphilar/covid19-dataset-in-japan",
 ]
 
 for dataset in kaggle_datasets:
     api.dataset_download_files(dataset, path=path_, unzip=True)
+
+population_pyramid_path_ = path_ + "/population-pyramid-2019"
+kaggle_dataset_population_pyramid = "hotessy/population-pyramid-2019"
+api.dataset_download_files(kaggle_dataset_population_pyramid, path=population_pyramid_path_, unzip=True)
 
 # OxCGRT
 oxcgrt_file = "https://raw.githubusercontent.com/OxCGRT/covid-policy-tracker/master/data/OxCGRT_latest.csv"

--- a/input.py
+++ b/input.py
@@ -37,6 +37,8 @@ kaggle_datasets = [
 for dataset in kaggle_datasets:
     api.dataset_download_files(dataset, path=path_, unzip=True)
 
+# Download Kaggle population pyramid datasets
+# Extract the datasets in population-pyramid-2019 folder
 population_pyramid_path_ = path_ + "/population-pyramid-2019"
 kaggle_dataset_population_pyramid = "hotessy/population-pyramid-2019"
 api.dataset_download_files(kaggle_dataset_population_pyramid, path=population_pyramid_path_, unzip=True)


### PR DESCRIPTION
## Related issues
This is related to issues #266, #267.

## Fix bugs
Updated `input.py` script with the correct population pyramid path for extracting the relative datasets under `kaggle/input/population-pyramid-2019/` folder.
