### PR TITLE
add: full complement when R >> I when outbreaking

### DIFF
--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -410,7 +410,7 @@ class JHUData(CleaningBase):
                     - Confirmed (int): the number of confirmed cases
                     - Fatal (int): the number of fatal cases
                     - the other columns will be ignored
-            max_ignored (int): Max number of recovered cases to be ignored [cases]
+            max_ignored (int): max number of confirmed and recovered cases to be ignored [cases]
 
         Returns:
             pandas.DataFrame
@@ -426,8 +426,8 @@ class JHUData(CleaningBase):
         """
         c, f, r = subset_df[[self.C, self.F, self.R]].max().tolist()
         if r > max_ignored and r > (c - f) * 0.1:
-            # Check if the difference between the recovered and confirmed
-            # is less than 1% of the confirmed when outbreaking
+            # Check if sum of recovered is more than 99%
+            # of sum of recovered and infected when outbreaking
             sel_1 = subset_df[self.C] > max_ignored
             sel_2 = subset_df[self.C].diff().diff() > 0
             _df = subset_df.loc[sel_1 & sel_2]

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -426,7 +426,14 @@ class JHUData(CleaningBase):
         """
         c, f, r = subset_df[[self.C, self.F, self.R]].max().tolist()
         if r > max_ignored and r > (c - f) * 0.1:
-            return subset_df
+            # Check if the difference between the recovered and confirmed
+            # is less than 1% of the confirmed when outbreaking
+            sel_1 = subset_df[self.C] > max_ignored
+            sel_2 = subset_df[self.C].diff().diff() > 0
+            _df = subset_df.loc[sel_1 & sel_2]
+            _df = _df.loc[_df[self.R] > 0.99 * (_df[self.C] - _df[self.F])]
+            if _df.empty:
+                return subset_df
         df = subset_df.set_index(self.DATE)
         # Closing period
         self._closing_period = self._closing_period or self.calculate_closing_period()

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -429,7 +429,7 @@ class JHUData(CleaningBase):
             # Check if sum of recovered is more than 99%
             # of sum of recovered and infected when outbreaking
             sel_1 = subset_df[self.C] > max_ignored
-            sel_2 = subset_df[self.C].diff().diff() > 0
+            sel_2 = subset_df[self.C].diff().diff().rolling(14).mean() > 0
             _df = subset_df.loc[sel_1 & sel_2]
             _df = _df.loc[_df[self.R] > 0.99 * (_df[self.C] - _df[self.F])]
             if _df.empty:

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -148,10 +148,11 @@ class TestJHUData(object):
         assert is_complemented
         assert df[Term.C].is_monotonic_increasing
 
-    @pytest.mark.parametrize("country", ["Netherlands", "China"])
+    @pytest.mark.parametrize("country", ["Netherlands", "China", "Germany"])
     def test_subset_complement_full(self, jhu_data, country):
-        with pytest.raises(ValueError):
-            jhu_data.subset(country=country)
+        if country != "Germany":
+            with pytest.raises(ValueError):
+                jhu_data.subset(country=country)
         df, is_complemented = jhu_data.subset_complement(country=country)
         assert set(df.columns) == set(Term.NLOC_COLUMNS)
         assert is_complemented
@@ -166,7 +167,7 @@ class TestJHUData(object):
         with pytest.raises(KeyError):
             jhu_data.subset_complement(country=country, end_date="01Jan1900")
 
-    @pytest.mark.parametrize("country", ["UK", "Netherlands", "China", "Japan"])
+    @pytest.mark.parametrize("country", ["UK", "Netherlands", "China", "Germany", "Japan"])
     def test_records(self, jhu_data, country):
         df, is_complemented = jhu_data.subset_complement(country=country)
         assert set(df.columns) == set(Term.NLOC_COLUMNS)

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 import warnings
 import pandas as pd
+from covsirphy import SubsetNotFoundError
 from covsirphy import CleaningBase, SIRF
 from covsirphy import COVID19DataHub, DataLoader, LinelistData, ExampleData
 from covsirphy import Term, JHUData, CountryData, PopulationData, OxCGRTData
@@ -169,9 +170,14 @@ class TestJHUData(object):
 
     @pytest.mark.parametrize("country", ["UK", "Netherlands", "China", "Germany", "Japan"])
     def test_records(self, jhu_data, country):
-        df, is_complemented = jhu_data.subset_complement(country=country)
+        df, is_complemented = jhu_data.records(country=country)
         assert set(df.columns) == set(Term.NLOC_COLUMNS)
         assert is_complemented
+
+    @pytest.mark.parametrize("country", ["Netherlands", "Moon"])
+    def test_records_error(self, jhu_data, country):
+        with pytest.raises(SubsetNotFoundError):
+            jhu_data.records(country=country, auto_complement=False)
 
     @pytest.mark.parametrize(
         "applied, expected, iso3",


### PR DESCRIPTION
## Related issues
This is related to #339 

## What was changed
When the number of recovered cases is too large when outbreaking, full complement on recovered data will be done.