### PR TITLE
Issue359 unexecuted

### DIFF
--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -15,7 +15,7 @@ from covsirphy.util.map import jpn_map
 from covsirphy.util.optimize import Optimizer
 from covsirphy.util.stopwatch import StopWatch
 from covsirphy.util.error import deprecate
-from covsirphy.util.error import SubsetNotFoundError, ScenarioNotFoundError
+from covsirphy.util.error import SubsetNotFoundError, ScenarioNotFoundError, UnExecutedError
 from covsirphy.util.file import save_dataframe
 from covsirphy.util.argument import find_args
 # cleaning
@@ -73,7 +73,7 @@ __all__ = [
     "line_plot", "jpn_map", "StopWatch", "deprecate", "find_args",
     "save_dataframe",
     "PolicyMeasures",
-    "SubsetNotFoundError", "ScenarioNotFoundError",
+    "SubsetNotFoundError", "ScenarioNotFoundError", "UnExecutedError",
     # Deprecated
     "Population", "Word",
 ]

--- a/covsirphy/analysis/param_tracker.py
+++ b/covsirphy/analysis/param_tracker.py
@@ -198,15 +198,16 @@ class ParamTracker(Term):
             - Tau will be fixed as the last phase's value.
             - kwargs: Default values are the parameter values of the last phase.
         """
+        if end_date is not None:
+            self.ensure_date(end_date, name="end_date")
         try:
             self._series.add(
                 end_date=end_date, days=days, population=population,
                 model=model, tau=self.tau, **kwargs)
         except ValueError:
             last_date = self._series.unit("last").end_date
-            s1 = '@end_date needs to match "DDMmmYYYY" format'
             raise ValueError(
-                f'{s1} and be over {last_date}. However, {end_date} was applied.') from None
+                f'@end_date must be over {last_date}. However, {end_date} was applied.') from None
         return self._series
 
     def delete_all(self):

--- a/covsirphy/analysis/param_tracker.py
+++ b/covsirphy/analysis/param_tracker.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import sklearn
+from covsirphy.util.error import UnExecutedError
 from covsirphy.cleaning.term import Term
 from covsirphy.ode.mbase import ModelBase
 from covsirphy.phase.phase_unit import PhaseUnit
@@ -97,8 +98,7 @@ class ParamTracker(Term):
         Ensure that phases were set.
         """
         if not self._series:
-            raise ValueError(
-                "Phases should be registered with .trend() or .add() in advance.")
+            raise UnExecutedError(".trend() or .add()")
 
     def find_phase(self, date):
         """
@@ -426,8 +426,7 @@ class ParamTracker(Term):
         try:
             return self._series.simulate(record_df=self.record_df, y0_dict=y0_dict)
         except NameError:
-            raise NameError(
-                "Parameter estimation should be done with .estimate() in advance.") from None
+            raise UnExecutedError(".estimate()")
 
     def _compare_with_actual(self, variables, y0_dict=None):
         """

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -129,9 +129,10 @@ class Scenario(DataHandler):
         Returns:
             covsirphy.ParamTracker
         """
+        # Registered
         if name in self._tracker_dict:
             return self._tracker_dict[name]
-        # Phase series
+        # Un-registered and create it
         if template not in self._tracker_dict:
             raise ScenarioNotFoundError(template)
         tracker = copy.deepcopy(self._tracker_dict[template])

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -5,7 +5,7 @@ import copy
 import warnings
 import numpy as np
 import pandas as pd
-from covsirphy.util.error import deprecate, ScenarioNotFoundError
+from covsirphy.util.error import deprecate, ScenarioNotFoundError, UnExecutedError
 from covsirphy.util.plotting import line_plot, box_plot
 from covsirphy.analysis.param_tracker import ParamTracker
 from covsirphy.analysis.data_handler import DataHandler
@@ -449,9 +449,8 @@ class Scenario(DataHandler):
         """
         estimator = self._tracker_dict[name].series.unit(phase).estimator
         if estimator is None:
