### PR TITLE
add: DataLoader.jhu() calls .japan() internally

### DIFF
--- a/covsirphy/cleaning/cbase.py
+++ b/covsirphy/cleaning/cbase.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
 import warnings
 import country_converter as coco
 from dask import dataframe as dd
@@ -28,6 +29,7 @@ class CleaningBase(Term):
             self._raw = pd.DataFrame()
             self._cleaned_df = pd.DataFrame()
         else:
+            Path(filename).parent.mkdir(exist_ok=True, parents=True)
             self._raw = dd.read_csv(
                 filename, dtype={"Province/State": "object"}
             ).compute()

--- a/covsirphy/cleaning/dataloader.py
+++ b/covsirphy/cleaning/dataloader.py
@@ -165,8 +165,15 @@ class DataLoader(Term):
             return JHUData(filename=local_file)
         jhu_data = self._covid19dh(
             name="jhu", basename=basename, verbose=verbose)
+        # Retrieve JHU data from COVID-19 Data Hub
+        jhu_data = self._covid19dh(
+            name="jhu", basename=basename, verbose=verbose)
+        # Set recovery period for full complement of recovered data in some countries
         jhu_data.recovery_period = self.linelist(
             verbose=verbose).recovery_period()
+        # Replace Japan dataset with the government-announced data
+        japan_data = self.japan()
+        jhu_data.replace(japan_data)
         return jhu_data
 
     def population(self, basename="covid19dh.csv", local_file=None, verbose=1):

--- a/covsirphy/cleaning/japan_data.py
+++ b/covsirphy/cleaning/japan_data.py
@@ -49,6 +49,7 @@ class JapanData(CountryData):
     ]
 
     def __init__(self, filename, force=False, verbose=1):
+        Path(filename).parent.mkdir(exist_ok=True, parents=True)
         if Path(filename).exists() and not force:
             self._raw = self.load(filename)
         else:

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -142,6 +142,9 @@ class JHUData(CleaningBase):
 
         Returns:
             covsirphy.JHUData: self
+
+        Notes:
+            Citation of the country data will be added to 'JHUData.citation' description.
         """
         self.ensure_instance(country_data, CountryData, name="country_data")
         # Read new dataset
@@ -154,6 +157,8 @@ class JHUData(CleaningBase):
         # Combine JHU data and the new data
         df = pd.concat([df, new], axis=0, sort=False)
         self._cleaned_df = df.copy()
+        # Citation
+        self._citation += f"\n{country_data.citation}"
         return self
 
     def _subset(self, country, province, start_date, end_date, population):

--- a/covsirphy/cleaning/linelist.py
+++ b/covsirphy/cleaning/linelist.py
@@ -41,6 +41,7 @@ class LinelistData(CleaningBase):
         if Path(filename).exists() and not force:
             self._raw = self.load(filename)
         else:
+            Path(filename).parent.mkdir(exist_ok=True, parents=True)
             self._raw = self._retrieve(filename=filename, verbose=verbose)
         self._cleaned_df = self._cleaning()
         self._citation = "Xu, B., Gutierrez, B., Mekaru, S. et al. " \

--- a/example/dataset_load.py
+++ b/example/dataset_load.py
@@ -16,23 +16,17 @@ def main():
     # Create data loader instance
     data_loader = cs.DataLoader(input_dir)
     # Load JHU dataset
+    print("<The number of cases>")
     jhu_data = data_loader.jhu()
     print(jhu_data.citation)
     ncov_df = jhu_data.cleaned()
     ncov_df.to_csv(output_dir.joinpath("covid19_cleaned_jhu.csv"), index=False)
-    # Load Japan dataset (the number of cases)
-    japan_data = data_loader.japan()
-    print(japan_data.citation)
-    japan_df = japan_data.cleaned()
-    japan_df.to_csv(output_dir.joinpath(
-        "covid19_cleaned_japan.csv"), index=False)
-    # Replace records of Japan with Japan-specific dataset
-    jhu_data.replace(japan_data)
-    ncov_df = jhu_data.cleaned()
-    ncov_df.to_csv(
-        output_dir.joinpath("jhu_cleaned_replaced.csv"), index=False
-    )
+    # Subset for Japan
+    japan_df, _ = jhu_data.records("Japan")
+    japan_df.to_csv(
+        output_dir.joinpath("jhu_cleaned_japan.csv"), index=False)
     # Load Population dataset
+    print("<Population values>")
     population_data = data_loader.population()
     print(population_data.citation)
     population_df = population_data.cleaned()
@@ -40,15 +34,12 @@ def main():
         output_dir.joinpath("population_cleaned.csv"), index=False
     )
     # Load OxCGRT dataset
+    print("<Government response tracker>")
     oxcgrt_data = data_loader.oxcgrt()
     print(oxcgrt_data.citation)
     oxcgrt_df = oxcgrt_data.cleaned()
     oxcgrt_df.to_csv(
         output_dir.joinpath("oxcgrt_cleaned.csv"), index=False
-    )
-    # Create a subset for a country with ISO3 country code
-    oxcgrt_data.subset("JPN").to_csv(
-        output_dir.joinpath("oxcgrt_cleaned_jpn.csv"), index=False
     )
 
 


### PR DESCRIPTION
## Related issues
This is related to #383 .

## What was changed
`DataLoader.jhu()` will call `DataLoader.japan()` internally to replace Japan dataset of COVID-19 Data Hub with that of https://github.com/lisphilar/covid19-sir/tree/master/data