### PR TITLE
Issue731 grid

### DIFF
--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -1317,7 +1317,10 @@ class Scenario(Term):
             name (str): scenario name
             test_size (float): proportion of the test dataset of Elastic Net regression
             seed (int): random seed when spliting the dataset to train/test data
-            delay (int or None): delay period [days] or None (Scenario.estimate_delay() calculate automatically)
+            delay (int or tuple(int, int) or None):
+                - (int): delay period [days],
+                - tuple(int, int): select the best value with grid search in this range, or
+                - None: Scenario.estimate_delay() calculate automatically
             removed_cols (list[str] or None): list of variables to remove from X dataset or None (indicators used to estimate delay period)
             metric (str or None): metric name or None (use @metrics)
             metrics (str): alias of @metric
@@ -1353,13 +1356,6 @@ class Scenario(Term):
             raise UnExecutedError(
                 "Scenario.estimate() or Scenario.add()",
                 message=f", specifying @model (covsirphy.SIRF etc.) and @name='{name}'.")
-        # Set delay effect
-        if delay is None:
-            delay, delay_df = self.estimate_delay(oxcgrt_data)
-            removed_cols = list(set(delay_df.columns.tolist()) | set(removed_cols or []))
-        else:
-            delay = self._ensure_natural_int(delay, name="delay")
-            removed_cols = removed_cols or None
         # Create training/test dataset
         param_df = self._track_param(name=name)[model.PARAMETERS]
         try:
@@ -1368,9 +1364,31 @@ class Scenario(Term):
             raise NotRegisteredExtraError(
                 "Scenario.register(jhu_data, population_data, extras=[...])",
                 message="with extra datasets") from None
-        records_df = records_df.loc[:, ~records_df.columns.isin(removed_cols)]
-        # Fit regression models
+        records_df = records_df.loc[:, ~records_df.columns.isin(removed_cols or [])]
         data = param_df.join(records_df)
+        # Set delay effect
+        if delay is None:
+            # Estimate delay period with Scenario.estimate_delay()
+            delay, delay_df = self.estimate_delay(oxcgrt_data)
+            records_df = records_df.loc[:, ~records_df.columns.isin(delay_df.columns)]
+            data = param_df.join(records_df)
+        elif isinstance(delay, tuple):
+            # Estimate the best delay value with grid search in the range
+            delay_min, delay_max = delay
+            self._ensure_natural_int(delay_min, name="delay[0]")
+            self._ensure_natural_int(delay_max, name="delay[1]")
+            score_dict = {}
+            for candidate in range(delay_min, delay_max + 1):
+                handler_candidate = RegressionHandler(data=data, model=model, delay=candidate, **kwargs)
+                try:
+                    score_dict[candidate] = handler_candidate.fit(metric=metric)
+                except ValueError:
+                    pass
+            delay, _ = Evaluator.best_one(score_dict, metric=metric)
+        else:
+            # Use specified delay value
+            delay = self._ensure_natural_int(delay, name="delay")
+        # Fit regression models
         handler = RegressionHandler(data=data, model=model, delay=delay, **kwargs)
         handler.fit(metric=metric)
         self._reghandler_dict[name] = handler

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -373,6 +373,9 @@ class Scenario(Term):
             raise ScenarioNotFoundError(template)
         tracker = copy.deepcopy(self._tracker_dict[template])
         self._tracker_dict[name] = tracker
+        # Remove regressor
+        if name in self._reghandler_dict:
+            self._reghandler_dict.pop(name)
         return tracker
 
     @deprecate(old="Scenario.add_phase()", new="Scenario.add()")

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -364,6 +364,9 @@ class Scenario(Term):
 
         Returns:
             covsirphy.ParamTracker
