### PR TITLE
add: "phases" argument

### DIFF
--- a/covsirphy/analysis/param_tracker.py
+++ b/covsirphy/analysis/param_tracker.py
@@ -152,7 +152,7 @@ class ParamTracker(Term):
 
     def all_phases(self):
         """
-        Return the names of all phases.
+        Return the names of all enabled phases.
 
         Returns:
             list[str]: the names of all enabled phases

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -272,7 +272,7 @@ class TestScenario(object):
         snl.estimate(SIRF, timeout=5, timeout_iteration=5)
         # Simulation
         snl.simulate(variables=[Term.C, Term.CI, Term.F, Term.R])
-        snl.simulate(phases=["0th"])
+        snl.simulate(phases=all_phases[-1])
         # Parameter history (Deprecated)
         snl.param_history([Term.RT], divide_by_first=False)
         snl.param_history(["rho"])
@@ -286,7 +286,7 @@ class TestScenario(object):
         snl.history(target="Rt")
         snl.history(target="sigma")
         snl.history(target="rho", show_figure=False)
-        snl.history(target="Infected", phases=["0th"])
+        snl.history(target="Infected", phases=all_phases[-1])
         with pytest.raises(KeyError):
             snl.history(target="temperature")
         # Change rate of parameters

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -272,7 +272,7 @@ class TestScenario(object):
         snl.estimate(SIRF, timeout=5, timeout_iteration=5)
         # Simulation
         snl.simulate(variables=[Term.C, Term.CI, Term.F, Term.R])
-        snl.simulate(phases=all_phases[-1])
+        snl.simulate(phases=all_phases[-2:])
         # Parameter history (Deprecated)
         snl.param_history([Term.RT], divide_by_first=False)
         snl.param_history(["rho"])
@@ -286,7 +286,7 @@ class TestScenario(object):
         snl.history(target="Rt")
         snl.history(target="sigma")
         snl.history(target="rho", show_figure=False)
-        snl.history(target="Infected", phases=all_phases[-1])
+        snl.history(target="Infected", phases=all_phases[-2:])
         with pytest.raises(KeyError):
             snl.history(target="temperature")
         # Change rate of parameters

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -272,6 +272,7 @@ class TestScenario(object):
         snl.estimate(SIRF, timeout=5, timeout_iteration=5)
         # Simulation
         snl.simulate(variables=[Term.C, Term.CI, Term.F, Term.R])
+        snl.simulate(phases=["0th"])
         # Parameter history (Deprecated)
         snl.param_history([Term.RT], divide_by_first=False)
         snl.param_history(["rho"])
@@ -285,7 +286,7 @@ class TestScenario(object):
         snl.history(target="Rt")
         snl.history(target="sigma")
         snl.history(target="rho", show_figure=False)
-        snl.history(target="Infected")
+        snl.history(target="Infected", phases=["0th"])
         with pytest.raises(KeyError):
             snl.history(target="temperature")
         # Change rate of parameters


### PR DESCRIPTION
## Related issues
#511

## What was changed
Add `phases=None` (default) argument to select phases to show in `Scenario.history()`/`Scenario.simulate()` method.