### PR TITLE
Issue670 default

### DIFF
--- a/covsirphy/analysis/param_tracker.py
+++ b/covsirphy/analysis/param_tracker.py
@@ -34,11 +34,15 @@ class ParamTracker(Term):
     """
 
     def __init__(self, record_df, phase_series, area=None, tau=None):
-        self.record_df = self._ensure_dataframe(
-            record_df, name="record_df", columns=self.SUB_COLUMNS)
-        self._series = self._ensure_instance(
-            phase_series, PhaseSeries, name="phase_seres")
+        # Phase series
+        self._series = self._ensure_instance(phase_series, PhaseSeries, name="phase_series")
+        # Records
+        self._ensure_dataframe(record_df, name="record_df", columns=self.SUB_COLUMNS)
+        df = record_df.loc[record_df[self.DATE] >= self.date_obj(phase_series.first_date)]
+        self.record_df = df.loc[df[self.DATE] <= self.date_obj(phase_series.last_date)]
+        # Area name
         self.area = area or ""
+        # Tau value
         self.tau = self._ensure_tau(tau)
 
     def __len__(self):

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -1222,7 +1222,7 @@ class Scenario(Term):
     def estimate_delay(self, oxcgrt_data=None, indicator="Stringency_index",
                        target="Confirmed", value_range=(7, None)):
         """
-        Estimate the average day [days] between the indicator and the target.
+        Estimate the mode value of delay period [days] between the indicator and the target.
         We assume that the indicator impact on the target value with delay.
 
         Args:
@@ -1238,7 +1238,7 @@ class Scenario(Term):
 
         Returns:
             tuple(int, pandas.DataFrame):
-                - int: the estimated number of days of delay [day]
+                - int: the estimated number of days of delay [day] (mode value)
                 - pandas.DataFrame:
                     Index
                         reset index
@@ -1264,8 +1264,11 @@ class Scenario(Term):
         df_filtered = df.loc[df["Period Length"] < df["Period Length"].quantile(0.99)]
         if value_range[1] is not None:
             df_filtered = df_filtered.loc[df["Period Length"] < value_range[1]]
-        delay_days = self._data.recovery_period() if df_filtered.empty else int(df_filtered["Period Length"].mean())
-        return (delay_days, df)
+        # Calculate representative value (mode)
+        if df_filtered.empty:
+            return (self._data.recovery_period(), df)
+        delay_period = df_filtered["Period Length"].mode()[0]
+        return (int(delay_period), df)
 
     def _fit_create_data(self, model, name, delay, removed_cols):
         """

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -630,7 +630,11 @@ class Scenario(Term):
             pass
         # Minimum size of phases
         if min_size is None:
-            delay, _ = self.estimate_delay(**find_args(self.estimate_delay, **kwargs))
+            try:
+                delay, _ = self.estimate_delay(**find_args(self.estimate_delay, **kwargs))
+            except KeyError:
+                # Extra datasets are not registered
+                delay = 7
             min_size = max(7, delay)
         self._ensure_int_range(min_size, name="min_size", value_range=(2, None))
         kwargs["min_size"] = min_size

--- a/covsirphy/trend/trend_detector.py
+++ b/covsirphy/trend/trend_detector.py
@@ -106,7 +106,7 @@ class TrendDetector(Term):
             index=[self.num2str(num) for num in range(len(self._points) + 1)]
         )
 
-    def sr(self, algo="Pelt-rbf", **kwargs):
+    def sr(self, algo="Binseg-normal", **kwargs):
         """
         Perform S-R trend analysis.
 

--- a/covsirphy/trend/trend_detector.py
+++ b/covsirphy/trend/trend_detector.py
@@ -32,7 +32,7 @@ class TrendDetector(Term):
         "Change points" is the same as the start dates of phases except for the 0th phase.
     """
 
-    def __init__(self, data, area="Selected area", min_size=5):
+    def __init__(self, data, area="Selected area", min_size=7):
         self._ensure_dataframe(data, name="data", columns=self.SUB_COLUMNS)
         # Index: Date, Columns: the number cases
         self._record_df = data.groupby(self.DATE).last()

--- a/tests/test_phase_series.py
+++ b/tests/test_phase_series.py
@@ -14,6 +14,9 @@ class TestPhaseSeries(object):
         # Setting
         population = population_data.value(country)
         series = PhaseSeries("01Apr2020", "22Apr2020", population)
+        # First/last date
+        assert series.first_date == "01Apr2020"
+        assert series.last_date == "22Apr2020"
         # Whether units are registered or not
         assert not series
         assert series.summary().empty


### PR DESCRIPTION
## Related issues
#670 and #686

## What was changed
- `TrendDetector(..., min_size=7)` as default
- `TrendDetector(algo="Binseg-normal")` as default
- When `min_size=None` with `Scenario.trend()`, `min_size` for S-R trend anlysis will be set as the delay period calculated with `Scenario.estimate_delay()`
- Close #686: use mode value of delay period