### PR TITLE
fix: VarnameRetrievingError by removing nameof

### DIFF
--- a/covsirphy/analysis/data_handler.py
+++ b/covsirphy/analysis/data_handler.py
@@ -5,7 +5,6 @@ from datetime import timedelta
 import itertools
 import numpy as np
 import pandas as pd
-from varname import nameof
 from covsirphy.util.error import SubsetNotFoundError, UnExpectedValueError
 from covsirphy.util.error import NotRegisteredMainError, NotRegisteredExtraError
 from covsirphy.util.term import Term
@@ -29,17 +28,17 @@ class DataHandler(Term):
     """
     # {nameof(JHUData): JHUData} does not work with AST magics, including pytest and ipython
     # Main datasets {str: class}
-    __NAME_JHU = nameof(JHUData)
-    __NAME_POPULATION = nameof(PopulationData)
+    __NAME_JHU = "JHUData"
+    __NAME_POPULATION = "PopulationData"
     MAIN_DICT = {
         __NAME_JHU: JHUData,
         __NAME_POPULATION: PopulationData
     }
     # Extra datasets {str: class}
-    __NAME_COUNTRY = nameof(CountryData)
-    __NAME_OXCGRT = nameof(OxCGRTData)
-    __NAME_PCR = nameof(PCRData)
-    __NAME_VACCINE = nameof(VaccineData)
+    __NAME_COUNTRY = "CountryData"
+    __NAME_OXCGRT = "OxCGRTData"
+    __NAME_PCR = "PCRData"
+    __NAME_VACCINE = "VaccineData"
     EXTRA_DICT = {
         __NAME_COUNTRY: CountryData,
         __NAME_OXCGRT: OxCGRTData,
@@ -66,14 +65,14 @@ class DataHandler(Term):
         # Register datasets: date and main columns will be set internally if main data available
         self.register(**kwargs)
 
-    @property
+    @ property
     def main_satisfied(self):
         """
         bool: all main datasets were registered or not
         """
         return all(self._data_dict[name] for name in self.MAIN_DICT.keys())
 
-    @property
+    @ property
     def complemented(self):
         """
         bool or str: whether complemented or not and the details, None when not confirmed
@@ -85,7 +84,7 @@ class DataHandler(Term):
             raise NotRegisteredMainError(".register(jhu_data, population_data)")
         return self._complemented
 
-    @property
+    @ property
     def population(self):
         """
         int: population value
@@ -97,21 +96,21 @@ class DataHandler(Term):
             raise NotRegisteredMainError(".register(jhu_data, population_data)")
         return self._population
 
-    @property
+    @ property
     def first_date(self):
         """
         str: the first date of the records
         """
         return self._first_date
 
-    @property
+    @ property
     def last_date(self):
         """
         str: the last date of the records
         """
         return self._last_date
 
-    @property
+    @ property
     def today(self):
         """
         str: reference date to determine whether a phase is a past phase or a future phase

--- a/poetry.lock
+++ b/poetry.lock
@@ -69,20 +69,6 @@ docs = ["sphinx"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pytest"]
 
 [[package]]
-name = "asttokens"
-version = "2.0.4"
-description = "Annotate AST trees with source code positions"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-six = "*"
-
-[package.extras]
-test = ["astroid", "pytest"]
-
-[[package]]
 name = "async-generator"
 version = "1.10"
 description = "Async generators and context managers for Python 3.5+"
@@ -446,14 +432,6 @@ description = "Discover and load entry points from installed packages."
 category = "dev"
 optional = false
 python-versions = ">=2.7"
-
-[[package]]
-name = "executing"
-version = "0.5.4"
-description = "Get the currently executing AST node of a frame, and other information"
-category = "main"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "fiona"
@@ -1324,17 +1302,6 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "pure-eval"
-version = "0.1.1"
-description = "Safely evaluate AST nodes without side effects"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.extras]
-tests = ["pytest"]
-
-[[package]]
 name = "py"
 version = "1.10.0"
 description = "library with cross-python path, ini-parsing, io, code, log facilities"
@@ -2049,19 +2016,6 @@ secure = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "cer
 socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
-name = "varname"
-version = "0.6.2"
-description = "Dark magics about variable names in python."
-category = "main"
-optional = false
-python-versions = ">=3.6,<4.0"
-
-[package.dependencies]
-asttokens = ">=2.0.0,<3.0.0"
-executing = "*"
-pure_eval = "<1.0.0"
-
-[[package]]
 name = "wbdata"
 version = "0.3.0"
 description = "A library to access World Bank data"
