### PR TITLE
Issue357 recovery period

### DIFF
--- a/covsirphy/cleaning/dataloader.py
+++ b/covsirphy/cleaning/dataloader.py
@@ -76,6 +76,8 @@ class DataLoader(Term):
         self.dir_path.mkdir(parents=True, exist_ok=True)
         # COVID-19 Data Hub
         self.covid19dh = None
+        # Cache instances
+        self._linelist_data = None
 
     @staticmethod
     def _last_updated_local(path):
@@ -164,7 +166,11 @@ class DataLoader(Term):
         """
         if local_file is not None:
             return JHUData(filename=local_file)
-        return self._covid19dh(name="jhu", basename=basename, verbose=verbose)
+        jhu_data = self._covid19dh(
+            name="jhu", basename=basename, verbose=verbose)
+        jhu_data.recovery_period = self.linelist(
+            verbose=verbose).recovery_period()
+        return jhu_data
 
     def population(self, basename="covid19dh.csv", local_file=None, verbose=1):
         """
@@ -251,6 +257,9 @@ class DataLoader(Term):
         Returns:
             covsirphy.CountryData: dataset at country level in Japan
         """
-        filename = self.dir_path.joinpath(basename)
-        force = self._download_necessity(filename=filename)
-        return LinelistData(filename=filename, force=force, verbose=verbose)
+        if self._linelist_data is None:
+            filename = self.dir_path.joinpath(basename)
+            force = self._download_necessity(filename=filename)
+            self._linelist_data = LinelistData(
+                filename=filename, force=force, verbose=verbose)
+        return self._linelist_data

--- a/covsirphy/cleaning/linelist.py
+++ b/covsirphy/cleaning/linelist.py
@@ -238,6 +238,17 @@ class LinelistData(CleaningBase):
         df = df.drop([self.C, self.CI, self.F, self.R], axis=1)
         return df.reset_index(drop=True)
 
+    def recovery_period(self):
+        """
+        Calculate median value of recovery period (from confirmation to recovery).
+
+        Returns:
+            int: recovery period [days]
+        """
+        df = self.closed(outcome=self.R)
+        series = (df[self.R_DATE] - df[self.CONFIRM_DATE]).dt.days
+        return int(series.median())
+
     def total(self):
         """
         This is not defined for this child class.

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -54,6 +54,9 @@ class TestLinelistData(object):
             with pytest.raises(KeyError):
                 linelist_data.closed(outcome=outcome)
 
+    def test_recovery_period(self, linelist_data):
+        assert isinstance(linelist_data.recovery_period(), int)
+
 
 class TestDataLoader(object):
     def test_start(self):
@@ -143,6 +146,9 @@ class TestJHUData(object):
         assert isinstance(jhu_data.countries(complement=False), list)
         assert isinstance(jhu_data.countries(complement=True), list)
 
+    def test_closing_period(self, jhu_data):
+        assert isinstance(jhu_data.calculate_closing_period(), int)
+
     @pytest.mark.parametrize("country", ["UK"])
     def test_subset_complement_non_monotonic(self, jhu_data, country):
         df, is_complemented = jhu_data.subset_complement(country=country)
@@ -151,6 +157,7 @@ class TestJHUData(object):
 
     @pytest.mark.parametrize("country", ["Netherlands", "China", "Germany"])
     def test_subset_complement_full(self, jhu_data, country):
+        assert isinstance(jhu_data.recovery_period, int)
         if country != "Germany":
             with pytest.raises(ValueError):
                 jhu_data.subset(country=country)


### PR DESCRIPTION
## Related issues
This is related to #357.

## What was changed
-  `LinelistData.recovery_period()` calculates median value of recovery period.
- `DataLoader.jhu()` will download linelist data as well as the dataset of COVID-19 Data Hub are returns `JHUData` instance, calling `DataLoader.linelist()` internally.
- `DataLoader.jhu()` will set `.recovery_period` property with the value of recovery period [days] calculated with `LinelistData.recovery_period()`.
- `JHUData._complement_recovered_full()` uses the expected value of recovery period set with `.recovery_period` property.