### PR TITLE
docs: necessity of uninstall of typing

### DIFF
--- a/docs/markdown/INSTALLATION.md
+++ b/docs/markdown/INSTALLATION.md
@@ -12,7 +12,7 @@ pip install --upgrade "git+https://github.com/lisphilar/covid19-sir.git#egg=covs
 ```
 
 Note:  
-When using **development version** of CovsirPhy in Kaggle Notebook, please run the following codes to remove third-party `typing` package.
+When using **development versions** of CovsirPhy in Kaggle Notebook, please run the following codes to remove third-party `typing` package.
 
 ```Python
 !pip uninstall typing -y

--- a/docs/markdown/INSTALLATION.md
+++ b/docs/markdown/INSTALLATION.md
@@ -12,10 +12,11 @@ pip install --upgrade "git+https://github.com/lisphilar/covid19-sir.git#egg=covs
 ```
 
 Note:  
-When using CovsirPhy in Kaggle Notebook, please run the following codes to remove third-party `typing` package.
+When using **development version** of CovsirPhy in Kaggle Notebook, please run the following codes to remove third-party `typing` package.
 
 ```Python
 !pip uninstall typing -y
+!pip install --upgrade "git+https://github.com/lisphilar/covid19-sir.git#egg=covsirphy"
 ```
 
 # Dataset preparation


### PR DESCRIPTION
## Related issues
#516 

## What was changed
To note that
`!pip uninstall typing -y` is necessary only when using **development versions** of CovsirPhy with Kaggle Notebook.