### PR TITLE
update: stop supressing DeprecationWarning

### DIFF
--- a/covsirphy/cleaning/jhu_data.py
+++ b/covsirphy/cleaning/jhu_data.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import warnings
 import numpy as np
 import pandas as pd
 from covsirphy.util.error import SubsetNotFoundError, deprecate
@@ -434,10 +433,11 @@ class JHUData(CleaningBase):
             for country in df[self.COUNTRY].unique()
         ]
         valid_periods = list(filter(lambda x: x >= 0, periods))
-        warnings.simplefilter("error", category=DeprecationWarning)
+        if not valid_periods:
+            return default
         try:
             return int(pd.Series(valid_periods).median())
-        except (ValueError, DeprecationWarning):
+        except ValueError:
             return default
 
     def _calculate_recovery_period_country(self, valid_df, country, upper_limit_days=90,


### PR DESCRIPTION
## Related issues
#596 

## What was changed
to revert https://github.com/lisphilar/covid19-sir/commit/c55faabfa9b113fe0c81798a095463dc156050f4, replaced
```Python
import warnings
warnings.filterwarnings("ignore", category=DeprecationWarning)
try:
    return int(pd.Series(valid_periods).median())
except DeprecationWarning:
    pass
```
with
```Python
if valid_periods:
    return int(pd.Series(valid_periods).median())
```

`warnings.filterwarnings("ignore", category=DeprecationWarning)` changed the warning with Anaconda to a fatal error.