### PR TITLE
remove: imterpolation and sampling of S-R

### DIFF
--- a/covsirphy/phase/sr_change.py
+++ b/covsirphy/phase/sr_change.py
@@ -62,14 +62,9 @@ class ChangeFinder(Term):
         # Convert index to serial numbers
         serial_df = pd.DataFrame(np.arange(1, df.index.max() + 1, 1))
         serial_df.index += 1
-        df = pd.merge(
-            df, serial_df, left_index=True, right_index=True, how="outer")
+        df = df.join(serial_df, how="outer")
         series = df.reset_index(drop=True).iloc[:, 0]
-        series = series.interpolate(limit_direction="both")
-        # Sampling to reduce run-time of Ruptures
-        samples = np.linspace(
-            0, series.index.max(), len(self.sr_df), dtype=np.int64)
-        series = series[samples]
+        series = series.dropna()
         # Detection with Ruptures
         algorithm = rpt.Pelt(model="rbf", jump=1, min_size=self.min_size)
         results = algorithm.fit_predict(series.values, pen=0.5)

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -143,36 +143,39 @@ class TestPhaseSeries(object):
     def test_replace(self, jhu_data, population_data, country):
         # Setting
         population = population_data.value(country)
-        sr_df = jhu_data.to_sr(country=country, population=population)
         series = PhaseSeries("01Apr2020", "01Aug2020", population)
-        series.trend(sr_df, show_figure=False)
+        series.add(end_date="01May2020")
+        series.add(end_date="01Jun2020")
+        series.add(end_date="01Jul2020")
+        series.add()
         # Replace one old phase with one new phase
-        unit_old = series.unit("2nd")
+        unit_old = series.unit("0th")
         unit_new = PhaseUnit(
             unit_old.start_date, unit_old.end_date, population
         )
         unit_new.set_ode(tau=360)
-        series.replace("2nd", unit_new)
-        assert series.unit("2nd") == unit_new
+        series.replace("0th", unit_new)
+        assert series.unit("0th") == unit_new
         # Replace one old phase with two new phases
-        unit_old = series.unit("2nd")
+
+        unit_old = series.unit("1st")
         change_date = Term.date_change(unit_old.end_date, days=-7)
         unit_pre = PhaseUnit(
             unit_old.start_date, Term.yesterday(change_date), population)
         unit_pre.set_ode(tau=360)
         unit_fol = PhaseUnit(change_date, unit_old.end_date, population)
         unit_fol.set_ode(tau=360)
-        series.replaces(phase="2nd", new_list=[unit_pre, unit_fol])
-        print(series.unit("2nd"), unit_pre)
-        assert series.unit("2nd") == unit_pre
-        assert series.unit("3rd") == unit_fol
+        series.replaces(phase="1st", new_list=[unit_pre, unit_fol])
+        print(series.unit("1st"), unit_pre)
+        assert series.unit("1st") == unit_pre
+        assert series.unit("2nd") == unit_fol
         # TypeError of new_list
         with pytest.raises(TypeError):
-            series.replaces(phase="2nd", new_list=[unit_pre, Term])
+            series.replaces(phase="3rd", new_list=[unit_pre, Term])
         # ValueError with tense
         with pytest.raises(ValueError):
             future_unit = PhaseUnit("01Sep2020", "01Dec2020", population)
-            series.replaces(phase="2nd", new_list=[future_unit])
+            series.replaces(phase="3rd", new_list=[future_unit])
         # Add phase without deletion of any phases
         new1 = PhaseUnit("02Aug2020", "01Sep2020", population)
         new2 = PhaseUnit("02Sep2020", "01Oct2020", population)

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -92,7 +92,7 @@ class TestPhaseSeries(object):
         series.trend(sr_df, show_figure=False)
         # Un-registered phase
         with pytest.raises(KeyError):
-            series.unit("10th")
+            series.unit("100th")
 
     @pytest.mark.parametrize("country", ["Japan"])
     def test_add_phase_with_model(self, jhu_data, population_data, country):

--- a/tests/test_phase_unit.py
+++ b/tests/test_phase_unit.py
@@ -110,7 +110,7 @@ class TestPhaseUnit(object):
             unit.estimate()
         unit.record_df = record_df
         assert set(unit.record_df.columns) == set(Term.SUB_COLUMNS)
-        unit.estimate()
+        unit.estimate(timeout=20)
         # Check results
         assert isinstance(unit.estimator, Estimator)
         assert set(SIR.PARAMETERS).issubset(unit.to_dict())

