### PR TITLE
fix: ValueError in PolicyMeasures.estimate()

### DIFF
--- a/covsirphy/phase/phase_estimator.py
+++ b/covsirphy/phase/phase_estimator.py
@@ -108,7 +108,7 @@ class MPEstimator(Term):
             province = id_dict["province"] if "province" in id_dict else None
             population = self.population_data.value(
                 country=country, province=province)
-            record_df = self.jhu_data.records(
+            record_df, _ = self.jhu_data.records(
                 country=country, province=province, population=population,
                 auto_complement=auto_complement)
         else:

--- a/covsirphy/phase/phase_estimator.py
+++ b/covsirphy/phase/phase_estimator.py
@@ -85,13 +85,14 @@ class MPEstimator(Term):
         self._units.extend(units)
         return self
 
-    def _run(self, unit, tau, **kwargs):
+    def _run(self, unit, tau, auto_complement=False, **kwargs):
         """
         Run estimation for one phase.
 
         Args:
             unit (covsirphy.PhaseUnit): unit of one phase
             tau (int or None): tau value [min], a divisor of 1440
+            auto_complement (bool): if True and necessary, the number of cases will be complemented
             kwargs: keyword arguments of model parameters and covsirphy.Estimator.run()
         """
         # Set tau
@@ -108,7 +109,8 @@ class MPEstimator(Term):
             population = self.population_data.value(
                 country=country, province=province)
             record_df = self.jhu_data.records(
-                country=country, province=province, population=population)
+                country=country, province=province, population=population,
+                auto_complement=auto_complement)
         else:
             record_df = self.record_df.copy()
         unit.estimate(record_df=record_df, **kwargs)

--- a/covsirphy/phase/phase_estimator.py
+++ b/covsirphy/phase/phase_estimator.py
@@ -107,9 +107,8 @@ class MPEstimator(Term):
             province = id_dict["province"] if "province" in id_dict else None
             population = self.population_data.value(
                 country=country, province=province)
-            record_df = self.jhu_data.subset(
-                country=country, province=province, population=population
-            )
+            record_df = self.jhu_data.records(
+                country=country, province=province, population=population)
         else:
             record_df = self.record_df.copy()
         unit.estimate(record_df=record_df, **kwargs)

--- a/covsirphy/phase/sr_change.py
+++ b/covsirphy/phase/sr_change.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from datetime import timedelta
+import warnings
 import numpy as np
 import pandas as pd
 import ruptures as rpt
@@ -66,6 +67,7 @@ class ChangeFinder(Term):
         series = df.reset_index(drop=True).iloc[:, 0]
         series = series.dropna()
         # Detection with Ruptures
+        warnings.simplefilter("ignore", category=RuntimeWarning)
         algorithm = rpt.Pelt(model="rbf", jump=1, min_size=self.min_size)
         results = algorithm.fit_predict(series.values, pen=0.5)
         # Convert index values to Susceptible values

--- a/covsirphy/worldwide/policy.py
+++ b/covsirphy/worldwide/policy.py
@@ -185,8 +185,7 @@ class PolicyMeasures(Term):
             [
                 unit.set_id(
                     country=self.jhu_data.country_to_iso3(country),
-                    phase=f"{self.num2str(num):>4}"
-                )
+                    phase=f"{self.num2str(num):>4}")
                 for (num, unit) in enumerate(self.scenario_dict[country][self.MAIN]) if unit]
             for country in self._countries
         ]
@@ -194,8 +193,7 @@ class PolicyMeasures(Term):
         # Parameter estimation
         mp_estimator = MPEstimator(
             jhu_data=self.jhu_data, population_data=self.population_data,
-            model=model, tau=self.tau, **kwargs
-        )
+            model=model, tau=self.tau, **kwargs)
         mp_estimator.add(units)
         results = mp_estimator.run(
             n_jobs=n_jobs, auto_complement=True, **kwargs)

--- a/covsirphy/worldwide/policy.py
+++ b/covsirphy/worldwide/policy.py
@@ -197,7 +197,8 @@ class PolicyMeasures(Term):
             model=model, tau=self.tau, **kwargs
         )
         mp_estimator.add(units)
-        results = mp_estimator.run(n_jobs=n_jobs, **kwargs)
+        results = mp_estimator.run(
+            n_jobs=n_jobs, auto_complement=True, **kwargs)
         # Register the results
         for country in self._countries:
             new_units = [

--- a/tests/test_policy_measures.py
+++ b/tests/test_policy_measures.py
@@ -24,6 +24,7 @@ class TestPolicyMeasures(object):
 
     def test_analysis(self, jhu_data, population_data, oxcgrt_data):
         warnings.simplefilter("ignore", category=UserWarning)
+        warnings.simplefilter("error", category=RuntimeWarning)
         # Create instance
         analyser = PolicyMeasures(
             jhu_data, population_data, oxcgrt_data, tau=360)

--- a/tests/test_policy_measures.py
+++ b/tests/test_policy_measures.py
@@ -62,6 +62,7 @@ class TestPolicyMeasures(object):
 
     def test_error(self, jhu_data, population_data, oxcgrt_data):
         warnings.simplefilter("ignore", category=UserWarning)
+        warnings.simplefilter("raise", category=RuntimeWarning)
         # Create instance
         analyser = PolicyMeasures(
             jhu_data, population_data, oxcgrt_data, tau=360)

--- a/tests/test_policy_measures.py
+++ b/tests/test_policy_measures.py
@@ -62,7 +62,7 @@ class TestPolicyMeasures(object):
 
     def test_error(self, jhu_data, population_data, oxcgrt_data):
         warnings.simplefilter("ignore", category=UserWarning)
-        warnings.simplefilter("raise", category=RuntimeWarning)
+        warnings.simplefilter("error", category=RuntimeWarning)
         # Create instance
         analyser = PolicyMeasures(
             jhu_data, population_data, oxcgrt_data, tau=360)


### PR DESCRIPTION
## Related issues
This is related to #373 .

## What was changed
`MPEstimater._run()` uses `JHUData.records()` rather than `JHUData.subset()`.