### PR TITLE
Issue718 example data

### DIFF
--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -110,17 +110,14 @@ __all__ = [
     "TrendDetector", "TrendPlot", "trend_plot",
     # ode
     "ModelBase", "SIR", "SIRD", "SIRF", "SEWIRF", "ODEHandler",
-    # simulation
-    "ODESimulator", "Estimator",
-    # phase
-    "PhaseSeries", "PhaseUnit", "MPEstimator",
     # regression
     "RegressionHandler",
     # analysis
-    "ExampleData", "Scenario", "ModelValidator", "ParamTracker", "DataHandler", "PhaseTracker",
+    "ExampleData", "Scenario", "ModelValidator", "DataHandler", "PhaseTracker",
     # Deprecated
     "Population", "Word", "jpn_map", "SIRFV", "line_plot_multiple", "ChangeFinder", "Trend",
-    "Optimizer", "save_dataframe", "PolicyMeasures",
+    "Optimizer", "save_dataframe", "PolicyMeasures", "ODESimulator", "Estimator", "ParamTracker",
+    "PhaseSeries", "PhaseUnit", "MPEstimator",
 ]
 
 # Show exceptions in better format if used from command line

--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -118,11 +118,9 @@ __all__ = [
     "RegressionHandler",
     # analysis
     "ExampleData", "Scenario", "ModelValidator", "ParamTracker", "DataHandler", "PhaseTracker",
-    # worldwide
-    "PolicyMeasures",
     # Deprecated
     "Population", "Word", "jpn_map", "SIRFV", "line_plot_multiple", "ChangeFinder", "Trend",
-    "Optimizer", "save_dataframe",
+    "Optimizer", "save_dataframe", "PolicyMeasures",
 ]
 
 # Show exceptions in better format if used from command line

--- a/covsirphy/analysis/param_tracker.py
+++ b/covsirphy/analysis/param_tracker.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from covsirphy.util.error import UnExecutedError
+from covsirphy.util.error import UnExecutedError, deprecate
 from covsirphy.util.argument import find_args
 from covsirphy.util.evaluator import Evaluator
 from covsirphy.util.term import Term
@@ -34,6 +34,7 @@ class ParamTracker(Term):
         tau (int or None): tau value [min]
     """
 
+    @deprecate("", new="ODEHandler", version="2.19.1-zeta-fu1")
     def __init__(self, record_df, phase_series, area=None, tau=None):
         # Phase series
         self._series = self._ensure_instance(phase_series, PhaseSeries, name="phase_series")

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -804,7 +804,7 @@ class Scenario(Term):
         Args:
             phase (str): phase name, like 1st, 2nd...
             name (str): phase series name
-            kwargs: keyword arguments of covsirphy.Estimator.accuracy()
+            kwargs: the other arguments will be ignored
 
         Note:
             If 'Main' was used as @name, main PhaseSeries will be used.

--- a/covsirphy/ode/mbase.py
+++ b/covsirphy/ode/mbase.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 import numpy as np
 import pandas as pd
+from covsirphy.util.error import deprecate
 from covsirphy.util.term import Term
 
 
@@ -70,9 +71,10 @@ class ModelBase(Term):
         raise NotImplementedError
 
     @classmethod
+    @deprecate(".param_range()", new=".guess()", version="2.19.1-zeta-fu1")
     def param_range(cls, taufree_df, population, quantiles=(0.3, 0.7)):
         """
-        Define the value range of ODE parameters using (X, dX/dt) points.
+        Deprecated. Define the value range of ODE parameters using (X, dX/dt) points.
         This method should be overwritten in subclass.
 
         Args:
@@ -91,9 +93,10 @@ class ModelBase(Term):
         raise NotImplementedError
 
     @classmethod
+    @deprecate(".specialize()", new=".convert()", version="2.19.1-zeta-fu1")
     def specialize(cls, data_df, population):
         """
-        Specialize the dataset for this model.
+        Deprecated. Specialize the dataset for this model.
         This method should be overwritten in subclass.
 
         Args:
@@ -119,9 +122,10 @@ class ModelBase(Term):
         raise NotImplementedError
 
     @classmethod
+    @deprecate(".restore()", new=".convert_reverse()", version="2.19.1-zeta-fu1")
     def restore(cls, specialized_df):
         """
