### PR TITLE
fix: partial and ending partial complement + show complement new method

### DIFF
--- a/covsirphy/cleaning/jhu_complement.py
+++ b/covsirphy/cleaning/jhu_complement.py
@@ -25,6 +25,14 @@ class JHUDataComplementHandler(Term):
         Status code: 'fully complemented recovered data' and so on as noted in self.run() docstring.
     """
     RAW_COLS = [Term.C, Term.F, Term.R]
+    MONOTONIC_CONFIRMED = "Monotonic_confirmed"
+    MONOTONIC_FATAL = "Monotonic_fatal"
+    MONOTONIC_RECOVERED = "Monotonic_recovered"
+    FULL_RECOVERED = "Full_recovered"
+    PARTIAL_RECOVERED = "Partial_recovered"
+    RECOVERED_COLS = [MONOTONIC_RECOVERED, FULL_RECOVERED, PARTIAL_RECOVERED]
+    SHOW_COMPLEMENT_COLS = [Term.C, Term.F, *RECOVERED_COLS]
+    SHOW_COMPLEMENT_FULL_COLS = [MONOTONIC_CONFIRMED, MONOTONIC_FATAL, *RECOVERED_COLS]
     # Kind of complement: {score: name}
     STATUS_NAME_DICT = {
         1: "sorting",
@@ -42,6 +50,7 @@ class JHUDataComplementHandler(Term):
             max_ignored, name="max_ignored")
         self.max_ending_unupdated = self.ensure_natural_int(
             max_ending_unupdated, name="max_ending_unupdated")
+        self.complement_dict = None
 
     def _protocol(self):
         """
@@ -58,8 +67,9 @@ class JHUDataComplementHandler(Term):
             (self.R, self._recovered_full, 4),
             (self.R, self._recovered_sort, 1),
             (self.R, functools.partial(self._monotonic, variable=self.R), 2),
-            (self.R, self._recovered_partial_ending, 3),
             (self.R, self._recovered_partial, 3),
+            (self.R, self._recovered_partial_ending, 3),
+            (self.R, self._recovered_sort, 1),
             (self.R, functools.partial(self._monotonic, variable=self.R), 2),
             (self.R, self._recovered_sort, 1),
             (None, self._post_processing, 0)
@@ -80,7 +90,7 @@ class JHUDataComplementHandler(Term):
                     - The other columns will be ignored
 
         Returns:
-            tuple(pandas.DataFrame, str):
+            tuple(pandas.DataFrame, str, dict):
                 pandas.DataFrame:
                     Index: reset index
                     Columns:
@@ -90,6 +100,7 @@ class JHUDataComplementHandler(Term):
                         - Fatal(int): the number of fatal cases
                         - Recovered (int): the number of recovered cases
                 str: status code
+                dict: status for each complement type
 
         Notes:
             Status code will be selected from:
@@ -105,6 +116,7 @@ class JHUDataComplementHandler(Term):
         # Initialize
         after_df = subset_df.copy()
         status_dict = dict.fromkeys(self.RAW_COLS, 0)
+        self.complement_dict = dict.fromkeys(self.SHOW_COMPLEMENT_COLS, 0)
         # Perform complement one by one
         for (variable, func, score) in self._protocol():
             before_df, after_df = after_df.copy(), func(after_df)
@@ -116,7 +128,7 @@ class JHUDataComplementHandler(Term):
             f"{self.STATUS_NAME_DICT[score]} complemented {v.lower()} data"
             for (v, score) in status_dict.items() if score]
         status = " and \n".join(status_list)
-        return (after_df, status)
+        return (after_df, status, self.complement_dict)
 
     def _pre_processing(self, subset_df):
         """
@@ -185,6 +197,10 @@ class JHUDataComplementHandler(Term):
             # Reduce values to the previous date
             df.loc[:date, variable] = series * raw_last / series.iloc[-1]
             df[variable] = df[variable].fillna(0).astype(np.int64)
+        if variable in [self.C, self.F]:
+            self.complement_dict[variable] = True
+        else:
+            self.complement_dict["Monotonic_recovered"] = True
         return df
 
     def _recovered_full(self, df):
@@ -218,13 +234,14 @@ class JHUDataComplementHandler(Term):
         # Estimate recovered records
         df[self.R] = (df[self.C] - df[self.F]).shift(
             periods=self.recovery_period, freq="D")
+        self.complement_dict["Full_recovered"] = True
         return df
 
     def _recovered_partial_ending(self, df):
         """
