### PR TITLE
Issue516 dep

### DIFF
--- a/docs/markdown/INSTALLATION.md
+++ b/docs/markdown/INSTALLATION.md
@@ -12,7 +12,11 @@ pip install --upgrade "git+https://github.com/lisphilar/covid19-sir.git#egg=covs
 ```
 
 Note:  
-When using CovsirPhy in Google Colaboratory, please restart runtime after installation.
+When using CovsirPhy in Kaggle Notebook, please run the following codes to remove third-party `typing` package.
+
+```Python
+!pip uninstall typing -y
+```
 
 # Dataset preparation
 Recommended datasets for analysis can be downloaded and updated easily with `DataLoader` class. If you have CSV files in your environment, you can analyse them.

--- a/poetry.lock
+++ b/poetry.lock
@@ -1880,7 +1880,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.9"
-content-hash = "3c6f6dd93c02ac9881e1c2f4e7cc191173762f0af5d18e328ff0c5eb0fce5150"
+content-hash = "aea1c9ab9c528856f7193cb667c45ea08930e7751ecbca82e29fcccd6ce9c44c"
 
 [metadata.files]
 aiohttp = [

--- a/poetry.lock
+++ b/poetry.lock
@@ -1880,7 +1880,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.9"
-content-hash = "aea1c9ab9c528856f7193cb667c45ea08930e7751ecbca82e29fcccd6ce9c44c"
+content-hash = "4e61eb17a2efddc5f26529af921e28b169cbc3e4921f3aa1bfec2f476b7f54ef"
 
 [metadata.files]
 aiohttp = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 
 [tool.poetry.dependencies]
 python = "^3.6.9"
-numpy = "^1.19.5"
+numpy = "^1.18.5"
 optuna = "^2.3.0"
 pandas = "^1.1.5"
 seaborn = "^0.11.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ requests = "^2.25.1"
 ruptures = "^1.1.1"
 covid19dh = "^2.0.3"
 tabulate = "^0.8.7"
-matplotlib = "^3.3.3"
+matplotlib = "^3.2.1"
 country-converter = "^0.7.1"
 wbdata = "^0.3.0"
 dask = {version = "^2020.12.0", extras = ["dataframe"]}


### PR DESCRIPTION
## Related issues
#480 and #516

## What was changed
- For #480, downgrade `matplotlib` from 3.3.3 to 3.2.1 (Restart of runtime in Google colab will not be necessary)
- For #516, downgrade `numpy` from 2.9.5 to 2.9.1 (to fix `AttributeError` in installation with Kaggle Notebook)
- Update installation guide to install CovsirPhy in Kaggle/Google Colab