-            raise AttributeError(
-                f'Scenario.estimate(model, phases=["{phase}"], name={name}) must be done in advance.'
-            )
+            raise UnExecutedError(
+                f'Scenario.estimate(model, phases=["{phase}"], name={name})')
         return estimator
 
     def estimate_history(self, phase, name="Main", **kwargs):
@@ -508,11 +507,10 @@ class Scenario(DataHandler):
         try:
             sim_df = tracker.simulate(y0_dict=y0_dict)
         except ValueError:
-            raise ValueError(
-                "Phases should be registered with Scenario.trend() or Scenario.add() in advance.") from None
+            raise UnExecutedError(
+                "Scenario.trend() or Scenario.add()") from None
         except NameError:
-            raise NameError(
-                "Parameter estimation should be done with Scenario.estimate() in advance.") from None
+            raise UnExecutedError("Scenario.estimate(model)") from None
         if not show_figure:
             return sim_df
         # Show figure
@@ -574,8 +572,8 @@ class Scenario(DataHandler):
         selectable_set = set(selectable_cols)
         df = series.summary().replace(self.UNKNOWN, None)
         if not selectable_set.issubset(df.columns):
-            raise ValueError(
-                f"Scenario.estimate(model, phases=None, name={name}) must be done in advance.")
+            raise UnExecutedError(
+                f'Scenario.estimate(model, phases=None, name="{name}")')
         targets = [targets] if isinstance(targets, str) else targets
         targets = targets or selectable_cols
         if not set(targets).issubset(selectable_set):

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -506,11 +506,9 @@ class Scenario(DataHandler):
         tracker = self._tracker(name)
         try:
             sim_df = tracker.simulate(y0_dict=y0_dict)
-        except ValueError:
+        except UnExecutedError:
             raise UnExecutedError(
-                "Scenario.trend() or Scenario.add()") from None
-        except NameError:
-            raise UnExecutedError("Scenario.estimate(model)") from None
+                "Scenario.trend() or Scenario.add(), and Scenario.estimate(model)") from None
         if not show_figure:
             return sim_df
         # Show figure

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -170,6 +170,8 @@ class Scenario(DataHandler):
             - Tau will be fixed as the last phase's value.
             - kwargs: Default values are the parameter values of the last phase.
         """
+        if end_date is not None:
+            self.ensure_date(end_date, name="end_date")
         tracker = self._tracker(name)
         try:
             tracker.add(
@@ -177,9 +179,8 @@ class Scenario(DataHandler):
                 model=model, **kwargs)
         except ValueError:
             last_date = tracker.series.unit("last").end_date
-            s1 = f'For "{name}" scenario, @end_date needs to match "DDMmmYYYY" format'
             raise ValueError(
-                f'{s1} and be over {last_date}. However, {end_date} was applied.') from None
+                f'@end_date must be over {last_date}. However, {end_date} was applied.') from None
         self._tracker_dict[name] = tracker
         return self
 

--- a/covsirphy/cleaning/country_data.py
+++ b/covsirphy/cleaning/country_data.py
@@ -4,6 +4,7 @@
 from dask import dataframe as dd
 import numpy as np
 import pandas as pd
+from covsirphy.util.error import UnExecutedError
 from covsirphy.cleaning.cbase import CleaningBase
 
 
@@ -81,8 +82,7 @@ class CountryData(CleaningBase):
                     - Recovered (int): the number of recovered cases
         """
         if not self.var_dict:
-            raise ValueError(
-                "Please execute CountryData.set_variables() in advance.")
+            raise UnExecutedError("CountryData.set_variables()")
         df = self._raw.copy()
         # Rename the columns
         df = df.rename(self.var_dict, axis=1)

--- a/covsirphy/cleaning/term.py
+++ b/covsirphy/cleaning/term.py
@@ -47,6 +47,7 @@ class Term(object):
     MONO_COLUMNS = [C, F, R]
     # Date format: 22Jan2020 etc.
     DATE_FORMAT = "%d%b%Y"
+    DATE_FORMAT_DESC = "DDMmmYYYY"
     # Separator of country and province
     SEP = "/"
     # EDA
