### PR TITLE
support Python 3.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ We have the following options to start analysis with CovsirPhy. Datasets are not
 
 <strong>[Installation and dataset preparation](https://lisphilar.github.io/covid19-sir/INSTALLATION.html) explains how to install and prepare datasets for all users.</strong>
 
-Stable versions of Covsirphy are available at [PyPI (The Python Package Index): covsirphy](https://pypi.org/project/covsirphy/) and support Python 3.7 or newer versions.
+Stable versions of Covsirphy are available at [PyPI (The Python Package Index): covsirphy](https://pypi.org/project/covsirphy/) and support Python 3.6 or newer versions.
 ```
 pip install covsirphy --upgrade
 ```

--- a/docs/markdown/INSTALLATION.md
+++ b/docs/markdown/INSTALLATION.md
@@ -29,7 +29,7 @@ Lisphilar (2020), GitHub repository, COVID-19 dataset in Japan.
 If you want to use a new dataset for your analysis, please kindly inform us via [GitHub Issues: Request new method of DataLoader class](https://github.com/lisphilar/covid19-sir/issues/new/?template=request-new-method-of-dataloader-class.md). Please read [Guideline of contribution](https://lisphilar.github.io/covid19-sir/CONTRIBUTING.html) in advance.
 
 ## 1. Standard users
-Stable versions of Covsirphy are available at [PyPI (The Python Package Index): covsirphy](https://pypi.org/project/covsirphy/) and support Python 3.7 or newer versions.
+Stable versions of Covsirphy are available at [PyPI (The Python Package Index): covsirphy](https://pypi.org/project/covsirphy/) and support Python 3.6 or newer versions.
 ```
 pip install --upgrade covsirphy
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,6 +12,7 @@ keywords = covid19
 classifiers =
     Development Status :: 5 - Production/Stable
     License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
 


### PR DESCRIPTION
## Related issues
This is related to #335 

## What was changed
Support Python 3.6.
Tests will be performed Python 36 and 3.8 with semaphore CI.