### PR TITLE
Issue670 select algo in trend

### DIFF
--- a/covsirphy/analysis/param_tracker.py
+++ b/covsirphy/analysis/param_tracker.py
@@ -81,7 +81,7 @@ class ParamTracker(Term):
         Args:
             force (bool): if True, change points will be over-written
             show_figure (bool): if True, show the result as a figure
-            kwargs: keyword arguments of covsirphy.TrendDetector() and covsirphy.trend_plot()
+            kwargs: keyword arguments of covsirphy.TrendDetector(), .TrendDetector.sr() and .trend_plot()
 
         Returns:
             covsirphy.PhaseSeries
@@ -89,7 +89,7 @@ class ParamTracker(Term):
         detector = TrendDetector(
             data=self.record_df, area=self.area, **find_args(TrendDetector, **kwargs))
         # Perform S-R trend analysis
-        detector.sr()
+        detector.sr(**find_args(TrendDetector.sr, **kwargs))
         # Register phases
         if force or not self._series:
             self._series.clear(include_past=True)

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -599,7 +599,7 @@ class Scenario(Term):
             name (str): phase series name
             show_figure (bool): if True, show the result as a figure
             filename (str): filename of the figure, or None (display)
-            kwargs: keyword arguments of covsirphy.TrendDetector() and covsirphy.trend_plot()
+            kwargs: keyword arguments of covsirphy.TrendDetector(), .TrendDetector.sr() and .trend_plot()
 
         Returns:
             covsirphy.Scenario: self

--- a/covsirphy/trend/trend_detector.py
+++ b/covsirphy/trend/trend_detector.py
@@ -126,8 +126,7 @@ class TrendDetector(Term):
             "BottomUp-normal": (rpt.BottomUp, {"model": "normal"}),
         }
         if algo not in algo_dict:
-            algo_str = ", ".join(list(algo_dict.keys()))
-            raise UnExpectedValueError(f"@algo should be selected from {algo_str}, but {algo} was applied.")
+            raise UnExpectedValueError(name="algo", value=algo, candidates=list(algo_dict.keys()))
         algo_kwargs.update(algo_dict[algo][1])
         algorithm = algo_dict[algo][0](**algo_kwargs)
         # Run trend analysis

--- a/covsirphy/trend/trend_detector.py
+++ b/covsirphy/trend/trend_detector.py
@@ -3,7 +3,7 @@
 
 import pandas as pd
 import ruptures as rpt
-from covsirphy.util.error import deprecate
+from covsirphy.util.error import deprecate, UnExpectedValueError
 from covsirphy.util.term import Term
 from covsirphy.trend.sr_change import _SRChange
 
@@ -104,6 +104,9 @@ class TrendDetector(Term):
             algo (str): detection algorithms and models
             kwargs: the other arguments of algorithm classes (ruptures.Pelt, .Binseg, BottomUp)
 
+        Raises:
+            UnExpectedValueError: un-expected value was applied as algorithm name
+
         Returns:
             covsirphy.TrendDetector: self
 
@@ -124,7 +127,7 @@ class TrendDetector(Term):
         }
         if algo not in algo_dict:
             algo_str = ", ".join(list(algo_dict.keys()))
-            raise KeyError(f"@algo should be selected from {algo_str}, but {algo} was applied.")
+            raise UnExpectedValueError(f"@algo should be selected from {algo_str}, but {algo} was applied.")
         algo_kwargs.update(algo_dict[algo][1])
         algorithm = algo_dict[algo][0](**algo_kwargs)
         # Run trend analysis

--- a/covsirphy/trend/trend_detector.py
+++ b/covsirphy/trend/trend_detector.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pandas as pd
+import ruptures as rpt
 from covsirphy.util.error import deprecate
 from covsirphy.util.term import Term
 from covsirphy.trend.sr_change import _SRChange
@@ -95,15 +96,40 @@ class TrendDetector(Term):
             index=[self.num2str(num) for num in range(len(self._points) + 1)]
         )
 
-    def sr(self):
+    def sr(self, algo="Pelt-rbf", **kwargs):
         """
         Perform S-R trend analysis.
 
+        Args:
+            algo (str): detection algorithms and models
+            kwargs: the other arguments of algorithm classes (ruptures.Pelt, .Binseg, BottomUp)
+
         Returns:
             covsirphy.TrendDetector: self
+
+        Note:
+            Candidates of @algo are "Pelt-rbf", "Binseg-rbf", "Binseg-normal", "BottomUp-rbf", "BottomUp-normal".
+            Please refer to documentation of ruptures package.
+            https://centre-borelli.github.io/ruptures-docs/
         """