-        Restore Confirmed/Infected/Recovered/Fatal using a dataframe with the variables of the model.
+        Deprecated. Restore Confirmed/Infected/Recovered/Fatal using a dataframe with the variables of the model.
         This method should be overwritten in subclass.
 
         Args:
@@ -170,9 +174,10 @@ class ModelBase(Term):
         raise NotImplementedError
 
     @classmethod
+    @deprecate(".taufree()", new=".convert()", version="2.19.1-zeta-fu1")
     def tau_free(cls, subset_df, population, tau=None):
         """
-        Create a dataframe specialized to the model.
+        Deprecated. Create a dataframe specialized to the model.
         If tau is not None, Date column will be converted to '(Date - start date) / tau'
         and saved in t column.
 

--- a/covsirphy/ode/mbase.py
+++ b/covsirphy/ode/mbase.py
@@ -144,13 +144,7 @@ class ModelBase(Term):
                     - Recovered (int): the number of recovered cases
                     - the other columns @specialzed_df has
         """
-        df = specialized_df.copy()
-        other_cols = list(set(df.columns) - set(cls.VALUE_COLUMNS))
-        df[cls.C] = None
-        df[cls.CI] = None
-        df[cls.F] = None
-        df[cls.R] = None
-        return df.loc[:, [*cls.VALUE_COLUMNS, *other_cols]]
+        raise NotImplementedError
 
     def calc_r0(self):
         """

--- a/covsirphy/ode/ode_handler.py
+++ b/covsirphy/ode/ode_handler.py
@@ -318,5 +318,5 @@ class ODEHandler(Term):
                     - Runtime (str): runtime of optimization
         """
         tau = self.estimate_tau(data, **find_args(self.estimate_tau, **kwargs))
-        info_dict = self.estimate_params(data, **find_args(self.estimate_params, **kwargs))
+        info_dict = self.estimate_params(data, **kwargs)
         return (tau, info_dict)

--- a/covsirphy/ode/sewirf.py
+++ b/covsirphy/ode/sewirf.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+from covsirphy.util.error import deprecate
 from covsirphy.ode.mbase import ModelBase
 
 
@@ -60,9 +61,7 @@ class SEWIRF(ModelBase):
             - @sigma (float)
         """
         # Total population
-        self.population = self._ensure_natural_int(
-            population, name="population"
-        )
+        self.population = self._ensure_population(population)
         # Non-dim parameters
         self.theta = theta
         self.kappa = kappa
@@ -99,9 +98,10 @@ class SEWIRF(ModelBase):
         return np.array([dsdt, didt, drdt, dfdt, dedt, dwdt])
 
     @classmethod
+    @deprecate(".param_range()", new=".guess()", version="2.19.1-zeta-fu1")
     def param_range(cls, taufree_df, population):
         """
-        Define the range of parameters (not including tau value).
+        Deprecated. Define the range of parameters (not including tau value).
 
         Args:
             taufree_df (pandas.DataFrame):
@@ -123,9 +123,10 @@ class SEWIRF(ModelBase):
         )
 
     @classmethod
+    @deprecate(".specialize()", new=".convert()", version="2.19.1-zeta-fu1")
     def specialize(cls, data_df, population):
         """
-        Specialize the dataset for this model.
+        Deprecated. Specialize the dataset for this model.
 
         Args:
             data_df (pandas.DataFrame):
@@ -158,9 +159,10 @@ class SEWIRF(ModelBase):
         return df
 
     @classmethod
+    @deprecate(".restore()", new=".convert_reverse()", version="2.19.1-zeta-fu1")
     def restore(cls, specialized_df):
         """
-        Restore Confirmed/Infected/Recovered/Fatal.
+        Deprecated. Restore Confirmed/Infected/Recovered/Fatal.
          using a dataframe with the variables of the model.
 
         Args:

--- a/covsirphy/ode/sir.py
+++ b/covsirphy/ode/sir.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+from covsirphy.util.error import deprecate
 from covsirphy.ode.mbase import ModelBase
 
 
@@ -44,9 +45,7 @@ class SIR(ModelBase):
 
     def __init__(self, population, rho, sigma):
         # Total population
