### PR TITLE
Issue420

### DIFF
--- a/covsirphy/cleaning/dataloader.py
+++ b/covsirphy/cleaning/dataloader.py
@@ -167,9 +167,6 @@ class DataLoader(Term):
         # Retrieve JHU data from COVID-19 Data Hub
         jhu_data = self._covid19dh(
             name="jhu", basename=basename, verbose=verbose)
-        # Set recovery period for full complement of recovered data in some countries
-        jhu_data.recovery_period = self.linelist(
-            verbose=verbose).recovery_period()
         # Replace Japan dataset with the government-announced data
         japan_data = self.japan()
         jhu_data.replace(japan_data)

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -258,8 +258,6 @@ class JHUData(CleaningBase):
                 start_date=start_date, end_date=end_date, message="with 'Recovered > 0'") from None
         return df
 
-    @deprecate("JHUData.to_sr()",
-               new="JHUData.records().set_index('Date').[:, ['Recovered', 'Susceptible']]")
     def to_sr(self, country, province=None,
               start_date=None, end_date=None, population=None):
         """

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -440,7 +440,7 @@ class JHUData(CleaningBase):
         # Calculate how many days passed to reach the number of cases
         df = df.unstack().reset_index()
         df.columns = ["Variable", "Date", "Number"]
-        df["Days"] = (df[self.DATE] - df[self.DATE].min()).st.days
+        df["Days"] = (df[self.DATE] - df[self.DATE].min()).dt.days
         # Calculate recovery period (mode value because bimodal)
         df = df.pivot_table(values="Days", index="Number", columns="Variable")
         df = df.interpolate(limit_area="inside").dropna().astype(np.int64)

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -393,7 +393,7 @@ class JHUData(CleaningBase):
         # Calculate mode value of closing period
         return int(df["Elapsed"].mode().astype(np.int64).values[0])
 
-    def _calculate_recovery_period(self):
+    def calculate_recovery_period(self):
         """
         Calculate the median value of recovery period of all countries
         where recovered values are reported.
@@ -495,8 +495,9 @@ class JHUData(CleaningBase):
                 country=country, country_alias=country_alias, province=province,
                 start_date=start_date, end_date=end_date) from None
         # Complement, if necessary
+        self._recovery_period = self._recovery_period or self.calculate_recovery_period()
         handler = JHUDataComplementHandler(
-            recovery_period=self._recovery_period or self._calculate_recovery_period(),
+            recovery_period=self._recovery_period,
             interval=interval,
             max_ignored=max_ignored,
             max_ending_unupdated=max_ending_unupdated,

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -401,9 +401,6 @@ class JHUData(CleaningBase):
         Notes:
             If no records we can use for calculation were registered, 17 [days] will be applied.
         """
-        # If registered, we will use it
-        if self._recovery_period is not None:
-            return self._recovery_period
         # Get valid data for calculation
         df = self._cleaned_df.copy()
         df = df.loc[df[self.PROVINCE] == self.UNKNOWN]
@@ -411,12 +408,12 @@ class JHUData(CleaningBase):
         # If no records were found 17 days will be returned
         if df.empty:
             return 17
+        # Calculate median value of recovery period in all countries with valid data
         periods = [
             self._calculate_recovery_period_country(df, country)
             for country in df[self.COUNTRY].unique()
         ]
-        self._recovery_period = int(pd.Series(periods).median())
-        return self._recovery_period
+        return int(pd.Series(periods).median())
 
     def _calculate_recovery_period_country(self, valid_df, country):
         """
@@ -496,7 +493,7 @@ class JHUData(CleaningBase):
                 start_date=start_date, end_date=end_date) from None
         # Complement, if necessary
         handler = JHUDataComplementHandler(
-            recovery_period=self._recovery_period or self.calculate_closing_period(),
+            recovery_period=self._recovery_period or self._calculate_recovery_period(),
             interval=interval,
             max_ignored=max_ignored,
             max_ending_unupdated=max_ending_unupdated,

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -3,7 +3,7 @@
 
 import numpy as np
 import pandas as pd
-from covsirphy.util.error import SubsetNotFoundError
+from covsirphy.util.error import SubsetNotFoundError, deprecate
 from covsirphy.cleaning.cbase import CleaningBase
 from covsirphy.cleaning.country_data import CountryData
 from covsirphy.cleaning.jhu_complement import JHUDataComplementHandler
@@ -258,6 +258,8 @@ class JHUData(CleaningBase):
                 start_date=start_date, end_date=end_date, message="with 'Recovered > 0'") from None
         return df
 