+
+        Note:
+            If regressors was registered by Scenario.fit(), the regressor will be removed.
         """
         # Registered
         if name in self._tracker_dict:

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -125,3 +125,18 @@ class Evaluator(object):
         if metric not in cls._METRICS_DICT:
             raise UnExpectedValueError("metric", metric, candidates=list(cls._METRICS_DICT.keys()))
         return cls._METRICS_DICT[metric][1]
+
+    @classmethod
+    def best_one(cls, candidate_dict, **kwargs):
+        """
+        Select the best one with scores.
+
+        Args:
+            candidate_dict (dict[object, float]): scores of candidates
+            kwargs: keyword arguments of Evaluator.smaller_is_better()
+
+        Returns:
+            tuple(object, float): the best one and its score
+        """
+        comp_f = {True: min, False: max}[cls.smaller_is_better(**kwargs)]
+        return comp_f(candidate_dict.items(), key=lambda x: x[1])

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -277,7 +277,7 @@ class TestScenario(object):
         # Fitting
         with pytest.raises(UnExecutedError):
             snl.predict()
-        info_dict = snl.fit(delay=delay, metric="RMSLE")
+        info_dict = snl.fit(delay=delay)
         assert isinstance(info_dict, dict)
         # Deprecated: fit with oxcgrt_data
         warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -286,5 +286,5 @@ class TestScenario(object):
         snl.predict()
         assert Term.FUTURE in snl.summary()[Term.TENSE].unique()
         # Fitting & predict
-        snl.fit_predict(delay=delay, metric="RMSLE")
+        snl.fit_predict(delay=delay)
         assert Term.FUTURE in snl.summary()[Term.TENSE].unique()

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -272,17 +272,21 @@ class TestScenario(object):
         assert isinstance(delay, int)
         assert isinstance(df, pd.DataFrame)
 
-    @pytest.mark.parametrize("delay", [5, (7, 31), None])
-    def test_fit_predict(self, snl, oxcgrt_data, delay):
+    def test_fit_predict_error(self, snl, oxcgrt_data):
         # Fitting
         snl.clear()
         with pytest.raises(UnExecutedError):
             snl.predict()
-        info_dict = snl.fit(delay=delay)
-        assert isinstance(info_dict, dict)
         # Deprecated: fit with oxcgrt_data
         warnings.filterwarnings("ignore", category=DeprecationWarning)
         snl.fit(oxcgrt_data)
+
+    @pytest.mark.parametrize("delay", [5, (7, 31), None])
+    def test_fit_predict(self, snl, oxcgrt_data, delay):
+        # Fitting
+        snl.clear()
+        info_dict = snl.fit(delay=delay)
+        assert isinstance(info_dict, dict)
         # Prediction
         snl.predict()
         assert Term.FUTURE in snl.summary()[Term.TENSE].unique()

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -275,6 +275,7 @@ class TestScenario(object):
     @pytest.mark.parametrize("delay", [5, (7, 31), None])
     def test_fit_predict(self, snl, oxcgrt_data, delay):
         # Fitting
+        snl.clear()
         with pytest.raises(UnExecutedError):
             snl.predict()
         info_dict = snl.fit(delay=delay)

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -272,11 +272,12 @@ class TestScenario(object):
         assert isinstance(delay, int)
         assert isinstance(df, pd.DataFrame)
 
-    def test_fit_predict(self, snl, oxcgrt_data):
+    @pytest.mark.parametrize("delay", [5, (7, 31), None])
+    def test_fit_predict(self, snl, oxcgrt_data, delay):
         # Fitting
         with pytest.raises(UnExecutedError):
             snl.predict()
-        info_dict = snl.fit()
+        info_dict = snl.fit(delay=delay, metric="RMSLE")
         assert isinstance(info_dict, dict)
         # Deprecated: fit with oxcgrt_data
         warnings.filterwarnings("ignore", category=DeprecationWarning)
@@ -285,5 +286,5 @@ class TestScenario(object):
         snl.predict()
         assert Term.FUTURE in snl.summary()[Term.TENSE].unique()
         # Fitting & predict
-        snl.fit_predict()
+        snl.fit_predict(delay=delay, metric="RMSLE")
         assert Term.FUTURE in snl.summary()[Term.TENSE].unique()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -51,6 +51,11 @@ class TestEvaluator(object):
         score_metrics = evaluator.score(metrics=metric)
         assert score_metric == score_metrics
         assert isinstance(Evaluator.smaller_is_better(metric=metric), bool)
+        best_tuple = Evaluator.best_one({"A": 1.0, "B": 1.5, "C": 2.0}, metric=metric)
+        if metric == "R2":
+            assert best_tuple == ("C", 2.0)
+        else:
+            assert best_tuple == ("A", 1.0)
 
     @pytest.mark.parametrize("metric", ["ME", "MAE", "MSE", "MSLE", "MAPE", "RMSE", "RMSLE", "R2"])
     @pytest.mark.parametrize("how", ["all", "inner"])


### PR DESCRIPTION
## Related issues
#731

## What was changed
When `delay=(7, 31)` (not default currently), `Scenario.fit()` select the best delay value with grid search to minimize the score of `RegressionHandler.fit()`.