### PR TITLE
fix: Na values in full complement

### DIFF
--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -364,7 +364,7 @@ class JHUData(CleaningBase):
         self._closing_period = self._closing_period or self.calculate_closing_period()
         # Estimate recovered records
         shifted = df[self.C].shift(periods=self._closing_period, freq="D")
-        df[self.R] = shifted.fillna(0).astype(np.int64) - df[self.F]
+        df[self.R] = (shifted - df[self.F]).fillna(0).astype(np.int64)
         # Re-calculate infected records
         df[self.CI] = df[self.C] - df[self.F] - df[self.R]
         return df.reset_index()

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -365,6 +365,7 @@ class JHUData(CleaningBase):
         # Estimate recovered records
         shifted = df[self.C].shift(periods=self._closing_period, freq="D")
         df[self.R] = (shifted - df[self.F]).fillna(0).astype(np.int64)
+        df.loc[df[self.R] < 0, self.R] = 0
         # Re-calculate infected records
         df[self.CI] = df[self.C] - df[self.F] - df[self.R]
         return df.reset_index()


### PR DESCRIPTION
## Related issues
This is related to #334 .

## What was changed
FIx NA values in the output of `JHUData._complement_recovered_full()`. NA values will be changed to 0.