-        self.population = self._ensure_natural_int(
-            population, name="population"
-        )
+        self.population = self._ensure_population(population)
         # Non-dim parameters
         self.rho = rho
         self.sigma = sigma
@@ -71,9 +70,10 @@ class SIR(ModelBase):
         return np.array([dsdt, didt, drdt])
 
     @classmethod
+    @deprecate(".param_range()", new=".guess()", version="2.19.1-zeta-fu1")
     def param_range(cls, taufree_df, population, quantiles=(0.1, 0.9)):
         """
-        Define the value range of ODE parameters using (X, dX/dt) points.
+        Deprecated. Define the value range of ODE parameters using (X, dX/dt) points.
         In SIR model, X is S, I and R here.
 
         Args:
@@ -104,9 +104,10 @@ class SIR(ModelBase):
         return _dict
 
     @classmethod
+    @deprecate(".specialize()", new=".convert()", version="2.19.1-zeta-fu1")
     def specialize(cls, data_df, population):
         """
-        Specialize the dataset for this model.
+        Deprecated. Specialize the dataset for this model.
 
         Args:
             data_df (pandas.DataFrame):
@@ -137,9 +138,10 @@ class SIR(ModelBase):
         return df
 
     @classmethod
+    @deprecate(".restore()", new=".convert_reverse()", version="2.19.1-zeta-fu1")
     def restore(cls, specialized_df):
         """
-        Restore Confirmed/Infected/Recovered/Fatal.
+        Deprecated. Restore Confirmed/Infected/Recovered/Fatal.
          using a dataframe with the variables of the model.
 
         Args:

--- a/covsirphy/ode/sird.py
+++ b/covsirphy/ode/sird.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import numpy as np
+from covsirphy.util.error import deprecate
 from covsirphy.ode.mbase import ModelBase
 
 
@@ -46,9 +47,7 @@ class SIRD(ModelBase):
 
     def __init__(self, population, kappa, rho, sigma):
         # Total population
-        self.population = self._ensure_natural_int(
-            population, name="population"
-        )
+        self.population = self._ensure_population(population)
         # Non-dim parameters
         self.kappa = kappa
         self.rho = rho
@@ -75,9 +74,10 @@ class SIRD(ModelBase):
         return np.array([dsdt, didt, drdt, dfdt])
 
     @classmethod
+    @deprecate(".param_range()", new=".guess()", version="2.19.1-zeta-fu1")
     def param_range(cls, taufree_df, population, quantiles=(0.1, 0.9)):
         """
-        Define the value range of ODE parameters using (X, dX/dt) points.
+        Deprecated. Define the value range of ODE parameters using (X, dX/dt) points.
         In SIR model, X is S, I, R, D here.
 
         Args:
@@ -114,9 +114,10 @@ class SIRD(ModelBase):
         return _dict
 
     @classmethod
+    @deprecate(".specialize()", new=".convert()", version="2.19.1-zeta-fu1")
     def specialize(cls, data_df, population):
         """
-        Specialize the dataset for this model.
+        Deprecated. Specialize the dataset for this model.
 
         Args:
             data_df (pandas.DataFrame):
@@ -146,9 +147,10 @@ class SIRD(ModelBase):
         return df
 
     @classmethod
+    @deprecate(".restore()", new=".convert_reverse()", version="2.19.1-zeta-fu1")
     def restore(cls, specialized_df):
         """
-        Restore Confirmed/Infected/Recovered/Fatal using a dataframe with the variables of the model.
+        Deprecated. Restore Confirmed/Infected/Recovered/Fatal using a dataframe with the variables of the model.
 
         Args:
         @specialized_df (pandas.DataFrame): dataframe with the variables

--- a/covsirphy/ode/sirf.py
+++ b/covsirphy/ode/sirf.py
@@ -3,6 +3,7 @@
 
 import numpy as np
 import pandas as pd
+from covsirphy.util.error import deprecate
 from covsirphy.ode.mbase import ModelBase
 
 
@@ -50,9 +51,7 @@ class SIRF(ModelBase):
 
     def __init__(self, population, theta, kappa, rho, sigma):
         # Total population
