### PR TITLE
Issue429 pcr not default

### DIFF
--- a/covsirphy/cleaning/dataloader.py
+++ b/covsirphy/cleaning/dataloader.py
@@ -279,8 +279,7 @@ class DataLoader(Term):
         # Update the values using "Our World In Data" dataset
         owid_filename = self.dir_path.joinpath(basename_owid)
         owid_force = self._download_necessity(filename=owid_filename)
-        pcr_data.update_with_ourworldindata(
-            filename=owid_filename, force=owid_force)
+        pcr_data.use_ourworldindata(filename=owid_filename, force=owid_force)
         # Replace Japan dataset with the government-announced data
         japan_data = self.japan()
         pcr_data.replace(japan_data)

--- a/tests/test_datahub.py
+++ b/tests/test_datahub.py
@@ -229,8 +229,8 @@ class TestPCRData(object):
         df = pcr_data.cleaned()
         assert isinstance(PCRData.from_dataframe(df), PCRData)
 
-    def test_update_with_ourworldindata(self, pcr_data):
-        pcr_data.update_with_ourworldindata(
+    def test_use_ourworldindata(self, pcr_data):
+        pcr_data.use_ourworldindata(
             filename="input/ourworldindata_pcr.csv")
 
     def test_subset(self, pcr_data):
@@ -249,7 +249,7 @@ class TestPCRData(object):
         df, _ = pcr_data.records("Greece")
         assert set(df.columns) == set(PCRData.PCR_NLOC_COLUMNS)
 
-    @pytest.mark.parametrize("country", ["Greece", "Italy", "France"])
+    @pytest.mark.parametrize("country", ["Greece", "Italy"])
     def test_positive_rate(self, pcr_data, country):
         warnings.simplefilter("ignore", category=UserWarning)
         pcr_data.positive_rate(country, show_figure=True)

--- a/tests/test_datahub.py
+++ b/tests/test_datahub.py
@@ -249,7 +249,7 @@ class TestPCRData(object):
         df, _ = pcr_data.records("Greece")
         assert set(df.columns) == set(PCRData.PCR_NLOC_COLUMNS)
 
-    @pytest.mark.parametrize("country", ["Greece", "Italy"])
+    @pytest.mark.parametrize("country", ["Greece", "Italy", "France"])
     def test_positive_rate(self, pcr_data, country):
         warnings.simplefilter("ignore", category=UserWarning)
         pcr_data.positive_rate(country, show_figure=True)


### PR DESCRIPTION
## Related issues
#429

## What was changed
Only when `PCRIncorrectPreconditionError` is raised in `PCRData._pcr_check_preconditions()`, retrieve the data from "Our World In Data" for the country and retry `PCRData._pcr_check_preconditions()` with this new dataset.