### PR TITLE
add: update PCRData with "Our World In Data"

### DIFF
--- a/covsirphy/cleaning/cbase.py
+++ b/covsirphy/cleaning/cbase.py
@@ -51,19 +51,21 @@ class CleaningBase(Term):
         self._raw = self.ensure_dataframe(dataframe, name="dataframe")
 
     @staticmethod
-    def load(urlpath, header=0, columns=None):
+    def load(urlpath, header=0, columns=None, dtype="object"):
         """
         Load a local/remote file.
 
         Args:
             urlpath (str or pathlib.Path): filename or URL
             header (int): row number of the header
+            columns (list[str]): columns to use
+            dtype (str or dict[str]): data type for the dataframe or specified columns
 
         Returns:
             pd.DataFrame: raw dataset
         """
         kwargs = {
-            "low_memory": False, "dtype": "object", "header": header, "names": columns}
+            "low_memory": False, "dtype": dtype, "header": header, "usecols": columns}
         try:
             return dd.read_csv(urlpath, blocksize=None, **kwargs).compute()
         except (FileNotFoundError, UnicodeDecodeError, pd.errors.ParserError):

--- a/covsirphy/cleaning/dataloader.py
+++ b/covsirphy/cleaning/dataloader.py
@@ -250,14 +250,16 @@ class DataLoader(Term):
                 filename=filename, force=force, verbose=verbose)
         return self._linelist_data
 
-    def pcr(self, basename="covid19dh.csv", local_file=None, verbose=1):
+    def pcr(self, basename="covid19dh.csv", local_file=None,
+            basename_owid="ourworldindata_pcr.csv", verbose=1):
         """
         Load the dataset regarding the number of tests and confirmed cases,
         using local CSV file or COVID-19 Data Hub.
 
         Args:
-            basename (str or None): basename of the file to save the data
+            basename (str or None): basename of the file to save "COVID-19 Data Hub" data
             local_file (str or None): if not None, load the data from this file
+            basename_owid (str): basename of the file to save "Our World In Data" data
             verbose (int): level of verbosity
 
         Notes:
@@ -273,6 +275,9 @@ class DataLoader(Term):
         # Retrieve JHU data from COVID-19 Data Hub
         pcr_data = self._covid19dh(
             name="pcr", basename=basename, verbose=verbose)
+        # Update the values using "Our World In Data" dataset
+        owid_filename = self.dir_path.joinpath(basename_owid)
+        pcr_data.update_with_ourworldindata(filename=owid_filename)
         # Replace Japan dataset with the government-announced data
         japan_data = self.japan()
         pcr_data.replace(japan_data)

--- a/covsirphy/cleaning/pcr_data.py
+++ b/covsirphy/cleaning/pcr_data.py
@@ -190,6 +190,10 @@ class PCRData(CleaningBase):
         df[self.DATE] = pd.to_datetime(df[self.DATE])
         # Save the dataframe as the cleaned dataset
         self._cleaned_df = df.reset_index(drop=True)
+        # Update citation
+        self._citation += "\nHasell, J., Mathieu, E., Beltekian, D. et al." \
+            " A cross-country database of COVID-19 testing. Sci Data 7, 345 (2020)." \
+            " https://doi.org/10.1038/s41597-020-00688-8"
         return self
 
     def replace(self, country_data):

--- a/covsirphy/cleaning/pcr_data.py
+++ b/covsirphy/cleaning/pcr_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+from pathlib import Path
 import numpy as np
 import pandas as pd
 from dask import dataframe as dd
@@ -40,7 +41,8 @@ class PCRData(CleaningBase):
             ).compute()
             self._cleaned_df = self._cleaning()
         self.interval = self.ensure_natural_int(interval, name="interval")
-        self.min_pcr_tests = self.ensure_natural_int(min_pcr_tests, name="min_pcr_tests")
+        self.min_pcr_tests = self.ensure_natural_int(
+            min_pcr_tests, name="min_pcr_tests")
         self._citation = citation or ""
         # To avoid "imported but unused"
         self.__swifter = swifter
@@ -136,6 +138,59 @@ class PCRData(CleaningBase):
         instance._cleaned_df = cls.ensure_dataframe(
             dataframe, name="dataframe", columns=cls.PCR_COLUMNS)
         return instance
+
+    def _download_ourworldindata(self, filename):
+        """
+        Download the dataset (ISO code/date/the number of tests) from "Our World In Data" site.
+        https://github.com/owid/covid-19-data/tree/master/public/data
+        https://ourworldindata.org/coronavirus
+
+        Args:
+            filename (str): CSV filename to save the datasetretrieved from "Our World In Data"
+        """
+        url = "https://covid.ourworldindata.org/data/testing/covid-testing-all-observations.csv"
+        col_dict = {
+            "ISO code": self.ISO3,
+            "Date": self.DATE,
+            "Cumulative total": self.TESTS
+        }
+        # Download the dataset
+        df = self.load(url, columns=list(col_dict))
+        # Data cleaning
+        df = df.rename(col_dict, axis=1)
+        df[self.TESTS] = pd.to_numeric(df[self.TESTS], errors="coerce")
+        df[self.TESTS] = df[self.TESTS].fillna(method="ffill").astype(np.int64)
+        # Drop duplicated records
+        df = df.drop_duplicates(subset=[self.ISO3, self.DATE])
+        # Save as CSV file
+        df.to_csv(filename, index=False)
+        return df
+
+    def update_with_ourworldindata(self, filename, force=False):
+        """
+        Update the cleaned dataset using the data retrieved from "Our World In Data" site.
+        https://github.com/owid/covid-19-data/tree/master/public/data
+        https://ourworldindata.org/coronavirus
+
+        Args:
+            filename (str): CSV filename to save the datasetretrieved from "Our World In Data"
+            force (bool): if True, always download the dataset from "Our World In Data"
+        """
+        # Retrieve dataset from "Our World In Data" if necessary
+        Path(filename).parent.mkdir(exist_ok=True, parents=True)
+        if Path(filename).exists() and not force:
+            new_df = self.load(filename, dtype={self.TESTS: np.int64})
+        else:
+            new_df = self._download_ourworldindata(filename)
+        # Update the cleaned dataset
+        df = self._cleaned_df.copy()
+        df.index = df[self.ISO3].str.cat(df[self.DATE].astype(str), sep="_")
+        new_df.index = new_df[self.ISO3].str.cat(new_df[self.DATE], sep="_")
+        df.update(new_df)
+        df[self.DATE] = pd.to_datetime(df[self.DATE])
+        # Save the dataframe as the cleaned dataset
+        self._cleaned_df = df.reset_index(drop=True)
+        return self
 
     def replace(self, country_data):
         """

