### PR TITLE
Issue718 guess

### DIFF
--- a/covsirphy/ode/mbase.py
+++ b/covsirphy/ode/mbase.py
@@ -346,7 +346,7 @@ class ModelBase(Term):
         raise NotImplementedError
 
     @classmethod
-    def guess(cls, data, tau):
+    def guess(cls, data, tau, q=0.5):
         """
         With (X, dX/dt) for X=S, I, R and so on, guess parameter values.
         This will be overwitten by child classes.
@@ -362,8 +362,9 @@ class ModelBase(Term):
                     - Fatal(int): the number of fatal cases
                     - Recovered (int): the number of recovered cases
             tau (int): tau value [min]
+            q (float or tuple(float,)): the quantile(s) to compute, value(s) between (0, 1)
 
         Returns:
-            dict(str, float): guessed parameter values
+            dict(str, float or pandas.Series): guessed parameter values with the quantile(s)
         """
         raise NotImplementedError

--- a/covsirphy/ode/param_estimator.py
+++ b/covsirphy/ode/param_estimator.py
@@ -46,7 +46,7 @@ class _ParamEstimator(Term):
         # Step numbers
         self._step_n = df.index.max()
         # Parameter range
-        self._range_dict = model.param_range(df.reset_index(), self._population, quantiles=quantiles)
+        self._range_dict = model.guess(data, tau, q=quantiles)
         # Max values of the variables
         self._max_dict = {v: df[v].max() for v in model.VARIABLES}
 

--- a/covsirphy/ode/sewirf.py
+++ b/covsirphy/ode/sewirf.py
@@ -302,7 +302,7 @@ class SEWIRF(ModelBase):
         return df.loc[:, [cls.DATE, cls.S, cls.CI, cls.F, cls.R]]
 
     @classmethod
