### PR TITLE
Issue366

### DIFF
--- a/covsirphy/cleaning/linelist.py
+++ b/covsirphy/cleaning/linelist.py
@@ -135,8 +135,6 @@ class LinelistData(CleaningBase):
             df[col] = pd.to_datetime(
                 df[col], infer_datetime_format=True, errors="coerce")
         df = df.loc[~df[self.CONFIRM_DATE].isna()]
-        df = df.loc[~df[self.OUTCOME_DATE].isna()]
-        df = df.loc[df[self.CONFIRM_DATE] < df[self.OUTCOME_DATE]]
         # Outcome
         df[self.C] = ~df[self.CONFIRM_DATE].isna()
         df[self.R] = df[self.OUTCOME].str.lower().isin(
@@ -230,8 +228,9 @@ class LinelistData(CleaningBase):
             raise KeyError(
                 f"@outcome should be selected from {self.R} or {self.F}, but {outcome} was applied.")
         df = self._cleaned_df.copy()
-        # Subset by date
         df = df.loc[df[outcome]]
+        # Subset by date
+        df = df.loc[df[self.CONFIRM_DATE] < df[self.OUTCOME_DATE]]
         # Column names
         df = df.rename({self.OUTCOME_DATE: column_dict[outcome]}, axis=1)
         df = df.drop([self.C, self.CI, self.F, self.R], axis=1)

--- a/covsirphy/cleaning/linelist.py
+++ b/covsirphy/cleaning/linelist.py
@@ -134,6 +134,9 @@ class LinelistData(CleaningBase):
         for col in [self.HOSPITAL_DATE, self.CONFIRM_DATE, self.OUTCOME_DATE]:
             df[col] = pd.to_datetime(
                 df[col], infer_datetime_format=True, errors="coerce")
+        df = df.loc[~df[self.CONFIRM_DATE].isna()]
+        df = df.loc[~df[self.OUTCOME_DATE].isna()]
+        df = df.loc[df[self.CONFIRM_DATE] < df[self.OUTCOME_DATE]]
         # Outcome
         df[self.C] = ~df[self.CONFIRM_DATE].isna()
         df[self.R] = df[self.OUTCOME].str.lower().isin(
@@ -228,9 +231,7 @@ class LinelistData(CleaningBase):
                 f"@outcome should be selected from {self.R} or {self.F}, but {outcome} was applied.")
         df = self._cleaned_df.copy()
         # Subset by date
-        df = df.loc[(df[outcome]) & (~df[self.OUTCOME_DATE].isna())]
-        df = df.loc[~df[self.CONFIRM_DATE].isna()]
-        df = df.loc[df[self.CONFIRM_DATE] < df[self.OUTCOME_DATE]]
+        df = df.loc[df[outcome]]
         # Column names
         df = df.rename({self.OUTCOME_DATE: column_dict[outcome]}, axis=1)
         df = df.drop([self.C, self.CI, self.F, self.R], axis=1)


### PR DESCRIPTION
## Related issues
This is related to #366 

## What was changed
Records with NA in outcome date will be accepted because they are for active cases.
Records with NA in confirmation date will be removed.