### PR TITLE
Issue578 selectable pruners

### DIFF
--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -245,6 +245,7 @@ class TestScenario(object):
             snl.estimate(SIR, pruner="unknown")
         with pytest.raises(ValueError):
             snl.estimate(model=SIR, tau=1440)
+        snl.trend()
         snl.estimate(SIR, timeout=1, timeout_iteration=1)
         # Estimation history
         snl.estimate_history(phase="last")

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -241,6 +241,8 @@ class TestScenario(object):
         # Parameter estimation
         with pytest.raises(KeyError):
             snl.estimate(SIR, phases=["30th"])
+        with pytest.raises(KeyError):
+            snl.estimate(SIR, pruner="unknown")
         with pytest.raises(ValueError):
             snl.estimate(model=SIR, tau=1440)
         snl.estimate(SIR, timeout=1, timeout_iteration=1)


### PR DESCRIPTION
## Related issues
#578 

## What was changed
Add pruner argument to Scenario.estimate() (internally, `Estimator.run()`).
Users will select pruners and keyword aruments of pruners as follows.
- `Scenario.estimate(cs.SIRF, pruner="hyperband")`
- `Scenario.estimate(cs.SIRF, pruner="median")`
- `Scenario.estimate(cs.SIRF, pruner="threshold", upper=0.5)`
- `Scenario.estimate(cs.SIRF, pruner="percentile", percentile=50)`