### PR TITLE
fix: reworks in recovery periods validation

### DIFF
--- a/covsirphy/cleaning/jhu_complement.py
+++ b/covsirphy/cleaning/jhu_complement.py
@@ -220,13 +220,13 @@ class JHUDataComplementHandler(Term):
         self.complement_dict[f"Monotonic_{variable.lower()}"] = True
         return df
 
-    def _validate_recovery_period(self, df):
+    def _validate_recovery_period(self, country_df):
         """
         Calculates and validates recovery period for specific country
         as an additional condition in order to apply full complement or not
 
         Args:
-            df (pandas.DataFrame):
+            country_df (pandas.DataFrame):
                 - Index: reset_index
                 - Columns: Date, Confirmed, Recovered, Fatal
 
@@ -237,6 +237,7 @@ class JHUDataComplementHandler(Term):
               upper_limit_days has default value of 3 months (90 days)
               lower_limit_days has default value of 1 week (7 days)
         """
+        df = country_df.copy()
         # Calculate "Confirmed - Fatal"
         df["diff"] = df[self.C] - df[self.F]
         df = df.loc[:, ["diff", self.R]]

--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -427,7 +427,7 @@ class JHUData(CleaningBase):
             self._calculate_recovery_period_country(df, country)
             for country in df[self.COUNTRY].unique()
         ]
-        valid_periods = list(filter(lambda x: x > 0, periods))
+        valid_periods = list(filter(lambda x: x >= 0, periods))
         return int(pd.Series(valid_periods).median())
 
     def _calculate_recovery_period_country(self, valid_df, country, upper_limit_days=90,
@@ -441,6 +441,7 @@ class JHUData(CleaningBase):
             valid_df (pandas.DataFrame):
                 - Index: reset_index
                 - Columns: Date, Confirmed, Recovered, Fatal
+            country(str): country name or ISO3 code
             upper_limit_days (int): maximum number of valid partial recovery periods [days]
             lower_limit_days (int): minimum number of valid partial recovery periods [days]
             upper_percentage (float): fraction of partial recovery periods with value greater than upper_limit_days


### PR DESCRIPTION
## Related issues
Related to #514.

## What was changed
Follow-up reworks for `df.copy` usage. Also added checks for partial recovery periods in `_calculate_recovery_period_country()`.