### PR TITLE
Issue668 rate

### DIFF
--- a/covsirphy/regression/rate_elastic_net.py
+++ b/covsirphy/regression/rate_elastic_net.py
@@ -9,7 +9,8 @@ from covsirphy.regression.param_elastic_net import _ParamElasticNetRegressor
 
 class _RateElasticNetRegressor(_ParamElasticNetRegressor):
     """
-    Predict parameter values of ODE models with Elastic Net regression with Param(n) / Param(n-1) approach.
+    Predict parameter values of ODE models with Elastic Net regression
+    and Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) approach.
 
     Args:
         X (pandas.DataFrame):
@@ -29,14 +30,16 @@ class _RateElasticNetRegressor(_ParamElasticNetRegressor):
         If @seed is included in kwargs, this will be converted to @random_state.
     """
     # Description of regressor
-    DESC = "Indicators -> Parameters with Elastic Net with Param(n) / Param(n-1) approach"
+    DESC = "Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) with Elastic Net"
 
     def __init__(self, X, y, delay, **kwargs):
         # Remember the last value of y (= the previous value of target y)
         self._last_param_df = y.tail(1)
+        # Calculate X(n) / X(n-1) and replace inf with NAs (NAs will be removed in ._split())
+        X_div = X.div(X.shift(1)).replace(np.inf, np.nan)
         # Calculate y(n) / y(n-1) and replace inf with NAs (NAs will be removed in ._split())
         y_div = y.div(y.shift(1)).replace(np.inf, np.nan)
-        super().__init__(X, y_div, delay, **kwargs)
+        super().__init__(X_div, y_div, delay, **kwargs)
 
     def predict(self):
         """

--- a/covsirphy/regression/rate_elastic_net.py
+++ b/covsirphy/regression/rate_elastic_net.py
@@ -35,8 +35,8 @@ class _RateElasticNetRegressor(_ParamElasticNetRegressor):
     def __init__(self, X, y, delay, **kwargs):
         # Remember the last value of y (= the previous value of target y)
         self._last_param_df = y.tail(1)
-        # Calculate X(n) / X(n-1) and replace inf with NAs (NAs will be removed in ._split())
-        X_div = X.div(X.shift(1)).replace(np.inf, np.nan)
+        # Calculate X(n) / X(n-1) and replace inf with 0
+        X_div = X.div(X.shift(1)).replace(np.inf, 0)
         # Calculate y(n) / y(n-1) and replace inf with NAs (NAs will be removed in ._split())
         y_div = y.div(y.shift(1)).replace(np.inf, np.nan)
         super().__init__(X_div, y_div, delay, **kwargs)

--- a/covsirphy/regression/rate_elastic_net.py
+++ b/covsirphy/regression/rate_elastic_net.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from math import log10, floor
+import numpy as np
+import pandas as pd
+from covsirphy.regression.param_elastic_net import _ParamElasticNetRegressor
+
+
+class _RateElasticNetRegressor(_ParamElasticNetRegressor):
+    """
+    Predict parameter values of ODE models with Elastic Net regression with Param(n) / Param(n-1) approach.
+
+    Args:
+        X (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float): indicators
+        y (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float) target values
+        delay (int): delay period [days]
+        kwargs: keyword arguments of sklearn.model_selection.train_test_split(test_size=0.2, random_state=0)
+
+    Note:
+        If @seed is included in kwargs, this will be converted to @random_state.
+    """
+    # Description of regressor
+    DESC = "Indicators -> Parameters with Elastic Net with Param(n) / Param(n-1) approach"
+
+    def __init__(self, X, y, delay, **kwargs):
+        # Remember the last value of y (= the previous value of target y)
+        self._last_param_df = y.tail(1)
+        # Calculate y(n) / y(n-1) and replace inf with NAs (NAs will be removed in ._split())
+        y_div = y.div(y.shift(1)).replace(np.inf, np.nan)
+        super().__init__(X, y_div, delay, **kwargs)
+
+    def predict(self):
+        """
+        Predict parameter values (via y) with self._regressor and X_target.
+
+        Returns:
+            pandas.DataFrame:
+                Index
+                    Date (pandas.Timestamp): future dates
+                Columns
+                    (float): parameter values (4 digits)
+        """
+        # Predict parameter values
+        predicted = self._regressor.predict(self._X_target)
+        df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
+        # Calculate y(n) values with y(0) and y(n) / y(n-1)
+        df = pd.concat([self._last_param_df, predicted], axis=0, ignore_index=True, sort=True)
+        df = df.cumprod().iloc[1:]
+        # parameter values: 4 digits
+        return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))

--- a/covsirphy/regression/rate_elastic_net.py
+++ b/covsirphy/regression/rate_elastic_net.py
@@ -53,7 +53,7 @@ class _RateElasticNetRegressor(_ParamElasticNetRegressor):
         predicted = self._regressor.predict(self._X_target)
         df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
         # Calculate y(n) values with y(0) and y(n) / y(n-1)
-        df = pd.concat([self._last_param_df, df], axis=0, ignore_index=True, sort=True)
+        df = pd.concat([self._last_param_df, df], axis=0, sort=True)
         df = df.cumprod().iloc[1:]
         # parameter values: 4 digits
         return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))

--- a/covsirphy/regression/rate_elastic_net.py
+++ b/covsirphy/regression/rate_elastic_net.py
@@ -53,7 +53,7 @@ class _RateElasticNetRegressor(_ParamElasticNetRegressor):
         predicted = self._regressor.predict(self._X_target)
         df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
         # Calculate y(n) values with y(0) and y(n) / y(n-1)
-        df = pd.concat([self._last_param_df, predicted], axis=0, ignore_index=True, sort=True)
+        df = pd.concat([self._last_param_df, df], axis=0, ignore_index=True, sort=True)
         df = df.cumprod().iloc[1:]
         # parameter values: 4 digits
         return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))

--- a/covsirphy/regression/rate_elastic_net.py
+++ b/covsirphy/regression/rate_elastic_net.py
@@ -35,8 +35,8 @@ class _RateElasticNetRegressor(_ParamElasticNetRegressor):
     def __init__(self, X, y, delay, **kwargs):
         # Remember the last value of y (= the previous value of target y)
         self._last_param_df = y.tail(1)
-        # Calculate X(n) / X(n-1) and replace inf with 0
-        X_div = X.div(X.shift(1)).replace(np.inf, 0)
+        # Calculate X(n) / X(n-1) and replace inf/NA with 0
+        X_div = X.div(X.shift(1)).replace(np.inf, 0).fillna(0)
         # Calculate y(n) / y(n-1) and replace inf with NAs (NAs will be removed in ._split())
         y_div = y.div(y.shift(1)).replace(np.inf, np.nan)
         super().__init__(X_div, y_div, delay, **kwargs)

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -5,6 +5,7 @@ from covsirphy.util.evaluator import Evaluator
 from covsirphy.util.term import Term
 from covsirphy.ode.mbase import ModelBase
 from covsirphy.regression.param_elastic_net import _ParamElasticNetRegressor
+from covsirphy.regression.rate_elastic_net import _RateElasticNetRegressor
 
 
 class RegressionHandler(Term):
@@ -56,6 +57,7 @@ class RegressionHandler(Term):
         """
         self._reg_dict = {
             _ParamElasticNetRegressor.DESC: self._fit_param_reg(_ParamElasticNetRegressor),
+            _RateElasticNetRegressor.DESC: self._fit_param_reg(_RateElasticNetRegressor),
         }
         # Select the best regressor with the metric
         comp_f = {True: min, False: max}[Evaluator.smaller_is_better(metric=metric)]

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -88,6 +88,7 @@ class RegressionHandler(Term):
 
         Returns:
             dict(str, object): regressor information of the best model, including
