### PR TITLE
Add option for last date limit to PCRData.positive_rate() + simplify colored maps legend

### DIFF
--- a/covsirphy/cleaning/pcr_data.py
+++ b/covsirphy/cleaning/pcr_data.py
@@ -532,7 +532,7 @@ class PCRData(CleaningBase):
         raise PCRIncorrectPreconditionError(
             country=country, province=province, message="Too many missing Tests records")
 
-    def positive_rate(self, country, province=None, window=7, show_figure=True, filename=None):
+    def positive_rate(self, country, province=None, window=7, last_date=None, show_figure=True, filename=None):
         """
         Return the PCR rate of a country as a dataframe.
 
@@ -540,6 +540,7 @@ class PCRData(CleaningBase):
             country(str): country name or ISO3 code
             province(str or None): province name
             window (int): window of moving average, >= 1
+            last_date (str or None): the last date of the total tests records or None (max date of main dataset)
             show_figure (bool): if True, show the records as a line-plot.
             filename (str): filename of the figure, or None (display figure)
 
@@ -571,6 +572,9 @@ class PCRData(CleaningBase):
         except PCRIncorrectPreconditionError:
             raise PCRIncorrectPreconditionError(
                 country=country, province=province, message="Too many missing Tests records") from None
+        # Limit tests records to last date
+        if last_date is not None:
+            subset_df = subset_df.loc[subset_df[self.DATE] <= last_date]
         # Process PCR data
         df, is_complemented = self._pcr_processing(subset_df, window)
         # Calculate PCR values

--- a/covsirphy/cleaning/pcr_data.py
+++ b/covsirphy/cleaning/pcr_data.py
@@ -574,7 +574,7 @@ class PCRData(CleaningBase):
                 country=country, province=province, message="Too many missing Tests records") from None
         # Limit tests records to last date
         if last_date is not None:
-            subset_df = subset_df.loc[subset_df[self.DATE] <= last_date]
+            subset_df = subset_df.loc[subset_df[self.DATE] <= pd.to_datetime(last_date)]
         # Process PCR data
         df, is_complemented = self._pcr_processing(subset_df, window)
         # Calculate PCR values

--- a/covsirphy/visualization/colored_map.py
+++ b/covsirphy/visualization/colored_map.py
@@ -89,7 +89,7 @@ class ColoredMap(VisualizeBase):
         gdf.loc[gdf["Value"] < 0, "Value"] = 0
         # Colorbar
         divider = make_axes_locatable(self._ax)
-        cax = divider.append_axes("right", size="5%", pad=0.1)
+        cax = divider.append_axes("bottom", size="5%", pad=0.1)
         # Arguments of plotting with GeoPandas
         plot_kwargs = {
             "legend": True,
@@ -103,10 +103,11 @@ class ColoredMap(VisualizeBase):
             }
         }
         plot_kwargs.update(kwargs)
+        plot_kwargs["legend_kwds"] = {'orientation': "horizontal"}
         # Convert to log10 scale
         if logscale:
             gdf["Value"] = np.log10(gdf["Value"] + 1)
-            plot_kwargs["legend_kwds"] = {"label": "in log10 scale"}
+            # plot_kwargs["legend_kwds"] = {"label": "in log10 scale"}
         # Plotting
         warnings.filterwarnings("ignore", category=UserWarning)
         if not gdf["Value"].isna().sum():

--- a/covsirphy/visualization/colored_map.py
+++ b/covsirphy/visualization/colored_map.py
@@ -107,7 +107,6 @@ class ColoredMap(VisualizeBase):
         # Convert to log10 scale
         if logscale:
             gdf["Value"] = np.log10(gdf["Value"] + 1)
-            # plot_kwargs["legend_kwds"] = {"label": "in log10 scale"}
         # Plotting
         warnings.filterwarnings("ignore", category=UserWarning)
         if not gdf["Value"].isna().sum():

--- a/tests/test_cleaning/test_pcr.py
+++ b/tests/test_cleaning/test_pcr.py
@@ -3,6 +3,7 @@
 
 import warnings
 import pytest
+import pandas as pd
 from covsirphy import SubsetNotFoundError, PCRIncorrectPreconditionError
 from covsirphy import PCRData
 
@@ -41,11 +42,14 @@ class TestPCRData(object):
         assert set(df.columns) == set([*PCRData.PCR_NLOC_COLUMNS, PCRData.T_DIFF])
 
     @pytest.mark.parametrize("country", ["Greece", "Italy", "Sweden"])
-    def test_positive_rate(self, pcr_data, country):
+    @pytest.mark.parametrize("last_date", ["21Apr2021", None])
+    def test_positive_rate(self, pcr_data, country, last_date):
         warnings.simplefilter("ignore", category=UserWarning)
-        pcr_data.positive_rate(country, show_figure=True)
-        df = pcr_data.positive_rate(country, show_figure=False)
+        pcr_data.positive_rate(country, last_date=last_date, show_figure=True)
+        df = pcr_data.positive_rate(country, last_date=last_date, show_figure=False)
         assert set([PCRData.T_DIFF, PCRData.C_DIFF, PCRData.PCR_RATE]).issubset(df.columns)
+        if last_date is not None:
+            assert df[pcr_data.DATE].max() <= pd.to_datetime(last_date)
 
     @pytest.mark.parametrize("country", ["China"])
     def test_positive_rate_error(self, pcr_data, country):


### PR DESCRIPTION
## Related issues
This is related to issues #745 and #747.

## What was changed
1. Added argument `last_date` in `PCRData.positive_rate()`.
2. Use horizontal legend in colored maps

Call example for `PCRData.positive_rate()`:
```
import covsirphy as cs
data_loader = cs.DataLoader()
pcr_data = data_loader.pcr()
country = "Italy"
pcr_data.positive_rate(country, last_date="21Apr2021")

```