### PR TITLE
add: register total as country level data

### DIFF
--- a/covsirphy/cleaning/country_data.py
+++ b/covsirphy/cleaning/country_data.py
@@ -101,6 +101,8 @@ class CountryData(CleaningBase):
             df[self.PROVINCE] = self._province or self.UNKNOWN
         # Values
         v_cols = [self.C, self.F, self.R]
+        for col in v_cols:
+            df[col] = pd.to_numeric(df[col], errors="coerce")
         df[v_cols] = df[v_cols].fillna(0).astype(np.int64)
         df[self.CI] = df[self.C] - df[self.F] - df[self.R]
         # Groupby date and province

--- a/tests/test_dataloader.py
+++ b/tests/test_dataloader.py
@@ -136,7 +136,6 @@ class TestCountryData(object):
         raw_df.to_csv(filename)
         # Create CountryData instance
         country_data = CountryData(filename=filename, country="Italy")
-        country_data.raw = raw_df.copy()
         country_data.set_variables(
             date="date", confirmed="confirmed", recovered="recovered", fatal="deaths",
             province="administrative_area_level_2"


### PR DESCRIPTION
## Related issues
#555 and #557

## What was changed
- Add `CountryData.register_total()` to register total value of all provinces as country level data.
- Close #557: `ValueError: invalid literal for int() with base 10: '0.0'` when `running `country_data.cleaned()`.