--- a/docs/markdown/INSTALLATION.md
+++ b/docs/markdown/INSTALLATION.md
@@ -48,6 +48,11 @@ Xu, B., Gutierrez, B., Mekaru, S. et al. Epidemiological data from the COVID-19 
 
 - Linelist of case reports
 
+### [Our World In Data](https://github.com/owid/covid-19-data/tree/master/public/data)
+Citation: Hasell, J., Mathieu, E., Beltekian, D. et al. A cross-country database of COVID-19 testing. Sci Data 7, 345 (2020). https://doi.org/10.1038/s41597-020-00688-8
+
+- The number of tests
+
 ### [Datasets for CovsirPhy](https://github.com/lisphilar/covid19-sir/tree/master/data)
 Lisphilar (2020), GitHub repository, COVID-19 dataset in Japan.  
 

--- a/example/dataset_load.py
+++ b/example/dataset_load.py
@@ -44,15 +44,13 @@ def main():
     # Load PCR test dataset
     print("<The number of PCR tests>")
     pcr_data = data_loader.pcr()
-    print(oxcgrt_data.citation)
+    print(pcr_data.citation)
     pcr_df = pcr_data.cleaned()
     pcr_df.to_csv(
-        output_dir.joinpath("pcr_cleaned.csv"), index=False
-    )
+        output_dir.joinpath("pcr_cleaned.csv"), index=False)
     pcr_data.positive_rate(
         country="Greece",
-        filename=output_dir.joinpath("pcr_positive_rate_Greece.jpg")
-    )
+        filename=output_dir.joinpath("pcr_positive_rate_Greece.jpg"))
 
 
 if __name__ == "__main__":

--- a/tests/test_datahub.py
+++ b/tests/test_datahub.py
@@ -31,7 +31,8 @@ class TestDataLoader(object):
         with pytest.raises(TypeError):
             DataLoader(directory=0)
 
-    def test_dataloader(self, jhu_data, population_data, oxcgrt_data, japan_data, linelist_data):
+    def test_dataloader(self, jhu_data, population_data, oxcgrt_data,
+                        japan_data, linelist_data, pcr_data):
         # List of primary sources of COVID-19 Data Hub
         data_loader = DataLoader()
         assert data_loader.covid19dh_citation
@@ -41,6 +42,7 @@ class TestDataLoader(object):
         assert isinstance(oxcgrt_data, OxCGRTData)
         assert isinstance(japan_data, CountryData)
         assert isinstance(linelist_data, LinelistData)
+        assert isinstance(pcr_data, PCRData)
         # Local file
         data_loader.jhu(local_file="input/covid19dh.csv")
         data_loader.population(local_file="input/covid19dh.csv")
@@ -223,6 +225,10 @@ class TestPCRData(object):
     def test_from_dataframe(self, pcr_data):
         df = pcr_data.cleaned()
         assert isinstance(PCRData.from_dataframe(df), PCRData)
+
+    def test_update_with_ourworldindata(self, pcr_data):
+        pcr_data.update_with_ourworldindata(
+            filename="input/ourworldindata_pcr.csv")
 
     def test_subset(self, pcr_data):
         with pytest.raises(SubsetNotFoundError):


### PR DESCRIPTION
## Related issues
#429 

## What was changed
Use PCR dataset (ISO3 code, date, the number of tests) retrieved from "Our World In Data" to update `PCRData`. `PCRData" created by `DataLoader` class will have two data source, COVID-19 Data Hub and this new dataset.