### PR TITLE
update: default value of estimation timeout to 180

### DIFF
--- a/covsirphy/simulation/estimator.py
+++ b/covsirphy/simulation/estimator.py
@@ -88,8 +88,8 @@ class Estimator(Term):
             sampler=optuna.samplers.TPESampler(seed=seed)
         )
 
-    def run(self, timeout=60, reset_n_max=3,
-            timeout_iteration=5, allowance=(0.98, 1.02), seed=0, **kwargs):
+    def run(self, timeout=180, reset_n_max=3,
+            timeout_iteration=10, allowance=(0.98, 1.02), seed=0, **kwargs):
         """
         Run optimization.
         If the result satisfied the following conditions, optimization ends.


### PR DESCRIPTION
## Related issues
This is related to #291 

## What was changed
Default value of `Estimator.run(timeout)` was changed from 60 to 180.

With `Estimator` class, CovsirPhy continues estimation while runtime does not over `timeout` and max simulated number of cases is not in the range of `(max actual number * 0.98, max actual number * 1.02)`.