-        self.population = self._ensure_natural_int(
-            population, name="population"
-        )
+        self.population = self._ensure_population(population)
         # Non-dim parameters
         self.theta = theta
         self.kappa = kappa
@@ -81,9 +80,10 @@ class SIRF(ModelBase):
         return np.array([dsdt, didt, drdt, dfdt])
 
     @classmethod
+    @deprecate(".param_range()", new=".guess()", version="2.19.1-zeta-fu1")
     def param_range(cls, taufree_df, population, quantiles=(0.1, 0.9)):
         """
-        Define the value range of ODE parameters using (X, dX/dt) points.
+        Deprecated. Define the value range of ODE parameters using (X, dX/dt) points.
         In SIR model, X is S, I, R, F here.
 
         Args:
@@ -118,9 +118,10 @@ class SIRF(ModelBase):
         return _dict
 
     @classmethod
+    @deprecate(".specialize()", new=".convert()", version="2.19.1-zeta-fu1")
     def specialize(cls, data_df, population):
         """
-        Specialize the dataset for this model.
+        Deprecated. Specialize the dataset for this model.
 
         Args:
             data_df (pandas.DataFrame):
@@ -149,9 +150,10 @@ class SIRF(ModelBase):
         return df
 
     @classmethod
+    @deprecate(".restore()", new=".convert_reverse()", version="2.19.1-zeta-fu1")
     def restore(cls, specialized_df):
         """
-        Restore Confirmed/Infected/Recovered/Fatal.
+        Deprecated. Restore Confirmed/Infected/Recovered/Fatal.
          using a dataframe with the variables of the model.
 
         Args:

--- a/covsirphy/phase/phase_estimator.py
+++ b/covsirphy/phase/phase_estimator.py
@@ -3,6 +3,7 @@
 
 import functools
 from multiprocessing import cpu_count, Pool
+from covsirphy.util.error import deprecate
 from covsirphy.util.stopwatch import StopWatch
 from covsirphy.util.term import Term
 from covsirphy.cleaning.jhu_data import JHUData
@@ -36,6 +37,7 @@ class MPEstimator(Term):
         When @record_df is None, @jhu_data and @population_data must be specified.
     """
 
+    @deprecate("MPEstimator", new="ODEHandler", version="2.19.1-zeta-fu1")
     def __init__(self, model, jhu_data=None, population_data=None,
                  record_df=None, tau=None, **kwargs):
         # Records

--- a/covsirphy/phase/phase_series.py
+++ b/covsirphy/phase/phase_series.py
@@ -18,6 +18,7 @@ class PhaseSeries(Term):
         population (int): initial value of total population in the place
     """
 
+    @deprecate("PhaseSeries", new="ODEHandler", version="2.19.1-zeta-fu1")
     def __init__(self, first_date, last_date, population):
         self._first_date = self._ensure_date(first_date, "first_date").strftime(self.DATE_FORMAT)
         self._last_date = self._ensure_date(last_date, "last_date").strftime(self.DATE_FORMAT)

--- a/covsirphy/phase/phase_unit.py
+++ b/covsirphy/phase/phase_unit.py
@@ -2,7 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pandas as pd
-from covsirphy.util.error import UnExecutedError
+from covsirphy.util.error import UnExecutedError, deprecate
 from covsirphy.util.evaluator import Evaluator
 from covsirphy.util.term import Term
 from covsirphy.ode.mbase import ModelBase
@@ -59,6 +59,7 @@ class PhaseUnit(Term):
         True
     """
 
+    @deprecate("PhaseUnit", new="ODEHandler", version="2.19.1-zeta-fu1")
     def __init__(self, start_date, end_date, population):
         self._ensure_date_order(start_date, end_date, name="end_date")
         self._start_date = start_date

--- a/covsirphy/simulation/estimator.py
+++ b/covsirphy/simulation/estimator.py
@@ -43,6 +43,7 @@ class Estimator(Term):
     warnings.simplefilter("ignore", FutureWarning)
     warnings.simplefilter("ignore", SyntaxWarning)
 
+    @deprecate("Estimator", new="ODEHandler", version="2.19.1-zeta-fu1")
     def __init__(self, record_df, model, population, tau=None, **kwargs):
         # ODE model
         self.model = self._ensure_subclass(model, ModelBase, name="model")