@@ -298,8 +299,7 @@ class Term(object):
             cls.date_obj(target)
         except ValueError:
             raise ValueError(
-                f"@{name} must be a natural number, but {target} was applied"
-            )
+                f"@{name} needs to match {cls.DATE_FORMAT_DESC}, but {target} was applied.")
         return target
 
     @staticmethod

--- a/covsirphy/phase/phase_unit.py
+++ b/covsirphy/phase/phase_unit.py
@@ -428,7 +428,7 @@ class PhaseUnit(Term):
             record_df = self._record_df.copy()
         if record_df.empty:
             raise UnExecutedError(
-                "PhaseUnit.record_df = ...", messages="or specify @record_df argument")
+                "PhaseUnit.record_df = ...", message="or specify @record_df argument")
         self.ensure_dataframe(
             record_df, name="record_df", columns=self.NLOC_COLUMNS)
         # Check dates

--- a/covsirphy/phase/phase_unit.py
+++ b/covsirphy/phase/phase_unit.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pandas as pd
+from covsirphy.util.error import UnExecutedError
 from covsirphy.cleaning.term import Term
 from covsirphy.ode.mbase import ModelBase
 from covsirphy.simulation.estimator import Estimator
@@ -399,8 +400,7 @@ class PhaseUnit(Term):
             NameError: ODE model is not registered
         """
         if self._model is None:
-            raise NameError(
-                "PhaseUnit.set_ode(model) must be done in advance.")
+            raise UnExecutedError("PhaseUnit.set_ode(model)")
 
     def estimate(self, record_df=None, **kwargs):
         """
@@ -419,10 +419,6 @@ class PhaseUnit(Term):
                     - any other columns will be ignored
             **kwargs: keyword arguments of Estimator.run()
 
-        Raises:
-            NameError: PhaseUnit.set_ode(model) was not done in advance.
-            ValueError: @record_df is None and PhaseUnit.record_df = ... was not done in advance.
-
         Notes:
             If @record_df is None, registered records will be used.
         """
@@ -431,8 +427,8 @@ class PhaseUnit(Term):
         if record_df is None:
             record_df = self._record_df.copy()
         if record_df.empty:
-            raise ValueError(
-                "@record_df must be specified or PhaseUnit.record_df = ... must be done in advance.")
+            raise UnExecutedError(
+                "PhaseUnit.record_df = ...", messages="or specify @record_df argument")
         self.ensure_dataframe(
             record_df, name="record_df", columns=self.NLOC_COLUMNS)
         # Check dates
@@ -538,8 +534,7 @@ class PhaseUnit(Term):
         # Conditions
         param_dict = self._ode_dict.copy()
         if None in param_dict.values():
-            raise KeyError(
-                "Tau and parameter values must be specified in advance with PhaseUnit.set_ode().")
+            raise UnExecutedError("PhaseUnit.set_ode()")
         tau = param_dict.pop(self.TAU)
         last_date = self.tomorrow(self._end_date)
         # Simulation

--- a/covsirphy/util/error.py
+++ b/covsirphy/util/error.py
@@ -45,30 +45,53 @@ class SubsetNotFoundError(KeyError, ValueError):
 
     def __init__(self, country, country_alias=None, province=None,
                  start_date=None, end_date=None, date=None, message=None):
-        # Area
-        if country_alias is None or country == country_alias:
-            c_alias_str = ""
-        else:
-            c_alias_str = f" ({country_alias})"
-        province_str = "" if province is None else f"{province}, "
-        self.area = f"{province_str}{country}{c_alias_str}"
-        # Date
-        if date is None:
-            start_str = "" if start_date is None else f" from {start_date}"
-            end_str = "" if end_date is None else f" to {end_date}"
-            self.date = f"{start_str}{end_str}"
-        else:
-            self.date = f" on {date}"
-        # The other messages
+        self.area = self._area(country, country_alias, province)
+        self.date = self._date(start_date, end_date, date)
         self.message = "" if message is None else f" {message}"
 
     def __str__(self):
         return f"Records{self.message} in {self.area}{self.date} were not found."
 
+    @staticmethod
+    def _area(country, country_alias, province):
+        """
+        Error when subset was failed with specified arguments.
+
+        Args:
+            country (str): country name
+            country_alias (str or None): country name used in the dataset
+            province (str or None): province name
+
+        Returns:
+            str: area name
+        """
+        if country_alias is None or country == country_alias:
+            c_alias_str = ""
+        else:
+            c_alias_str = f" ({country_alias})"
+        province_str = "" if province is None else f"{province}, "
+        return f"{province_str}{country}{c_alias_str}"
+
+    @staticmethod
+    def _date(start_date, end_date, date):
+        """
+        Error when subset was failed with specified arguments.
+
+        Args:
+            start_date (str or None): start date, like 22Jan2020
+            end_date (str or None): end date, like 01Feb2020
+            date (str or None): specified date, like 22Jan2020
+        """
+        if date is not None:
+            return f" on {date}"
+        start_str = "" if start_date is None else f" from {start_date}"
+        end_str = "" if end_date is None else f" to {end_date}"
+        return f"{start_str}{end_str}"
+
 
 class ScenarioNotFoundError(KeyError):
     """