+        # Set algorithm class
+        algo_kwargs = {"jump": 1, "min_size": self._min_size}
+        algo_kwargs.update(kwargs)
+        algo_dict = {
+            "Pelt-rbf": (rpt.Pelt, {"model":"rbf"}),
+            "Binseg-rbf": (rpt.Binseg, {"model":"rbf"}),
+            "Binseg-normal": (rpt.Binseg, {"model":"normal"}),
+            "BottomUp-rbf": (rpt.BottomUp, {"model":"rbf"}),
+            "BottomUp-normal": (rpt.BottomUp, {"model":"normal"}),
+        }
+        if algo not in algo_dict:
+            algo_str = ", ".join(list(algo_dict.keys()))
+            raise KeyError(f"@algo should be selected from {algo_str}, but {algo} was applied.")
+        algo_kwargs.update(algo_dict[algo][1])
+        algorithm = algo_dict[algo][0](**algo_kwargs)
+        # Run trend analysis
         finder = _SRChange(sr_df=self._record_df)
-        points = finder.run(min_size=self._min_size)
+        points = finder.run(algorithm=algorithm, **algo_kwargs)
         self._points = sorted(set(self._points) | set(points))
         return self
 

--- a/covsirphy/trend/trend_detector.py
+++ b/covsirphy/trend/trend_detector.py
@@ -119,11 +119,11 @@ class TrendDetector(Term):
         algo_kwargs = {"jump": 1, "min_size": self._min_size}
         algo_kwargs.update(kwargs)
         algo_dict = {
-            "Pelt-rbf": (rpt.Pelt, {"model":"rbf"}),
-            "Binseg-rbf": (rpt.Binseg, {"model":"rbf"}),
-            "Binseg-normal": (rpt.Binseg, {"model":"normal"}),
-            "BottomUp-rbf": (rpt.BottomUp, {"model":"rbf"}),
-            "BottomUp-normal": (rpt.BottomUp, {"model":"normal"}),
+            "Pelt-rbf": (rpt.Pelt, {"model": "rbf"}),
+            "Binseg-rbf": (rpt.Binseg, {"model": "rbf"}),
+            "Binseg-normal": (rpt.Binseg, {"model": "normal"}),
+            "BottomUp-rbf": (rpt.BottomUp, {"model": "rbf"}),
+            "BottomUp-normal": (rpt.BottomUp, {"model": "normal"}),
         }
         if algo not in algo_dict:
             algo_str = ", ".join(list(algo_dict.keys()))

--- a/tests/test_trend.py
+++ b/tests/test_trend.py
@@ -3,7 +3,7 @@
 
 import warnings
 import pytest
-from covsirphy import TrendDetector, Trend, ChangeFinder
+from covsirphy import TrendDetector, Trend, ChangeFinder, UnExpectedValueError
 
 
 class TestTrendDetector(object):
@@ -28,21 +28,34 @@ class TestTrendDetector(object):
         Trend(subset_df)
 
     @pytest.mark.parametrize(
+        "algo", ["Pelt-rbf", "Binseg-rbf", "Binseg-normal", "BottomUp-rbf", "BottomUp-normal"])
+    @pytest.mark.parametrize(
         "country",
         [
             "Italy", "India", "USA", "Greece", "Russia",
             "Brazil", "France", "Spain", "UK", "New Zealand", "Germany",
         ]
     )
-    def test_sr(self, jhu_data, population_data, country):
+    def test_sr(self, jhu_data, population_data, algo, country):
         # Dataset
         population = population_data.value(country)
         subset_df = jhu_data.subset(country=country, population=population)
         # S-R trend analysis
         detector = TrendDetector(data=subset_df, area=country)
-        detector.sr()
+        detector.sr(algo=algo)
         # Summary
         detector.summary()
+
+    @pytest.mark.parametrize("algo", ["Unknown"])
+    @pytest.mark.parametrize("country", ["Japan"])
+    def test_sr_algo_error(self, jhu_data, population_data, algo, country):
+        # Dataset
+        population = population_data.value(country)
+        subset_df = jhu_data.subset(country=country, population=population)
+        # S-R trend analysis
+        detector = TrendDetector(data=subset_df, area=country)
+        with pytest.raises(UnExpectedValueError):
+            detector.sr(algo=algo)
 
     @pytest.mark.parametrize("country", ["Japan"])
     def test_show(self, jhu_data, population_data, country, imgfile):


### PR DESCRIPTION
## Related issues
#670

## What was changed
We can select algorithms of change detection.
```Python
snl = cs.Scenario(country="Italy")
snl.register(jhu_data, population_data)
snl.trend(algo="Binseg-normal")
```
Argument `algo` will be selected from "Pelt-rbf", "Binseg-rbf", "Binseg-normal", "BottomUp-rbf" and "BottomUp-normal". At this time, the default value is "Pelt-rbf" and this means we use the same algoritm as that in the previous version.