-    def guess(cls, data, tau):
+    def guess(cls, data, tau, q=0.5):
         """
         With (X, dX/dt) for X=S, I, R and so on, guess parameter values.
         This is not implemented for SEWIR-F model.
@@ -318,6 +318,7 @@ class SEWIRF(ModelBase):
                     - Fatal(int): the number of fatal cases
                     - Recovered (int): the number of recovered cases
             tau (int): tau value [min]
+            q (float or tuple(float,)): the quantile(s) to compute, value(s) between (0, 1)
         """
         raise NotImplementedError(
             "SEWIR-F cannot be used for parameter estimation because we do not have records "

--- a/covsirphy/ode/sir.py
+++ b/covsirphy/ode/sir.py
@@ -269,7 +269,7 @@ class SIR(ModelBase):
         return df.loc[:, [cls.DATE, cls.S, cls.CI, cls.F, cls.R]]
 
     @classmethod
-    def guess(cls, data, tau):
+    def guess(cls, data, tau, q=0.5):
         """
         With (X, dX/dt) for X=S, I, R, guess parameter values.
 
@@ -284,12 +284,13 @@ class SIR(ModelBase):
                     - Fatal(int): the number of fatal cases
                     - Recovered (int): the number of recovered cases
             tau (int): tau value [min]
+            q (float or tuple(float,)): the quantile(s) to compute, value(s) between (0, 1)
 
         Returns:
-            dict(str, float): guessed parameter values
+            dict(str, float or pandas.Series): guessed parameter values with the quantile(s)
 
         Note:
-            We can guess parameter values as follows. Median will be calculated.
+            We can guess parameter values with difference equations as follows.
             - rho = - n * (dS/dt) / S / I
             - sigma = (dR/dt) / I
         """
@@ -298,10 +299,11 @@ class SIR(ModelBase):
         # Remove negative values and set variables
         df = df.loc[(df[cls.S] > 0) & (df[cls.CI] > 0)]
         n = df.loc[df.index[0], [cls.S, cls.CI, cls.FR]].sum()
-        # Guess parameter values
+        # Calculate parameter values with difference equation
         rho_series = 0 - n * df[cls.S].diff() / tau / df[cls.S] / df[cls.CI]
         sigma_series = df[cls.FR].diff() / tau / df[cls.CI]
+        # Guess representative values
         return {
-            "rho": rho_series.median(),
-            "sigma": sigma_series.median(),
+            "rho": rho_series.quantile(q=q).clip(0, 1),
+            "sigma": sigma_series.quantile(q=q).clip(0, 1),
         }

--- a/covsirphy/ode/sir.py
+++ b/covsirphy/ode/sir.py
@@ -299,9 +299,9 @@ class SIR(ModelBase):
         # Remove negative values and set variables
         df = df.loc[(df[cls.S] > 0) & (df[cls.CI] > 0)]
         n = df.loc[df.index[0], [cls.S, cls.CI, cls.FR]].sum()
-        # Calculate parameter values with difference equation
-        rho_series = 0 - n * df[cls.S].diff() / tau / df[cls.S] / df[cls.CI]
-        sigma_series = df[cls.FR].diff() / tau / df[cls.CI]
+        # Calculate parameter values with difference equation and tau-free data
+        rho_series = 0 - n * df[cls.S].diff() / df[cls.S] / df[cls.CI]
+        sigma_series = df[cls.FR].diff() / df[cls.CI]
         # Guess representative values
         return {
             "rho": rho_series.quantile(q=q).clip(0, 1),

--- a/covsirphy/ode/sird.py
+++ b/covsirphy/ode/sird.py
@@ -307,10 +307,10 @@ class SIRD(ModelBase):
         # Remove negative values and set variables
         df = df.loc[(df[cls.S] > 0) & (df[cls.CI] > 0)]
         n = df.loc[df.index[0], [cls.S, cls.CI, cls.F, cls.R]].sum()
-        # Calculate parameter values with difference equation
-        kappa_series = df[cls.F].diff() / tau / df[cls.CI]
-        rho_series = 0 - n * df[cls.S].diff() / tau / df[cls.S] / df[cls.CI]
-        sigma_series = df[cls.R].diff() / tau / df[cls.CI]
+        # Calculate parameter values with difference equation and tau-free data
+        kappa_series = df[cls.F].diff() / df[cls.CI]
+        rho_series = 0 - n * df[cls.S].diff() / df[cls.S] / df[cls.CI]
+        sigma_series = df[cls.R].diff() / df[cls.CI]
         # Guess representative values
         return {
             "kappa": kappa_series.quantile(q=q).clip(0, 1),

--- a/covsirphy/ode/sirf.py
+++ b/covsirphy/ode/sirf.py
@@ -313,10 +313,10 @@ class SIRF(ModelBase):
         # Remove negative values and set variables
         df = df.loc[(df[cls.S] > 0) & (df[cls.CI] > 0)]
         n = df.loc[df.index[0], [cls.S, cls.CI, cls.F, cls.R]].sum()
-        # Calculate parameter values with difference equation
-        kappa_series = df[cls.F].diff() / tau / df[cls.CI]
-        rho_series = 0 - n * df[cls.S].diff() / tau / df[cls.S] / df[cls.CI]
-        sigma_series = df[cls.R].diff() / tau / df[cls.CI]
+        # Calculate parameter values with difference equation and tau-free data
+        kappa_series = df[cls.F].diff() / df[cls.CI]
+        rho_series = 0 - n * df[cls.S].diff() / df[cls.S] / df[cls.CI]
+        sigma_series = df[cls.R].diff() / df[cls.CI]
         # Guess representative values
         return {
             "theta": 0.0 if isinstance(q, float) else pd.Series([0.0, 1.0]).repeat([1, len(q) - 1]),

--- a/covsirphy/ode/sirf.py
+++ b/covsirphy/ode/sirf.py
@@ -319,7 +319,7 @@ class SIRF(ModelBase):
         sigma_series = df[cls.R].diff() / tau / df[cls.CI]
         # Guess representative values
         return {
-            "theta": 0.0 if isinstance(q, float) else pd.Series([0.0, 0.5]).repeat([1, len(q) - 1]),
+            "theta": 0.0 if isinstance(q, float) else pd.Series([0.0, 1.0]).repeat([1, len(q) - 1]),
             "kappa": kappa_series.quantile(q=q).clip(0, 1),
             "rho": rho_series.quantile(q=q).clip(0, 1),
             "sigma": sigma_series.quantile(q=q).clip(0, 1),

--- a/covsirphy/ode/sirf.py
+++ b/covsirphy/ode/sirf.py
@@ -319,7 +319,7 @@ class SIRF(ModelBase):
         sigma_series = df[cls.R].diff() / df[cls.CI]
         # Guess representative values
         return {
-            "theta": 0.0 if isinstance(q, float) else pd.Series([0.0, 1.0]).repeat([1, len(q) - 1]),
+            "theta": 0.0 if isinstance(q, float) else pd.Series([0.0, 0.5]).repeat([1, len(q) - 1]),
             "kappa": kappa_series.quantile(q=q).clip(0, 1),
             "rho": rho_series.quantile(q=q).clip(0, 1),
             "sigma": sigma_series.quantile(q=q).clip(0, 1),

--- a/covsirphy/ode/sirf.py
+++ b/covsirphy/ode/sirf.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+import pandas as pd
 from covsirphy.ode.mbase import ModelBase
 
 
@@ -280,7 +281,7 @@ class SIRF(ModelBase):
         return df.loc[:, [cls.DATE, cls.S, cls.CI, cls.F, cls.R]]
 
     @classmethod
-    def guess(cls, data, tau):
+    def guess(cls, data, tau, q=0.5):
         """
         With (X, dX/dt) for X=S, I, R, F, guess parameter values.
 
@@ -295,13 +296,15 @@ class SIRF(ModelBase):
                     - Fatal(int): the number of fatal cases
                     - Recovered (int): the number of recovered cases
             tau (int): tau value [min]
+            q (float or tuple(float,)): the quantile(s) to compute, value(s) between (0, 1)
 
         Returns:
-            dict(str, float): guessed parameter values
+            dict(str, float or pandas.Series): guessed parameter values with the quantile(s)
 
         Note:
-            We can guess parameter values as follows. Median will be calculated.
-            - kappa = (dF/dt) / I when theta -> 0
+            We can guess parameter values with difference equations as follows.
+            - theta -> +0 (i.e. around 0 and not negative)
+            - kappa -> (dF/dt) / I when theta -> +0
             - rho = - n * (dS/dt) / S / I
             - sigma = (dR/dt) / I
         """
@@ -310,13 +313,14 @@ class SIRF(ModelBase):
         # Remove negative values and set variables
         df = df.loc[(df[cls.S] > 0) & (df[cls.CI] > 0)]
         n = df.loc[df.index[0], [cls.S, cls.CI, cls.F, cls.R]].sum()
-        # Guess parameter values
+        # Calculate parameter values with difference equation
         kappa_series = df[cls.F].diff() / tau / df[cls.CI]
         rho_series = 0 - n * df[cls.S].diff() / tau / df[cls.S] / df[cls.CI]
         sigma_series = df[cls.R].diff() / tau / df[cls.CI]
+        # Guess representative values
         return {
-            "theta": 0.0,
-            "kappa": kappa_series.median(),
-            "rho": rho_series.median(),
-            "sigma": sigma_series.median(),
+            "theta": 0.0 if isinstance(q, float) else pd.Series([0.0, 0.5]).repeat([1, len(q) - 1]),
+            "kappa": kappa_series.quantile(q=q).clip(0, 1),
+            "rho": rho_series.quantile(q=q).clip(0, 1),
+            "sigma": sigma_series.quantile(q=q).clip(0, 1),
         }

--- a/tests/test_ode.py
+++ b/tests/test_ode.py
@@ -39,7 +39,7 @@ class TestODEHandler(object):
     @pytest.mark.parametrize("model", [SIR, SIRD, SIRF])
     @pytest.mark.parametrize("first_date", ["01Jan2021"])
     @pytest.mark.parametrize("tau", [720])
-    @pytest.mark.parametrize("n_jobs", [-1, 1])
+    @pytest.mark.parametrize("n_jobs", [1, -1])
     def test_estimate(self, model, first_date, tau, n_jobs):
         # Create simulated dataset
         y0_dict = model.EXAMPLE["y0_dict"]


### PR DESCRIPTION
## Related issues
#718

## What was changed
For SIR, SIR-D, SIR-F model,
- `model.guess(data, tau, q=0.5)` returns 0.5 quantiles of parameter values
- `model.guess(data, tau, q=(0.1, 0.9))` returns 0.1 and 0.9 quantiles of parameter values

`model.param_range()` will not be used in parameter estimation and replaced with `model.guess(..., q=(0.1, 0.9))`.

Note that `cs.SIRF.guess(q=<float>)["theta"]` is always 0.0 and  `cs.SIRF.guess(q=<tuple(<float>, <float>)>)["theta"]` is always (0.0, 0.5), not (0.0, 1.0).