### PR TITLE
follow-up: no complement on example data

### DIFF
--- a/covsirphy/analysis/example_data.py
+++ b/covsirphy/analysis/example_data.py
@@ -200,3 +200,17 @@ class ExampleData(JHUData):
         country, _ = self._model_to_area(
             model=model, country=country, province=province)
         return super().subset(country=country, province=province, **kwargs)
+
+    def subset_complement(self, **kwargs):
+        """
+        This is the same as ExampleData.subset().
+        Complement will not be done.
+        """
+        return self.subset(**kwargs)
+
+    def records(self, **kwargs):
+        """
+        This is the same as ExampleData.subset().
+        Complement will not be done.
+        """
+        return self.subset(**kwargs)

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -105,6 +105,13 @@ class TestExampleData(object):
         example_data.add(SIRF, country="Moon")
         assert example_data.country_to_iso3("Moon") == "---"
 
+    def test_subset(self):
+        example_data = ExampleData()
+        example_data.add(SIRF, country="Japan")
+        example_data.subset(country="Japan")
+        example_data.subset_complement(country="Japan")
+        example_data.records(country="Japan")
+
 
 class TestJHUData(object):
     def test_cleaning(self, jhu_data):


### PR DESCRIPTION
## Related issues
This is follow-up for #382.

## What was changed
`ExampleData` class, a child class of `JHUData`, does not need complement methods. Becuase of this, `ExampleData.subset_complement()` and `ExampleData.records()` will return the same outputs with `ExampleData.subset()`.