### PR TITLE
add: Scenario.records_diff()

### DIFF
--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -181,6 +181,41 @@ class Scenario(Term):
         )
         return df
 
+    def records_diff(self, variables=None, window=7, show_figure=True, filename=None):
+        """
+        Return the number of daily new cases (the first discreate difference of records).
+
+        Args:
+            variables (str or None): variables to show
+            window (int): window of moving average, >= 1
+            show_figure (bool): if True, show the records as a line-plot.
+            filename (str): filename of the figure, or None (show figure)
+
+        Returns:
+            pandas.DataFrame
+                Index:
+                    - Date (pd.TimeStamp): Observation date
+                Columns:
+                    - Confirmed (int): daily new cases of Confirmed, if calculated
+                    - Infected (int):  daily new cases of Infected, if calculated
+                    - Fatal (int):  daily new cases of Fatal, if calculated
+                    - Recovered (int):  daily new cases of Recovered, if calculated
+
+        Notes:
+            @variables can be selected from Confirmed, Infected, Fatal and Recovered.
+            If None was set to @variables, ["Confirmed", "Fatal", "Recovered"] will be used.
+        """
+        variables = self.ensure_list(
+            variables or [self.C, self.F, self.R], candidates=self.VALUE_COLUMNS, name="variables")
+        window = self.ensure_natural_int(window, name="window")
+        df = self.record_df.set_index(self.DATE)[variables]
+        df = df.diff().rolling(window=window).mean()
+        if not show_figure:
+            return df
+        title = f"{self.area}: Daily new cases{' (complemented)' if self._complemented else ''}"
+        line_plot(df, title, y_integer=True, filename=filename)
+        return df
+
     def _create_tracker(self, name):
         """
         Create a instance of covsirphy.ParamTracker.

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -209,7 +209,7 @@ class Scenario(Term):
             variables or [self.C, self.F, self.R], candidates=self.VALUE_COLUMNS, name="variables")
         window = self.ensure_natural_int(window, name="window")
         df = self.record_df.set_index(self.DATE)[variables]
-        df = df.diff().rolling(window=window).mean()
+        df = df.diff().dropna().rolling(window=window).mean().dropna()
         if not show_figure:
             return df
         title = f"{self.area}: Daily new cases{' (complemented)' if self._complemented else ''}"

--- a/example/scenario_analysis.py
+++ b/example/scenario_analysis.py
@@ -28,7 +28,9 @@ def main():
     # Show records
     record_df = snl.records(filename=figpath("records"))
     save_df(record_df, "records", output_dir, abbr, use_index=False)
-    # Show S-R trend)
+    # Daily new cases
+    snl.records_diff(filename=figpath("records_diff"))
+    # Show S-R trend
     snl.trend(filename=figpath("trend"))
     print(snl.summary())
     # Parameter estimation

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -76,6 +76,13 @@ class TestScenario(object):
         assert set(df2.columns) == set(Term.NLOC_COLUMNS)
 
     @pytest.mark.parametrize("country", ["Japan"])
+    def test_records_diff(self, jhu_data, population_data, country):
+        warnings.simplefilter("ignore", category=UserWarning)
+        snl = Scenario(jhu_data, population_data, country)
+        snl.records_diff(window=7, show_figure=False)
+        snl.records_diff(window=100, show_figure=True)
+
+    @pytest.mark.parametrize("country", ["Japan"])
     def test_edit_series(self, jhu_data, population_data, country):
         # Setting
         snl = Scenario(jhu_data, population_data, country)


### PR DESCRIPTION
## Related issues
This is related to #367 

## What was changed
`Scenario.records_diff(variables=None, windows=7, show_figure=True, filename=None)` was created.
`variables` can be selected from Confirmed, Infected, Fatal and Recovered.
If None was set to `variables`, ["Confirmed", "Fatal", "Recovered"] will be used.