-        If ending recovered values do not change for more than applied 'self.interval' days
-        after reached 'self.max_ignored' cases, apply full complement only to these
-        unupdated values and keep the previous valid ones.
+        If ending recovered values do not change for more than applied 'self.max_ending_unupdated' days
+        after reached 'self.max_ignored' cases, apply either previous diff() (with some variance)
+        or full complement only to these ending unupdated values and keep the previous valid ones.
         _recovered_partial() does not handle well such values, because
         they are not in-between values and interpolation generates only similar values,
         but small compared to confirmed cases.
@@ -238,6 +255,9 @@ class JHUDataComplementHandler(Term):
             pandas.DataFrame: complemented records
                 Index: Date (pandas.TimeStamp)
                 Columns: Confirmed, Fatal, Recovered
+        
+        Note: _recovered_partial_ending() must always be called
+              after _recovered_partial()
         """
         # Whether complement is necessary or not
         r_max = df[self.R].max()
@@ -245,13 +265,31 @@ class JHUDataComplementHandler(Term):
         if not (r_max and sel_0):
             # full complement will be handled in _recovered_full()
             return df
-        # Complement any ending unupdated values.
-        # Fully complement last records that are not updated
-        # for more than max_ending_unupdated days;
-        # keep previous valid values as they are
+        # Complement any ending unupdated values that are not updated
+        # for more than max_ending_unupdated days,
+        # by keeping and propagating forward previous valid diff()
+        # min_index: index for first ending max R reoccurrence     
         min_index = df[self.R].idxmax() + timedelta(days=1)
-        df.loc[min_index:, self.R] = (df[self.C] - df[self.F]).shift(
-            periods=self.recovery_period, freq="D").loc[min_index:]
+        first_value = df.loc[min_index, self.R]
+        df_ending = df.copy()
+        df_ending.loc[df_ending.duplicated([self.R], keep="first"), self.R] = None
+        diff_series = df_ending[self.R].diff().ffill().fillna(0).astype(np.int64)
+        diff_series.loc[diff_series.duplicated(keep="last")] = None
+        diff_series.interpolate(
+            method="linear", inplace=True, limit_direction="both")
+        df.loc[min_index:, self.R] = first_value + diff_series[min_index:].cumsum()
+
+        # Check if the ending complement is valid (too large recovered ending values)
+        # If the validity check fails, then fully complement these ending values
+        sel_C1 = df[self.C] > self.max_ignored
+        sel_R1 = df[self.R] > self.max_ignored
+        cf_diff = df[self.C] - df[self.F] # check all values one-by-one, no rolling window
+        sel_limit = df[self.R] > 0.99 * cf_diff
+        s_df_1 = df.loc[sel_C1 & sel_R1 & sel_limit]
+        if not s_df_1.empty:
+            df.loc[min_index:, self.R] = (df[self.C] - df[self.F]).shift(
+                periods=self.recovery_period, freq="D").loc[min_index:]
+        self.complement_dict["Partial_recovered"] = True
         return df
 
     def _recovered_partial(self, df):
@@ -273,12 +311,13 @@ class JHUDataComplementHandler(Term):
         series = df.loc[df[self.R] > self.max_ignored, self.R]
         max_frequency = series.value_counts().max()
         if max_frequency <= self.interval:
-            return df
+            return df     
         # Complement in-between values
-        df.loc[df.duplicated([self.R], keep="last"), self.R] = None
+        df.loc[df.duplicated([self.R], keep="first"), self.R] = None
         df[self.R].interpolate(
             method="linear", inplace=True, limit_direction="both")
         df[self.R] = df[self.R].fillna(method="bfill")
+        self.complement_dict["Partial_recovered"] = True
         return df
 
     def _recovered_sort(self, df):
@@ -294,6 +333,9 @@ class JHUDataComplementHandler(Term):
             pandas.DataFrame: complemented records
                 Index: Date (pandas.TimeStamp)
                 Columns: Confirmed, Fatal, Recovered
+        
+        Note: _recovered_sort() must always be called
+              after _recovered_partial_ending()
         """
         df.loc[:, self.R] = sorted(df[self.R].abs())
         df[self.R].interpolate(method="time", inplace=True)

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -501,7 +501,7 @@ class JHUData(CleaningBase):
             max_ignored=max_ignored,
             max_ending_unupdated=max_ending_unupdated,
         )
-        df, status = handler.run(subset_df)
+        df, status, _ = handler.run(subset_df)
         # Calculate Susceptible
         df = self._calculate_susceptible(df, population)
         # Kind of complement or False
@@ -558,3 +558,64 @@ class JHUData(CleaningBase):
             raise SubsetNotFoundError(
                 country=country, country_alias=country_alias, province=province,
                 start_date=start_date, end_date=end_date, message="with 'Recovered > 0'") from None