+    @deprecate("JHUData.to_sr()",
+               new="JHUData.records().set_index('Date').[:, ['Recovered', 'Susceptible']]")
     def to_sr(self, country, province=None,
               start_date=None, end_date=None, population=None):
         """
@@ -358,6 +360,7 @@ class JHUData(CleaningBase):
             if not self.subset_complement(country=country, **kwargs)[0].empty]
         return sorted(raw_ok_set | set(comp_ok_list))
 
+    @deprecate("JHUData.calculate_closing_period()")
     def calculate_closing_period(self):
         """
         Calculate mode value of closing period, time from confirmation to get outcome.

--- a/tests/test_datahub.py
+++ b/tests/test_datahub.py
@@ -83,7 +83,6 @@ class TestJHUData(object):
         assert df.loc[df.index[-1], Term.DATE] == last_date
 
     def test_to_sr(self, jhu_data):
-        warnings.simplefilter("ignore", category=DeprecationWarning)
         df = jhu_data.to_sr("Japan", population=126_500_000)
         assert set(df.columns) == set([Term.R, Term.S])
 

--- a/tests/test_datahub.py
+++ b/tests/test_datahub.py
@@ -83,6 +83,7 @@ class TestJHUData(object):
         assert df.loc[df.index[-1], Term.DATE] == last_date
 
     def test_to_sr(self, jhu_data):
+        warnings.simplefilter("ignore", category=DeprecationWarning)
         df = jhu_data.to_sr("Japan", population=126_500_000)
         assert set(df.columns) == set([Term.R, Term.S])
 
@@ -96,7 +97,9 @@ class TestJHUData(object):
         assert isinstance(jhu_data.countries(complement=True), list)
 
     def test_closing_period(self, jhu_data):
+        warnings.simplefilter("ignore", category=DeprecationWarning)
         assert isinstance(jhu_data.calculate_closing_period(), int)
+        assert isinstance(jhu_data.calculate_recovery_period(), int)
 
     @pytest.mark.parametrize("country", ["UK"])
     def test_subset_complement_non_monotonic(self, jhu_data, country):

--- a/tests/test_datahub.py
+++ b/tests/test_datahub.py
@@ -106,11 +106,11 @@ class TestJHUData(object):
 
     @pytest.mark.parametrize("country", ["Netherlands", "China", "Germany"])
     def test_subset_complement_full(self, jhu_data, country):
-        assert isinstance(jhu_data.recovery_period, int)
         if country in set(["Netherlands", "China"]):
             with pytest.raises(ValueError):
                 jhu_data.subset(country=country)
         df, is_complemented = jhu_data.subset_complement(country=country)
+        assert isinstance(jhu_data.recovery_period, int)
         assert set(df.columns) == set(Term.NLOC_COLUMNS)
         assert is_complemented
         with pytest.raises(KeyError):


### PR DESCRIPTION
## Related issues
#420 

## What was changed
- Add `JHUData.calculate_recovery_period()` to calculate recovery period with JHU data
- Full complement of recovery data in `JHUData` will use recovery period calculated with the method above as default in `DataLoader.jhu()`
- Deprecate `JHUData.calculate_closing_period()` (will be removed in the future, version 3.0.0)