--- a/tests/test_policy_measures.py
+++ b/tests/test_policy_measures.py
@@ -52,7 +52,7 @@ class TestPolicyMeasures(object):
         # Parameter estimation
         with pytest.raises(ValueError):
             analyser.track()
-        analyser.estimate(SIRF)
+        analyser.estimate(SIRF, timeout=10)
         assert isinstance(analyser.summary(), pd.DataFrame)
         # Parameter history of Rt
         with pytest.raises(KeyError):

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -182,7 +182,7 @@ class TestScenario(object):
         # To markdown
         snl.summary().to_markdown()
 
-    @pytest.mark.parametrize("country", ["Greece"])
+    @pytest.mark.parametrize("country", ["Japan"])
     def test_estimate(self, jhu_data, population_data, country):
         warnings.simplefilter("ignore", category=UserWarning)
         # Setting
@@ -194,7 +194,7 @@ class TestScenario(object):
         snl.trend(include_init_phase=True, show_figure=False)
         snl.disable(phases=["0th"])
         with pytest.raises(AttributeError):
-            snl.estimate_history(phase="1th")
+            snl.estimate_history(phase="last")
         # Parameter estimation
         with pytest.raises(KeyError):
             snl.estimate(SIR, phases=["30th"])
@@ -207,7 +207,7 @@ class TestScenario(object):
             snl.estimate(model=SIR, phases=["0th"])
         snl.clear(include_past=True)
         snl.trend(show_figure=False)
-        snl.estimate(SIR)
+        snl.estimate(SIR, timeout=20)
         # Estimation history
         snl.estimate_history(phase="1st")
         # Estimation accuracy
@@ -223,7 +223,7 @@ class TestScenario(object):
         snl = Scenario(jhu_data, population_data, country)
         snl.trend(show_figure=False)
         with pytest.raises(ValueError):
-            snl.estimate(SIR, tau=1440)
+            snl.estimate(SIR, tau=1440, timeout=20)
 
     @pytest.mark.parametrize("country", ["Japan"])
     def test_simulate(self, jhu_data, population_data, country):
@@ -232,13 +232,13 @@ class TestScenario(object):
         # Setting
         snl = Scenario(jhu_data, population_data, country)
         snl.first_date = "01Apr2020"
-        snl.last_date = "01Aug2020"
+        snl.last_date = "01May2020"
         snl.trend(show_figure=False)
         # Parameter estimation
         with pytest.raises(ValueError):
             # Deprecated
             snl.param_history(["rho"])
-        snl.estimate(SIR)
+        snl.estimate(SIR, timeout=10)
         # Simulation
         snl.simulate()
         # Parameter history (Deprecated)
@@ -268,11 +268,11 @@ class TestScenario(object):
         # Setting
         snl = Scenario(jhu_data, population_data, country)
         snl.first_date = "01Apr2020"
-        snl.last_date = "19Oct2020"
+        snl.last_date = "01Jun2020"
         snl.trend(show_figure=False)
         # Retrospective analysis
         snl.retrospective(
-            "01Sep2020", model=SIR, control="Main", target="Retrospective")
+            "01May2020", model=SIR, control="Main", target="Retrospective")
 
     @pytest.mark.parametrize("country", ["Greece"])
     def test_complement(self, jhu_data, population_data, country):
@@ -295,7 +295,7 @@ class TestScenario(object):
     def test_score(self, jhu_data, population_data, country):
         snl = Scenario(jhu_data, population_data, country)
         snl.trend(show_figure=False)
-        snl.estimate(SIRF)
+        snl.estimate(SIRF, timeout=10)
         metrics_list = ["MAE", "MSE", "MSLE", "RMSE", "RMSLE"]
         for metrics in metrics_list:
             score = snl.score(metrics=metrics)
@@ -311,7 +311,7 @@ class TestScenario(object):
             snl.score()
         all_phases = snl.summary().index.tolist()
         snl.disable(phases=all_phases[:-2])
-        snl.estimate(SIRF)
+        snl.estimate(SIRF, timeout=10)
         with pytest.raises(TypeError):
             snl.score(variables="Infected")
         with pytest.raises(KeyError):


### PR DESCRIPTION
## Related issues
This is related to #270 

## What was changed
- Removed interpolation and sampling in S-R trend analysis.
- Updated test codes to shorten runtime of tests.