### PR TITLE
Issue668 predictor

### DIFF
--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -58,6 +58,8 @@ from covsirphy.simulation.simulator import ODESimulator
 from covsirphy.phase.phase_unit import PhaseUnit
 from covsirphy.phase.phase_series import PhaseSeries
 from covsirphy.phase.phase_estimator import MPEstimator
+# regression
+from covsirphy.regression.reg_handler import RegressionHandler
 # analysis
 from covsirphy.analysis.example_data import ExampleData
 from covsirphy.analysis.data_handler import DataHandler
@@ -108,6 +110,8 @@ __all__ = [
     "ODESimulator", "Estimator",
     # phase
     "PhaseSeries", "PhaseUnit", "MPEstimator",
+    # regression
+    "RegressionHandler",
     # analysis
     "ExampleData", "Scenario", "ModelValidator", "ParamTracker", "DataHandler",
     # worldwide

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -2,17 +2,10 @@
 # -*- coding: utf-8 -*-
 
 import copy
-from datetime import timedelta
-from math import log10, floor
 import warnings
 import sys
 import numpy as np
 import pandas as pd
-from sklearn.model_selection import train_test_split
-from sklearn import linear_model
-from sklearn.exceptions import ConvergenceWarning
-from sklearn.pipeline import Pipeline
-from sklearn.preprocessing import MinMaxScaler
 from covsirphy.util.argument import find_args
 from covsirphy.util.error import deprecate, ScenarioNotFoundError, UnExecutedError
 from covsirphy.util.error import NotRegisteredMainError, NotRegisteredExtraError
@@ -22,6 +15,7 @@ from covsirphy.util.term import Term
 from covsirphy.visualization.line_plot import line_plot
 from covsirphy.visualization.bar_plot import bar_plot
 from covsirphy.cleaning.jhu_data import JHUData
+from covsirphy.regression.param_elastic_net import _ParamElasticNetRegressor
 from covsirphy.analysis.param_tracker import ParamTracker
 from covsirphy.analysis.data_handler import DataHandler
 
@@ -65,8 +59,8 @@ class Scenario(Term):
             pass
         # Interactive (True) / script (False) mode
         self._interactive = hasattr(sys, "ps1")
-        # Prediction of parameter values in the future phases: {name: (regression model, X_target)}
-        self._lm_dict = {}
+        # Prediction of parameter values in the future phases: {name: RegressorBase)}
+        self._regressor_dict = {}
 
     def __getitem__(self, key):
         """
@@ -1299,46 +1293,7 @@ class Scenario(Term):
         delay_period = df_filtered["Period Length"].mode()[0]
         return (int(delay_period), df)
 
-    def _fit_create_data(self, model, name, delay, removed_cols):
-        """
-        Create train/test dataset for Elastic Net regression,
-        assuming that extra variables will impact on ODE parameter values with delay.
-
-        Args:
-            model (covsirphy.ModelBase): ODE model
-            name (str): scenario name
-            delay (int): delay period
-            removed_cols (list[str]): list of variables to remove from X dataset
-
-        Returns:
-            tuple(pandas.DataFrame):
-                - X dataset for linear regression
-                - y dataset for linear regression
-                - X dataset of the target dates
-        """
-        # Clear the future phases
-        self.clear(name=name, include_past=False)
-        # Parameter values
-        param_df = self._track_param(name=name)[model.PARAMETERS]
-        # Extra datasets (explanatory variables)
-        extras_df = self._data.records(main=False, extras=True).set_index(self.DATE)
-        extras_df = extras_df.loc[:, ~extras_df.columns.isin(removed_cols)]
-        # Apply delay on OxCGRT data
-        extras_df.index += timedelta(days=delay)
-        # Create training/test dataset
-        df = param_df.join(extras_df, how="inner")
-        df = df.rolling(window=delay).mean().dropna().drop_duplicates()
-        X = df.drop(model.PARAMETERS, axis=1)
-        y = df.loc[:, model.PARAMETERS]
-        # X dataset of the target dates
-        dates = pd.date_range(
-            start=param_df.index.max() + timedelta(days=1),
-            end=extras_df.index.max(),
-            freq="D")
-        X_target = extras_df.loc[dates]
-        return (X, y, X_target)
-
-    def fit(self, oxcgrt_data=None, name="Main", test_size=0.2, seed=0, delay=None, removed_cols=None, metric=None, metrics="R2"):
+    def fit(self, oxcgrt_data=None, name="Main", delay=None, removed_cols=None, metric=None, metrics="R2", **kwargs):
         """
         Learn the relationship of ODE parameter values and delayed OxCGRT scores using Elastic Net regression,
         assuming that OxCGRT scores will impact on ODE parameter values with delay.
@@ -1349,16 +1304,17 @@ class Scenario(Term):
             name (str): scenario name
             test_size (float): proportion of the test dataset of Elastic Net regression
             seed (int): random seed when spliting the dataset to train/test data
-            delay (int): delay period [days], please refer to Scenario.estimate_delay()
+            delay (int or None): delay period [days] or None (Scenario.estimate_delay() calculate automatically)
             removed_cols (list[str] or None): list of variables to remove from X dataset or None (indicators used to estimate delay period)
             metric (str or None): metric name or None (use @metrics)
             metrics (str): alias of @metric
+            kwargs: keyword arguments of sklearn.model_selection.train_test_split(test_size=0.2, random_state=0)
 
         Raises:
             covsirphy.UnExecutedError: Scenario.estimate() or Scenario.add() were not performed
 
         Returns:
-            dict(str, object):
+            dict(str, object): regressor information, including
                 - scaler (object): scaler class
                 - regressor (object): regressor class
                 - alpha (float): alpha value used in Elastic Net regression
@@ -1366,23 +1322,23 @@ class Scenario(Term):
                 - score_name (str): scoring method (specified with @metric or @metrics)
                 - score_train (float): score with train dataset
                 - score_test (float): score with test dataset
-                - X_train (numpy.array): X_train
-                - y_train (numpy.array): y_train
-                - X_test (numpy.array): X_test
-                - y_test (numpy.array): y_test
-                - X_target (numpy.array): X_target
+                - dataset (dict[numpy.ndarray]): X_train, X_test, y_train, y_test, X_target
                 - intercept (pandas.DataFrame): intercept and coefficients (Index ODE parameters, Columns indicators)
                 - coef (pandas.DataFrame): intercept and coefficients (Index ODE parameters, Columns indicators)
-                - delay (int): number of days of delay between policy measure and effect
-                  on number of confirmed cases.
+                - delay (int): delay period
 
         Note:
             @oxcgrt_data argument was deprecated. Please use Scenario.register(extras=[oxcgrt_data]).
 
         Note:
             Please refer to covsirphy.Evaluator.score() for metric names
+
+        Note:
+            If @seed is included in kwargs, this will be converted to @random_state.
         """
-        warnings.simplefilter("ignore", category=ConvergenceWarning)
+        metric = metric or metrics
+        # Clear the future phases
+        self.clear(name=name, include_past=False)
         # Register OxCGRT data
         if oxcgrt_data is not None:
             warnings.warn(
@@ -1403,56 +1359,21 @@ class Scenario(Term):
             delay = self._ensure_natural_int(delay, name="delay")
             removed_cols = removed_cols or None
         # Create training/test dataset
+        # Parameter values
+        param_df = self._track_param(name=name)[model.PARAMETERS]
+        # Extra datasets (explanatory variables)
         try:
-            X, y, X_target = self._fit_create_data(
-                model=model, name=name, delay=delay, removed_cols=removed_cols)
+            extras_df = self._data.records(main=False, extras=True).set_index(self.DATE)
         except NotRegisteredExtraError:
             raise NotRegisteredExtraError(
                 "Scenario.register(jhu_data, population_data, extras=[...])",
                 message="with extra datasets") from None
-        X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=test_size, random_state=seed)
-        # Create pipeline for learning
-        cv = linear_model.MultiTaskElasticNetCV(
-            alphas=[0, 0.001, 0.01, 0.1, 1, 10, 100, 1000],
-            l1_ratio=[0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
-            cv=5, n_jobs=-1)
-        steps = [
-            ("scaler", MinMaxScaler()),
-            ("regressor", cv),
-        ]
-        pipeline = Pipeline(steps=steps)
-        pipeline.fit(X_train, y_train)
-        # Register the pipeline and X-target for prediction
-        self._lm_dict[name] = (pipeline, X_target)
-        # Get scores
-        metric = metric or metrics
-        pred_train = pd.DataFrame(pipeline.predict(X_train), columns=y_train.columns)
-        pred_test = pd.DataFrame(pipeline.predict(X_test), columns=y_test.columns)
-        score_train = Evaluator(pred_train, y_train, how="all").score(metric=metric)
-        score_test = Evaluator(pred_test, y_test, how="all").score(metric=metric)
-        # Return information regarding regression model
-        reg_output = pipeline.named_steps.regressor
-        # Intercept and coefficients
-        intercept_df = pd.DataFrame(reg_output.coef_, index=y_train.columns, columns=X_train.columns)
-        intercept_df.insert(0, "Intercept", None)
-        intercept_df["Intercept"] = reg_output.intercept_
+        extras_df = extras_df.loc[:, ~extras_df.columns.isin(removed_cols)]
+        # Fit regression model
+        regressor = _ParamElasticNetRegressor(X=extras_df, y=param_df, delay=delay, **kwargs)
+        self._regressor_dict[name] = regressor
         # Return information
-        return {
-            **{k: type(v) for (k, v) in steps},
-            "alpha": reg_output.alpha_,
-            "l1_ratio": reg_output.l1_ratio_,
-            "score_name": metric,
-            "score_train": score_train,
-            "score_test": score_test,
-            "X_train": X_train,
-            "y_train": y_train,
-            "X_test": X_test,
-            "y_test": y_test,
-            "X_target": X_target,
-            "intercept": intercept_df,
-            "coef": intercept_df,
-            "delay": delay
-        }
+        return regressor.to_dict(metric=metric)
 
     def predict(self, days=None, name="Main"):
         """
@@ -1472,20 +1393,17 @@ class Scenario(Term):
             covsirphy.Scenario: self
         """
         # Arguments
-        if name not in self._lm_dict:
+        if name not in self._regressor_dict:
             raise UnExecutedError(f"Scenario.fit(name={name})")
-        model = self._tracker(name).last_model
         # Prediction with regression model
-        pipeline, X_target = self._lm_dict[name]
-        predicted = pipeline.predict(X_target)
+        regressor = self._regressor_dict[name]
+        df = regressor.predict()
         # -> end_date/parameter values
-        df = pd.DataFrame(predicted, index=X_target.index, columns=model.PARAMETERS)
-        df = df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))
         df.index = [date.strftime(self.DATE_FORMAT) for date in df.index]
         df.index.name = "end_date"
         # Days to predict
-        days = days or [len(X_target) - 1]
-        self._ensure_list(days, candidates=list(range(len(X_target))), name="days")
+        days = days or [len(df) - 1]
+        self._ensure_list(days, candidates=list(range(len(df))), name="days")
         phase_df = df.reset_index().loc[days, :]
         # Set new future phases
         for phase_dict in phase_df.to_dict(orient="records"):

--- a/covsirphy/regression/param_elastic_net.py
+++ b/covsirphy/regression/param_elastic_net.py
@@ -14,7 +14,7 @@ from covsirphy.regression.regbase import _RegressorBase
 
 class _ParamElasticNetRegressor(_RegressorBase):
     """
-    Predict parameter values with Elastic Net regression.
+    Predict parameter values of ODE models with Elastic Net regression.
 
     Args:
         X (pandas.DataFrame):
@@ -33,6 +33,8 @@ class _ParamElasticNetRegressor(_RegressorBase):
     Note:
         If @seed is included in kwargs, this will be converted to @random_state.
     """
+    # Description of regressor
+    DESC = "Indicators -> Parameters  with Elastic Net"
 
     def __init__(self, X, y, delay, **kwargs):
         super().__init__(X, y, delay, **kwargs)

--- a/covsirphy/regression/param_elastic_net.py
+++ b/covsirphy/regression/param_elastic_net.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from math import log10, floor
+import warnings
+import numpy as np
+import pandas as pd
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.linear_model import MultiTaskElasticNetCV
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MinMaxScaler
+from covsirphy.regression.regbase import _RegressorBase
+
+
+class _ParamElasticNetRegressor(_RegressorBase):
+    """
+    Predict parameter values with Elastic Net regression.
+
+    Args:
+        X (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float): indicators
+        y (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float) target values
+        delay (int): delay period [days]
+        kwargs: keyword arguments of sklearn.model_selection.train_test_split(test_size=0.2, random_state=0)
+
+    Note:
+        If @seed is included in kwargs, this will be converted to @random_state.
+    """
+
+    def __init__(self, X, y, delay, **kwargs):
+        super().__init__(X, y, delay, **kwargs)
+
+    def _fit(self):
+        """
+        Fit regression model with training dataset, update self._regressor and self._param.
+        """
+        warnings.filterwarnings("ignore", category=ConvergenceWarning)
+        # Model for Elastic Net regression
+        cv = MultiTaskElasticNetCV(
+            alphas=[0, 0.001, 0.01, 0.1, 1, 10, 100, 1000],
+            l1_ratio=[0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0],
+            cv=5, n_jobs=-1
+        )
+        # Fit with pipeline
+        steps = [
+            ("scaler", MinMaxScaler()),
+            ("regressor", cv),
+        ]
+        pipeline = Pipeline(steps=steps)
+        pipeline.fit(self._X_train, self._y_train)
+        reg_output = pipeline.named_steps.regressor
+        # Update regressor
+        self._regressor = pipeline
+        # Intercept/coef
+        intercept_df = pd.DataFrame(
+            reg_output.coef_, index=self._y_train.columns, columns=self._X_train.columns)
+        intercept_df.insert(0, "Intercept", None)
+        intercept_df["Intercept"] = reg_output.intercept_
+        # Update param
+        param_dict = {
+            **{k: type(v) for (k, v) in steps},
+            "alpha": reg_output.alpha_,
+            "l1_ratio": reg_output.l1_ratio_,
+            "intercept": intercept_df,
+            "coef": intercept_df,
+        }
+        self._param.update(param_dict)
+
+    def predict(self):
+        """
+        Predict parameter values (via y) with self._regressor and X_target.
+
+        Returns:
+            pandas.DataFrame:
+                Index
+                    Date (pandas.Timestamp): future dates
+                Columns
+                    (float): parameter values (4 digits)
+        """
+        # Predict parameter values
+        predicted = self._regressor.predict(self._X_target)
+        df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
+        # parameter values: 4 digits
+        return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))

--- a/covsirphy/regression/param_elastic_net.py
+++ b/covsirphy/regression/param_elastic_net.py
@@ -34,7 +34,7 @@ class _ParamElasticNetRegressor(_RegressorBase):
         If @seed is included in kwargs, this will be converted to @random_state.
     """
     # Description of regressor
-    DESC = "Indicators -> Parameters  with Elastic Net"
+    DESC = "Indicators -> Parameters with Elastic Net"
 
     def __init__(self, X, y, delay, **kwargs):
         super().__init__(X, y, delay, **kwargs)

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -1,0 +1,113 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from covsirphy.util.evaluator import Evaluator
+from covsirphy.util.term import Term
+from covsirphy.ode.mbase import ModelBase
+from covsirphy.regression.param_elastic_net import _ParamElasticNetRegressor
+
+
+class RegressionHandler(Term):
+    """
+    Handle regressors to predict parameter values of ODE models.
+    With .fit() method, the best regressor will be selected using score with test dataset.
+
+    Args:
+        data (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                - parameter values
+                - the number of cases
+                - indicators
+        model (covsirphy.ModelBase): ODE model
+        delay (int): delay period [days]
+        kwargs: keyword arguments of sklearn.model_selection.train_test_split(test_size=0.2, random_state=0)
+
+    Note:
+        If @seed is included in kwargs, this will be converted to @random_state.
+    """
+
+    def __init__(self, data, model, delay, **kwargs):
+        # Dataset
+        self._data = self._ensure_dataframe(data, name="data", time_index=True)
+        # ODE parameter values
+        self._ensure_subclass(model, ModelBase, name="model")
+        self._parameters = model.PARAMETERS[:]
+        # Delay period
+        self._delay = self._ensure_natural_int(delay, name="delay")
+        # Keyword arguments
+        self._kwargs = kwargs.copy()
+        # All regressors {name: RegressorBase}
+        self._reg_dict = {}
+        # The best regressor name
+        self._best = None
+
+    def fit(self, metric):
+        """
+        Fit regressors and select the best regressor using score with test dataset.
+
+        Args:
+            metric (str): metric name to select the best regressor
+
+        Note:
+            All regressors are here.
+            - Indicators -> Parameters  with Elastic Net
+        """
+        self._reg_dict = {
+            _ParamElasticNetRegressor.DESC: self._fit_param_reg(_ParamElasticNetRegressor),
+        }
+        # Select the best regressor with the metric
+        comp_f = {True: min, False: max}[Evaluator.smaller_is_better(metric=metric)]
+        self._best, _ = comp_f(self._reg_dict.items(), key=lambda x: x[1].score_test(metric=metric))
+
+    def _fit_param_reg(self, regressor_class):
+        """
+        Fit a regressor which uses ODE parameter values as y.
+
+        Args:
+            regressor_class (covsirphy.regression.regbase.RegressorBase): regression class
+
+        Returns:
+            covsirphy.regression.regbase.RegressorBase: fitted regressor
+        """
+        self._ensure_dataframe(self._data, name="data", columns=self._parameters)
+        X = self._data.drop(self._parameters, axis=1)
+        y = self._data.loc[:, self._parameters]
+        return regressor_class(X=X, y=y, delay=self._delay, **self._kwargs)
+
+    def to_dict(self, metric):
+        """
+        Return information regarding the best regressor.
+
+        Args:
+            metric (str): metric name to select the best regressor
+
+        Returns:
+            dict(str, object): regressor information of the best model, including
+                - scaler (object): scaler class
+                - regressor (object): regressor class
+                - alpha (float): alpha value used in Elastic Net regression
+                - l1_ratio (float): l1_ratio value used in Elastic Net regression
+                - score_name (str): scoring method (specified with @metric or @metrics)
+                - score_train (float): score with train dataset
+                - score_test (float): score with test dataset
+                - dataset (dict[numpy.ndarray]): X_train, X_test, y_train, y_test, X_target
+                - intercept (pandas.DataFrame): intercept and coefficients (Index ODE parameters, Columns indicators)
+                - coef (pandas.DataFrame): intercept and coefficients (Index ODE parameters, Columns indicators)
+                - delay (int): delay period
+        """
+        return self._reg_dict[self._best].to_dict(metric=metric)
+
+    def predict(self):
+        """
+        Predict parameter values of the ODE model using the best regressor.
+
+        Returns:
+            pandas.DataFrame:
+                Index
+                    Date (pandas.Timestamp): future dates
+                Columns
+                    (float): parameter values (4 digits)
+        """
+        return self._reg_dict[self._best].predict()

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -10,7 +10,7 @@ from covsirphy.regression.param_elastic_net import _ParamElasticNetRegressor
 class RegressionHandler(Term):
     """
     Handle regressors to predict parameter values of ODE models.
-    With .fit() method, the best regressor will be selected using score with test dataset.
+    With .fit() method, the best regressor will be selected based on the scores with test dataset.
 
     Args:
         data (pandas.DataFrame):
@@ -45,14 +45,14 @@ class RegressionHandler(Term):
 
     def fit(self, metric):
         """
-        Fit regressors and select the best regressor using score with test dataset.
+        Fit regressors and select the best regressor based on the scores with test dataset.
 
         Args:
             metric (str): metric name to select the best regressor
 
         Note:
             All regressors are here.
-            - Indicators -> Parameters  with Elastic Net
+            - Indicators -> Parameters with Elastic Net
         """
         self._reg_dict = {
             _ParamElasticNetRegressor.DESC: self._fit_param_reg(_ParamElasticNetRegressor),

--- a/covsirphy/regression/regbase.py
+++ b/covsirphy/regression/regbase.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from datetime import timedelta
+import pandas as pd
+from sklearn.model_selection import train_test_split
+from covsirphy.util.argument import find_args
+from covsirphy.util.evaluator import Evaluator
+from covsirphy.util.term import Term
+
+
+class _RegressorBase(Term):
+    """
+    Basic class for parameter prediction (forecasting).
+
+    Args:
+        X (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float): indicators
+        y (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float) target values
+        delay (int): delay period [days]
+        kwargs: keyword arguments of sklearn.model_selection.train_test_split(test_size=0.2, random_state=0)
+
+    Note:
+        If @seed is included in kwargs, this will be converted to @random_state.
+    """
+
+    def __init__(self, X, y, delay, **kwargs):
+        # Validate values
+        self._ensure_dataframe(X, name="X", time_index=True)
+        self._ensure_dataframe(y, name="y", time_index=True)
+        self._delay = self._ensure_natural_int(delay, name="delay")
+        # Set training/test dataset
+        splitted_all = self._split(X, y, self._delay, **kwargs)
+        self._X_train, self._X_test, self._y_train, self._y_test, self._X_target = splitted_all
+        # Regression model
+        self._regressor = None
+        self._param = {}
+        # Perform fitting
+        self._fit()
+
+    @staticmethod
+    def _split(X, y, delay, **kwargs):
+        """
+        Apply delay period to the X dataset.
+
+        Args:
+            X (pandas.DataFrame): indicators with time index
+            y (pandas.DataFrame): target values with time index
+            delay (int): delay period [days]
+            kwargs: keyword arguments of sklearn.model_selection.train_test_split(test_size=0.2, random_state=0)
+
+        Returns:
+            tuple(pandas.DataFrame): datasets with time index
+                - X_train
+                - X_test
+                - y_train
+                - y_test
+                - X_target
+
+        Note:
+            If @seed is included in kwargs, this will be converted to @random_state.
+        """
+        split_kwargs = {"test_size": 0.2, "random_state": 0, }
+        split_kwargs.update(kwargs)
+        split_kwargs["random_state"] = split_kwargs.get("seed", split_kwargs["random_state"])
+        split_kwargs = find_args(train_test_split, **split_kwargs)
+        # Apply delay period to X
+        X_delayed = X.copy()
+        X_delayed.index += timedelta(days=delay)
+        # Training/test data
+        df = X_delayed.join(y, how="inner")
+        df = df.rolling(window=delay).mean().dropna().drop_duplicates()
+        X_arranged = df.loc[:, X.columns]
+        y_arranged = df.loc[:, y.columns]
+        splitted = train_test_split(X_arranged, y_arranged, **split_kwargs)
+        # X_target
+        X_target = X_delayed.loc[X_delayed.index > y.index.max()]
+        return (*splitted, X_target)
+
+    def _fit(self):
+        """
+        Fit regression model with training dataset, update self._regressor and self._param.
+        This method should be overwritten by child classes.
+        """
+        raise NotImplementedError
+
+    def score_train(self, metric):
+        """
+        Calculate score with training dataset.
+
+        Args:
+            metric (str): metric name, refer to covsirphy.Evaluator.score()
+
+        Returns:
+            float: evaluation score
+        """
+        pred_train = pd.DataFrame(self._regressor.predict(self._X_train), columns=self._y_train.columns)
+        return Evaluator(pred_train, self._y_train, how="all").score(metric=metric)
+
+    def score_test(self, metric):
+        """
+        Calculate score with test dataset.
+
+        Args:
+            metric (str): metric name, refer to covsirphy.Evaluator.score()
+
+        Returns:
+            float: evaluation score
+        """
+        pred_test = pd.DataFrame(self._regressor.predict(self._X_test), columns=self._y_test.columns)
+        return Evaluator(pred_test, self._y_test, how="all").score(metric=metric)
+
+    def to_dict(self, metric):
+        """
+        Calculate score with training/test dataset.
+
+        Args:
+            metric (str): metric name, refer to covsirphy.Evaluator.score()
+        """
+        return {
+            **self._param,
+            "score_metric": metric,
+            "score_train": self.score_train(metric=metric),
+            "score_test": self.score_test(metric=metric),
+            "delay": self._delay,
+            "dataset": {
+                "X_train": self._X_train,
+                "y_train": self._y_train,
+                "X_test": self._X_test,
+                "y_test": self._y_test,
+                "X_target": self._X_target,
+            }
+        }
+
+    def predict(self):
+        """
+        Predict parameter values (via y) with self._regressor and X_target.
+        This method should be overwritten by child classes.
+
+        Returns:
+            pandas.DataFrame:
+                Index
+                    Date (pandas.Timestamp): future dates
+                Columns
+                    (float): parameter values
+        """
+        raise NotImplementedError

--- a/covsirphy/regression/regbase.py
+++ b/covsirphy/regression/regbase.py
@@ -11,7 +11,7 @@ from covsirphy.util.term import Term
 
 class _RegressorBase(Term):
     """
-    Basic class for parameter prediction (forecasting).
+    Basic class to predict parameter values of ODE models.
 
     Args:
         X (pandas.DataFrame):
@@ -30,6 +30,8 @@ class _RegressorBase(Term):
     Note:
         If @seed is included in kwargs, this will be converted to @random_state.
     """
+    # Description of regressor
+    DESC = ""
 
     def __init__(self, X, y, delay, **kwargs):
         # Validate values

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -50,6 +50,7 @@ class TestEvaluator(object):
         score_metric = evaluator.score(metric=metric)
         score_metrics = evaluator.score(metrics=metric)
         assert score_metric == score_metrics
+        assert isinstance(Evaluator.smaller_is_better(metric=metric), bool)
 
     @pytest.mark.parametrize("metric", ["ME", "MAE", "MSE", "MSLE", "MAPE", "RMSE", "RMSLE", "R2"])
     @pytest.mark.parametrize("how", ["all", "inner"])
@@ -82,3 +83,5 @@ class TestEvaluator(object):
         evaluator = Evaluator(true, pred, on=None)
         with pytest.raises(UnExpectedValueError):
             evaluator.score(metric="Unknown")
+        with pytest.raises(UnExpectedValueError):
+            evaluator.smaller_is_better(metric="Unknown")


### PR DESCRIPTION
## Related issues
#668 

## What was changed
For refactoring, I created `covsirphy.regression.reg_handler.RegressionHander` class. This is called in `Scenario.fit()` and `Scenario.predict()`.
`RegressionHandler.fit()` executes some regressors (only `_ParamElasticNetRegressor` for "Indicators -> Parameters  with Elastic Net" at this time) and select the best model for forecasting beased on the scores with test dataset.

When we need to add some regressors, we will create a child class of `covsirphy.regbase._RegressionBase` with class variable `.DESC` (regressor description), method `._fit()` and `.predict()`. Then, update `RegressionHandler.fit()`.