-    Error unregistered scenario name was specified.
+    Error when unregistered scenario name was specified.
 
     Args:
         name (str): scenario name

--- a/covsirphy/util/error.py
+++ b/covsirphy/util/error.py
@@ -102,3 +102,20 @@ class ScenarioNotFoundError(KeyError):
 
     def __str__(self):
         return f"{self.name} scenario is not registered."
+
+
+class UnExecutedError(AttributeError, NameError, ValueError):
+    """
+    Error when we have unexecuted methods that we need to run in advance.
+
+    Args:
+        method_name (str): method name to run in advance
+        message (str or None): the other messages
+    """
+
+    def __init__(self, method_name, message=None):
+        self.method_name = method_name
+        self.message = "." if message is None else f" {message}."
+
+    def __str__(self):
+        return f"Please execute {self.method_name} in advance{self.message}"

--- a/covsirphy/worldwide/policy.py
+++ b/covsirphy/worldwide/policy.py
@@ -4,7 +4,7 @@
 from itertools import groupby
 from operator import itemgetter
 import pandas as pd
-from covsirphy.util.error import deprecate
+from covsirphy.util.error import deprecate, UnExecutedError
 from covsirphy.util.plotting import line_plot
 from covsirphy.cleaning.jhu_data import JHUData
 from covsirphy.cleaning.population import PopulationData
@@ -281,8 +281,7 @@ class PolicyMeasures(Term):
                 Values: parameter values
         """
         if self.model is None:
-            raise ValueError(
-                "PolicyMeasures.estimate(model) must be done in advance.")
+            raise UnExecutedError("PolicyMeasures.estimate(model)")
         # Get parameter/Rt/data parameter value of each date
         df = self.summary().reset_index().replace(self.UNKNOWN, None)
         df[self.START] = pd.to_datetime(

--- a/tests/test_phase_unit.py
+++ b/tests/test_phase_unit.py
@@ -3,7 +3,7 @@
 
 import pytest
 from covsirphy import PhaseUnit
-from covsirphy import Term, SIR, Estimator
+from covsirphy import Term, SIR, Estimator, UnExecutedError
 
 
 class TestPhaseUnit(object):
@@ -139,9 +139,7 @@ class TestPhaseUnit(object):
         record_df = jhu_data.subset(country, population=population)
         # Parameter setting
         unit = PhaseUnit("27May2020", "27Jun2020", population)
-        with pytest.raises(NameError):
-            unit.simulate()
-        with pytest.raises(KeyError):
+        with pytest.raises(UnExecutedError):
             unit3 = PhaseUnit("27May2020", "27Jun2020", population)
             unit3.set_ode(model=SIR, tau=240, rho=0.006)
             unit3.simulate()


### PR DESCRIPTION
## Related issues
This is related to #359.

## What was changed
`UnExecutedError` was created to explain that we have unexecuted methods that we need to run in advance. This is a child class of `AttributeError`, `NameError` and `ValueError`.