### PR TITLE
update: title of .records() when complement

### DIFF
--- a/covsirphy/analysis/data_handler.py
+++ b/covsirphy/analysis/data_handler.py
@@ -143,12 +143,15 @@ class DataHandler(Term):
         Notes:
             Records with Recovered > 0 will be selected.
             If complement was performed by Scenario.complement() or Scenario(auto_complement=True),
-            "(complemented)" will be added to the title of the figure.
+            The kind of complement will be added to the title of the figure.
         """
         df = self.record_df.drop(self.S, axis=1)
         if not show_figure:
             return df
-        title = f"{self.area}: Cases over time{' (complemented)' if self._complemented else ''}"
+        if self._complemented:
+            title = f"{self.area}: Cases over time\nwith {self._complemented}"
+        else:
+            title = f"{self.area}: Cases over time"
         line_plot(
             df.set_index(self.DATE).drop(self.C, axis=1),
             title,


### PR DESCRIPTION
## Related issues
This is related to #382.

## What was changed
Figure titles of `Scenario.records()` with complement will be selected from
- "Cases over time" (when not complemented),
- "Cases over time with monotonic increasing complemented confirmed data",
- "Cases over time with monotonic increasing complemented fatal data",
- "Cases over time with monotonic increasing complemented recovered data",
- "Cases over time with fully complemented recovered data", or
- "Cases over time with partially complemented recovered data".

E.g.
![nld_records](https://user-images.githubusercontent.com/7270139/101358828-c4c3e600-38de-11eb-8e73-2775962a665d.jpg)