@@ -2142,7 +2096,7 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.9"
-content-hash = "78861dcbbd8ea2cb119b5fbb074ea89f4eab3677b41f29645a42e0c3bca4c674"
+content-hash = "49ff0a9229ec69ee10af292589322afe70cc8f50beb10aaeb6f58ad6f694ce1d"
 
 [metadata.files]
 aiohttp = [
@@ -2203,10 +2157,6 @@ argon2-cffi = [
     {file = "argon2_cffi-20.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:9dfd5197852530294ecb5795c97a823839258dfd5eb9420233c7cfedec2058f2"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win32.whl", hash = "sha256:e2db6e85c057c16d0bd3b4d2b04f270a7467c147381e8fd73cbbe5bc719832be"},
     {file = "argon2_cffi-20.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:8a84934bd818e14a17943de8099d41160da4a336bcc699bb4c394bbb9b94bd32"},
-]
-asttokens = [
-    {file = "asttokens-2.0.4-py2.py3-none-any.whl", hash = "sha256:766d3352908730efb20b95ae22db0f1cb1bedb67c6071fcffb5c236ea673f2f7"},
-    {file = "asttokens-2.0.4.tar.gz", hash = "sha256:a42e57e28f2ac1c85ed9b1f84109401427e5c63c04f61d15b8842b027eec5128"},
 ]
 async-generator = [
     {file = "async_generator-1.10-py3-none-any.whl", hash = "sha256:01c7bf666359b4967d2cda0000cc2e4af16a0ae098cbffcb8472fb9e8ad6585b"},
@@ -2418,10 +2368,6 @@ docutils = [
 entrypoints = [
     {file = "entrypoints-0.3-py2.py3-none-any.whl", hash = "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19"},
     {file = "entrypoints-0.3.tar.gz", hash = "sha256:c70dd71abe5a8c85e55e12c19bd91ccfeec11a6e99044204511f9ed547d48451"},
-]
-executing = [
-    {file = "executing-0.5.4-py3-none-any.whl", hash = "sha256:b96545c606c410e2b8500ef6e3f548d8678e1cb7a561dbcf46e16c19eed10c4e"},
-    {file = "executing-0.5.4.tar.gz", hash = "sha256:07b71adef0399e8579fa0165db5e5f8e9dd961fa66572664de95c838879768eb"},
 ]
 fiona = [
     {file = "Fiona-1.8.18-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:c64cc0bab040c3a2aec12edd2e1407e3b52609117d9a9a471e3d25172abb1e5e"},
@@ -2899,9 +2845,6 @@ prompt-toolkit = [
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},
     {file = "ptyprocess-0.7.0.tar.gz", hash = "sha256:5c5d0a3b48ceee0b48485e0c26037c0acd7d29765ca3fbb5cb3831d347423220"},
-]
-pure-eval = [
-    {file = "pure_eval-0.1.1-py3-none-any.whl", hash = "sha256:fae61a26700298a0910e975f5c694b9200b1877ea67ff47cdb783c0b7d7bab78"},
 ]
 py = [
     {file = "py-1.10.0-py2.py3-none-any.whl", hash = "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"},
@@ -3400,10 +3343,6 @@ unidecode = [
 urllib3 = [
     {file = "urllib3-1.26.3-py2.py3-none-any.whl", hash = "sha256:1b465e494e3e0d8939b50680403e3aedaa2bc434b7d5af64dfd3c958d7f5ae80"},
     {file = "urllib3-1.26.3.tar.gz", hash = "sha256:de3eedaad74a2683334e282005cd8d7f22f4d55fa690a2a1020a416cb0a47e73"},
-]
-varname = [
-    {file = "varname-0.6.2-py3-none-any.whl", hash = "sha256:001e6e501f4d76070e131b95a935e263b56a5437bf51421784ca49acb6923585"},
-    {file = "varname-0.6.2.tar.gz", hash = "sha256:96a33d90690b1a36fdf13f997b24a8b7cf676cdef68a7e6c7bbec9a069fb1f9b"},
 ]
 wbdata = [
     {file = "wbdata-0.3.0-py3-none-any.whl", hash = "sha256:cc8ab9deaff12b3699351305303b517cc0587011ce215d4f6df3996820ae4249"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ geopandas = "^0.8.2"
 mapclassify = "^2.4.2"
 Unidecode = "^1.2.0"
 descartes = "^1.1.0"
-varname = "^0.6.2"
 
 [tool.poetry.dev-dependencies]
 autopep8 = "^1.5.5"


### PR DESCRIPTION
## Related issues
#622

## What was changed
Follow-up for #622, remove `nameof` to fix `varname.utils.VarnameRetrievingError`.