+                - best (str): description of the selected approach
                 - scaler (object): scaler class
                 - regressor (object): regressor class
                 - alpha (float): alpha value used in Elastic Net regression
@@ -100,7 +101,9 @@ class RegressionHandler(Term):
                 - coef (pandas.DataFrame): intercept and coefficients (Index ODE parameters, Columns indicators)
                 - delay (int): delay period
         """
-        return self._reg_dict[self._best].to_dict(metric=metric)
+        fit_dict = {"best": self._best}
+        fit_dict.update(self._reg_dict[self._best].to_dict(metric=metric))
+        return fit_dict
 
     def predict(self):
         """

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -62,7 +62,8 @@ class RegressionHandler(Term):
         }
         # Predicted all parameter values must be >= 0
         self._reg_dict = {
-            k: v for (k, v) in approach_dict.items() if v.predict().ge(0).all().all()}
+            k: v for (k, v) in approach_dict.items()
+            if v.predict().ge(0).all().all() and v.predict().le(1).all().all()}
         # Select the best regressor with the metric
         comp_f = {True: min, False: max}[Evaluator.smaller_is_better(metric=metric)]
         self._best, _ = comp_f(self._reg_dict.items(), key=lambda x: x[1].score_test(metric=metric))

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -55,10 +55,14 @@ class RegressionHandler(Term):
             All regressors are here.
             - Indicators -> Parameters with Elastic Net
         """
-        self._reg_dict = {
+        # All approaches
+        approach_dict = {
             _ParamElasticNetRegressor.DESC: self._fit_param_reg(_ParamElasticNetRegressor),
             _RateElasticNetRegressor.DESC: self._fit_param_reg(_RateElasticNetRegressor),
         }
+        # Predicted all parameter values must be >= 0
+        self._reg_dict = {
+            k: v for (k, v) in approach_dict.items() if v.predict().ge(0).all().all()}
         # Select the best regressor with the metric
         comp_f = {True: min, False: max}[Evaluator.smaller_is_better(metric=metric)]
         self._best, _ = comp_f(self._reg_dict.items(), key=lambda x: x[1].score_test(metric=metric))

--- a/example/scenario_analysis.py
+++ b/example/scenario_analysis.py
@@ -56,7 +56,11 @@ def main(country="Italy", province=None, file_prefix="ita"):
     snl.simulate(name="Main", **filer.png("simulate_main"))
     snl.history_rate(name="Main", **filer.png("history-rate_main"))
     # Forecast scenario: Short-term prediction with regression and OxCGRT data
-    snl.fit_predict(name="Forecast")
+    fit_dict = snl.fit(name="Forecast")
+    fit_dict.pop("coef").to_csv(**filer.csv("fitting_coef", index=True))
+    del fit_dict["dataset"], fit_dict["intercept"]
+    print(fit_dict)
+    snl.predict(name="Forecast")
     snl.add(name="Forecast", end_date="31May2021")
     snl.simulate(name="Forecast", **filer.png("simulate_forecast"))
     snl.history_rate(name="Main", **filer.png("history-rate_forecast"))

--- a/example/scenario_analysis.py
+++ b/example/scenario_analysis.py
@@ -57,7 +57,7 @@ def main(country="Italy", province=None, file_prefix="ita"):
     snl.history_rate(name="Main", **filer.png("history-rate_main"))
     # Forecast scenario: Short-term prediction with regression and OxCGRT data
     fit_dict = snl.fit(name="Forecast")
-    fit_dict.pop("coef").to_csv(**filer.csv("fitting_coef", index=True))
+    fit_dict.pop("coef").to_csv(**filer.csv("forecast_coef", index=True))
     del fit_dict["dataset"], fit_dict["intercept"]
     print(fit_dict)
     snl.predict(name="Forecast")

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -179,7 +179,7 @@ class TestScenario(object):
         with pytest.raises(UnExecutedError):
             snl.param_history()
         # Parameter estimation
-        snl.estimate(SIRF, timeout=1, timeout_interation=1)
+        snl.estimate(SIRF, timeout=5, timeout_interation=1)
         snl.summary()
 
     def test_estimator(self, snl):

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -11,7 +11,7 @@ from covsirphy import Scenario, Term, PhaseSeries, Estimator, SIRF
 
 @pytest.fixture(scope="module")
 def snl(jhu_data, population_data, japan_data, oxcgrt_data, vaccine_data, pcr_data):
-    snl = Scenario(country="Japan", province=None, tau=None, auto_complement=True)
+    snl = Scenario(country="Italy", province=None, tau=None, auto_complement=True)
     snl.register(
         jhu_data, population_data,
         extras=[japan_data, oxcgrt_data, pcr_data, vaccine_data])
@@ -179,7 +179,7 @@ class TestScenario(object):
         with pytest.raises(UnExecutedError):
             snl.param_history()
         # Parameter estimation
-        snl.estimate(SIRF, timeout=20, timeout_interation=5)
+        snl.estimate(SIRF)
         snl.summary()
 
     def test_estimator(self, snl):

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -11,7 +11,7 @@ from covsirphy import Scenario, Term, PhaseSeries, Estimator, SIRF
 
 @pytest.fixture(scope="module")
 def snl(jhu_data, population_data, japan_data, oxcgrt_data, vaccine_data, pcr_data):
-    snl = Scenario(country="Japan", province=None, tau=None, auto_complement=True)
+    snl = Scenario(country="Italy", province=None, tau=None, auto_complement=True)
     snl.register(
         jhu_data, population_data,
         extras=[japan_data, oxcgrt_data, pcr_data, vaccine_data])
@@ -179,7 +179,7 @@ class TestScenario(object):
         with pytest.raises(UnExecutedError):
             snl.param_history()
         # Parameter estimation
-        snl.estimate(SIRF, timeout=1, timeout_interation=1)
+        snl.estimate(SIRF)
         snl.summary()
 
     def test_estimator(self, snl):

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -11,7 +11,7 @@ from covsirphy import Scenario, Term, PhaseSeries, Estimator, SIRF
 
 @pytest.fixture(scope="module")
 def snl(jhu_data, population_data, japan_data, oxcgrt_data, vaccine_data, pcr_data):
-    snl = Scenario(country="Italy", province=None, tau=None, auto_complement=True)
+    snl = Scenario(country="Japan", province=None, tau=None, auto_complement=True)
     snl.register(
         jhu_data, population_data,
         extras=[japan_data, oxcgrt_data, pcr_data, vaccine_data])
@@ -179,7 +179,7 @@ class TestScenario(object):
         with pytest.raises(UnExecutedError):
             snl.param_history()
         # Parameter estimation
-        snl.estimate(SIRF)
+        snl.estimate(SIRF, timeout=1, timeout_interation=1)
         snl.summary()
 
     def test_estimator(self, snl):

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -179,7 +179,7 @@ class TestScenario(object):
         with pytest.raises(UnExecutedError):
             snl.param_history()
         # Parameter estimation
-        snl.estimate(SIRF, timeout=5, timeout_interation=1)
+        snl.estimate(SIRF, timeout=20, timeout_interation=5)
         snl.summary()
 
     def test_estimator(self, snl):


### PR DESCRIPTION
## Related issues
#668

## What was changed
Add "Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) with Elastic Net" approach to forecasting.

Now we have the following two apporoaches and the best approaches will be selected with test scores. Approaches which lead un-expected parameter values (i.e. not in range (0, 1)) will not be selected.
- "Indicators -> Parameters with Elastic Net"
- Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) with Elastic Net