--- a/covsirphy/simulation/simulator.py
+++ b/covsirphy/simulation/simulator.py
@@ -19,6 +19,7 @@ class ODESimulator(Term):
         province (str or None): province name
     """
 
+    @deprecate("ODESimulator", new="ODEHandler", version="2.19.1-zeta-fu1")
     def __init__(self, country=None, province=None):
         self.country = country or self.UNKNOWN
         self.province = province or self.UNKNOWN

--- a/covsirphy/worldwide/policy.py
+++ b/covsirphy/worldwide/policy.py
@@ -26,6 +26,7 @@ class PolicyMeasures(Term):
         tau (int or None): tau value [min]
     """
 
+    @deprecate("PolicyMeasures", version="2.19.1-zeta-fu1")
     def __init__(self, jhu_data, population_data, oxcgrt_data, tau=None):
         # Records
         self.jhu_data = self._ensure_instance(

--- a/tests/test_deprecated/test_param_tracker.py
+++ b/tests/test_deprecated/test_param_tracker.py
@@ -2,11 +2,11 @@
 # -*- coding: utf-8 -*-
 
 
-from covsirphy.ode.mbase import ModelBase
-from covsirphy.phase.phase_unit import PhaseUnit
 import warnings
 import pytest
-from covsirphy import SIRF, PhaseSeries, ParamTracker
+from covsirphy import SIRF, PhaseSeries, ParamTracker, ModelBase, PhaseUnit
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_deprecated/test_phase_series.py
+++ b/tests/test_deprecated/test_phase_series.py
@@ -6,6 +6,8 @@ import pytest
 from covsirphy import PhaseSeries
 from covsirphy import Term, PhaseUnit, SIR
 
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
 
 class TestPhaseSeries(object):
 

--- a/tests/test_deprecated/test_phase_unit.py
+++ b/tests/test_deprecated/test_phase_unit.py
@@ -1,9 +1,12 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import warnings
 import pytest
 from covsirphy import PhaseUnit
 from covsirphy import Term, SIR, Estimator, UnExecutedError
+
+warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
 class TestPhaseUnit(object):

--- a/tests/test_deprecated/test_policy_measures.py
+++ b/tests/test_deprecated/test_policy_measures.py
@@ -7,6 +7,8 @@ import pytest
 from covsirphy import PolicyMeasures
 from covsirphy import SIRF, Scenario
 
+warnings.filterwarnings("ignore", category=DeprecationWarning)
+
 
 class UnTestPolicyMeasures(object):
     # Skip this test at this time

--- a/tests/test_example_data.py
+++ b/tests/test_example_data.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import pytest
 from covsirphy import ExampleData, SIRF
 
 
@@ -12,9 +13,20 @@ class TestExampleData(object):
         example_data.add(SIRF, country="Moon")
         assert example_data.country_to_iso3("Moon") == "---"
 
-    def test_subset(self):
+    def test_one_phase(self):
         example_data = ExampleData()
-        example_data.add(SIRF, country="Japan")
-        example_data.subset(country="Japan")
-        example_data.subset_complement(country="Japan")
-        example_data.records(country="Japan")
+        example_data.add(SIRF)
+        with pytest.raises(ValueError):
+            example_data.subset()
+        example_data.subset(model=SIRF)
+        example_data.subset(country=SIRF.NAME)
+        example_data.subset_complement(model=SIRF)
+        example_data.records(model=SIRF)
+        example_data.specialized(model=SIRF)
+        example_data.non_dim(model=SIRF)
+
+    def test_two_phases(self):
+        example_data = ExampleData()
+        example_data.add(SIRF)
+        example_data.add(SIRF)
+        example_data.subset(model=SIRF)


### PR DESCRIPTION
## Related issues
#718

## What was changed
- `ExampleData` will use `ODEHandler`, not old `ODESimulator`

The following classes will be deprecated.
- `model.param_range()`, `model.specialize()` and `model.restore()` for `SIR`, `SIRD and `SIRF`
- `worldwide.PolicyMeasures`
- `simulation.Estimator`
- `simulation.Simulator`
- `phase.MPEstimator`
- `phase.PhaseSeries`
- `phase.PhaseUnit`
- `analysis.ParamTracker`