+
+    def show_complement(self, country=None, province=None,
+                          start_date=None, end_date=None, population=None,
+                          interval=2, max_ignored=100, max_ending_unupdated=14):
+        """
+        To monitor effectivity and safety of complement on JHU subset,
+        we need to know what kind of complement was done for JHU subset
+        for each country (if country/countries specified) or for all countries.
+
+        Args:
+            country(str): country name or ISO3 code
+            province(str or None): province name
+            start_date(str or None): start date, like 22Jan2020
+            end_date(str or None): end date, like 01Feb2020
+            population(int or None): population value
+            interval (int): expected update interval of the number of recovered cases [days]
+            max_ignored (int): Max number of recovered cases to be ignored [cases]
+            max_ending_unupdated (int) : Max number of days to apply full complement,
+                 where ending recovered cases are not updated [days]
+
+        Returns:
+            pandas.DataFrame:
+                Index: reset index
+                Columns:
+                    - country(str): country name or ISO3 code
+                    - Monotonic_confirmed (str/bool): True if applied for confirmed cases or False otherwise
+                    - Monotonic_fatal (str/bool): True if applied for fatal cases or False otherwise
+                    - Monotonic_recovered (str/bool): True if applied for recovered or False otherwise
+                    - Full_recovered (str/bool): True if applied for recovered or False otherwise
+                    - Partial_recovered (str/bool): True if applied for recovered or False otherwise
+        """
+        complement_df = pd.DataFrame(columns=[self.COUNTRY, self.PROVINCE, *JHUDataComplementHandler.SHOW_COMPLEMENT_FULL_COLS])
+        complement_df.set_index(self.COUNTRY, inplace=True)
+        self._recovery_period = self._recovery_period or self.calculate_recovery_period()
+        if not country:
+            country = self._cleaned_df[self.COUNTRY].unique().tolist()
+
+        if type(country) is not list:
+            country = [country]
+        for cur_country in country:
+            if cur_country == "Others":
+                continue
+            if province == None:
+                province = "-"
+            country_alias = self.ensure_country_name(cur_country)
+            subset_df = self._subset(
+                country=cur_country, province=province, start_date=start_date, end_date=end_date)
+            if subset_df.empty:
+                raise SubsetNotFoundError(
+                    country=cur_country, country_alias=country_alias) from None
+            
+            handler = JHUDataComplementHandler(
+                recovery_period=self._recovery_period,
+                interval=interval,
+                max_ignored=max_ignored,
+                max_ending_unupdated=max_ending_unupdated,
+            )
+            _, _, complement_dict = handler.run(subset_df)
+            complement_dict_values = pd.Series(complement_dict.values(), dtype=bool).values
+            complement_df.loc[cur_country] = [province] + complement_dict_values.tolist()
+        return complement_df

--- a/tests/test_datahub.py
+++ b/tests/test_datahub.py
@@ -9,6 +9,7 @@ from covsirphy import SubsetNotFoundError, PCRIncorrectPreconditionError
 from covsirphy import COVID19DataHub, DataLoader, LinelistData
 from covsirphy import Term, JHUData, CountryData, PopulationData
 from covsirphy import OxCGRTData, PCRData, VaccineData
+from covsirphy import JHUDataComplementHandler
 
 
 class TestCOVID19DataHub(object):
@@ -170,6 +171,24 @@ class TestJHUData(object):
             response = jhu_data.ensure_country_name(applied)
             assert response == expected
             assert jhu_data.country_to_iso3(response) == iso3
+
+    @pytest.mark.parametrize(
+        "country, province",
+        [
+            ("Greece", None),
+            (["Greece", "Japan"], None),
+            (["Greece", "Japan"], "Tokyo"),
+            (None, None),
+        ]
+    )
+    def test_show_complement(self, jhu_data, country, province):
+        if isinstance(country, list) and (province is not None):
+            with pytest.raises(ValueError):
+                jhu_data.show_complement(country=country, province=province)
+        else:
+            complement_df = jhu_data.show_complement(country=country, province=province)
+            all_set = set(JHUDataComplementHandler.SHOW_COMPLEMENT_FULL_COLS)
+            assert all_set.issubset(complement_df.columns)
 
 
 class TestPopulationData(object):


### PR DESCRIPTION
## Related issues
This is related to #401, #450

## What was changed
For issue #401, new method `show_complement()` in `JHUData` class was created for returning the kind of complement that was done for JHU subset for all the available countries or for specified country/countries.

For issue #450, improved `_recovered_partial()` and `_recovered_partial_ending()`. For overcoming the constant ending diff values upon complementing, these ending diff values were interpolated in order to create some kind of variance.