### PR TITLE
Issue269

### DIFF
--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -25,7 +25,7 @@ class Scenario(Term):
         country (str): country name
         province (str or None): province name
         tau (int or None): tau value
-        uto_complement (bool): if True, the number of cases will be complemented.
+        auto_complement (bool): if True, the number of cases will be complemented.
     """
 
     def __init__(self, jhu_data, population_data, country, province=None, tau=None, auto_complement=True):

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -182,6 +182,8 @@ class Scenario(Term):
 
         Notes:
             Records with Recovered > 0 will be selected.
+            If complement was performed by Scenario.complement() or Scenario(auto_complement=True),
+            "(complemented)" will be added to the title of the figure.
         """
         df = self.record_df.drop(self.S, axis=1)
         if not show_figure:

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -49,6 +49,7 @@ class Scenario(Term):
         # {scenario_name: PhaseSeries}
         self._init_phase_series()
         # Complement the number of cases
+        self._complemented = False
         if auto_complement:
             self.complement()
 
@@ -112,6 +113,7 @@ class Scenario(Term):
         df[self.CI] = df[self.C] - df[self.F] - df[self.R]
         # Save records
         self.record_df = df.copy()
+        self._complemented = True
         return self
 
     def complement_reverse(self):
@@ -128,6 +130,7 @@ class Scenario(Term):
             end_date=self._last_date,
             population=self.population
         )
+        self._complemented = False
         return self
 
     @property
@@ -183,9 +186,10 @@ class Scenario(Term):
         df = self.record_df.drop(self.S, axis=1)
         if not show_figure:
             return df
+        title = f"{self.area}: Cases over time{' (complemented)' if self._complemented else ''}"
         line_plot(
             df.set_index(self.DATE).drop(self.C, axis=1),
-            f"{self.area}: Cases over time",
+            title,
             y_integer=True,
             filename=filename
         )

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -100,8 +100,8 @@ class Scenario(Term):
         # Complement
         df.loc[df.duplicated([self.R], keep="last"), self.R] = None
         df[self.R].interpolate(
-            method="spline", order=2, inplace=True, limit_direction="both")
-        df[self.R] = df[self.R].astype(np.int64)
+            method="linear", inplace=True, limit_direction="both")
+        df[self.R] = df[self.R].round().astype(np.int64)
         # Calculate Infected
         df[self.CI] = df[self.C] - df[self.F] - df[self.R]
         # Save records

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -78,24 +78,30 @@ class Scenario(Term):
             population=self.population
         )
 
-    def complement(self, update_interval=2):
+    def complement(self, interval=2, max_ignored=100):
         """
         Complement the number of recovered cases when not updated.
 
         Args:
-            update_interval (int): expected update interval of the number of recovered cases [days]
+            interval (int): expected update interval of the number of recovered cases [days]
+            max_ignored (int): Max number of recovered cases to be ignored [cases]
 
         Returns:
             covsirphy.Scenario: self
 
         Notes:
-            If the number of recovered cases did not change for more than @update_interval days,
+            If the number of recovered cases did not change
+            for more than @interval days after reached @max_ignored cases,
             complement will be applied to the number of recovered cases.
         """
         df = self.record_df.copy()
+        # Arguments
+        interval = self.ensure_natural_int(interval, name="interval")
+        max_ignored = self.ensure_natural_int(max_ignored, name="max_ignored")
         # If updated, do not perform complement
-        max_frequency = df[self.R].value_counts().max()
-        if max_frequency <= update_interval:
+        series = df.loc[df[self.R] > max_ignored, self.R]
+        max_frequency = series.value_counts().max()
+        if max_frequency <= interval:
             return self
         # Complement
         df.loc[df.duplicated([self.R], keep="last"), self.R] = None

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -273,3 +273,20 @@ class TestScenario(object):
         # Retrospective analysis
         snl.retrospective(
             "01Sep2020", model=SIR, control="Main", target="Retrospective")
+
+    @pytest.mark.parametrize("country", ["Greece"])
+    def test_complement(self, jhu_data, population_data, country):
+        max_ignored = 100
+        # Auto complement
+        snl = Scenario(
+            jhu_data, population_data, country, auto_complement=True)
+        recovered = snl.records(show_figure=False)[Term.R]
+        assert recovered[recovered > max_ignored].value_counts().max() == 1
+        # Restore the raw data
+        snl.complement_reverse()
+        recovered = snl.records(show_figure=False)[Term.R]
+        assert recovered[recovered > max_ignored].value_counts().max() != 1
+        # Complement
+        snl.complement()
+        recovered = snl.records(show_figure=False)[Term.R]
+        assert recovered[recovered > max_ignored].value_counts().max() == 1


### PR DESCRIPTION
## Related issues
This is related to #269 

## What was changed
- `Scenario` class complements the number of recovered cases automatically with `auto_complement=True` (default) argument and `Scenario.complement()` method.
- Users can restore the raw data with `Scenario.complement_reverse()` method.

## Details of complement
If the number of recovered cases did not change for more than `interval=12` days after reached `max_ignored=100` cases, complement will be applied to the number of recovered cases.

1. Duplicated values will be raplaced with `None`
2. Interpolated with linear function and rounded
3. `Infected` will be re-calculated

Because complement impacts on both of S-R trend analysis and parameter estimation, this will be performed when an instance of `Scenario` class will be created.