### PR TITLE
fix: changed interpolation method from spline to linear

### DIFF
--- a/covsirphy/cleaning/jhu_complement.py
+++ b/covsirphy/cleaning/jhu_complement.py
@@ -231,7 +231,7 @@ class JHUDataComplementHandler(Term):
             # Extrapolated value on the date
             series = df.loc[:date, variable]
             series.iloc[-1] = None
-            series.interpolate(method="spline", order=1, inplace=True)
+            series.interpolate(method="linear", inplace=True, limit_direction="both")
             series.fillna(method="ffill", inplace=True)
             # Reduce values to the previous date
             df.loc[:date, variable] = series * raw_last / series.iloc[-1]

--- a/covsirphy/cleaning/pcr_data.py
+++ b/covsirphy/cleaning/pcr_data.py
@@ -294,7 +294,7 @@ class PCRData(CleaningBase):
             # Extrapolated value on the date
             series = df.loc[:date, variable]
             series.iloc[-1] = None
-            series.interpolate(method="spline", order=1, inplace=True)
+            series.interpolate(method="linear", inplace=True, limit_direction="both")
             series.fillna(method="ffill", inplace=True)
             # Reduce values to the previous date
             df.loc[:date, variable] = series * raw_last / series.iloc[-1]


### PR DESCRIPTION
## Related issues
This is related to issue #681.

## What was changed
Changed interpolation method from `spline` to `linear` inside `jhu_complement` and `pcr_data`.