### PR TITLE
Issue725 dates

### DIFF
--- a/covsirphy/analysis/phase_tracker.py
+++ b/covsirphy/analysis/phase_tracker.py
@@ -434,16 +434,16 @@ class PhaseTracker(Term):
         if past_days is not None:
             past_days = self._ensure_natural_int(past_days, name="past_days")
             return (self._today - timedelta(days=past_days), self._today)
-        # Read @phases
-        if phases is not None:
-            self._ensure_list(phases, name="phases")
-            if "last" in phases:
-                last_phase = df.index[-1]
-                phases = [last_phase if ph == "last" else ph for ph in phases]
-            dates = []
-            for phase in phases:
-                self._ensure_selectable(phase, df.index.tolist(), name="phase")
-                dates.extend(pd.date_range(df.loc[phase, self.START], df.loc[phase, self.END]).tolist())
-            return (min(dates), max(dates))
         # No arguments were specified
-        return (start_default, end_default)
+        if phases is None:
+            return (start_default, end_default)
+        # Read @phases
+        self._ensure_list(phases, name="phases")
+        dates = []
+        for phase in phases:
+            phase_replaced = df.index[-1] if phase == "last" else phase
+            self._ensure_selectable(phase_replaced, df.index.tolist(), name="phase")
+            start = df.loc[phase_replaced, self.START]
+            end = df.loc[phase_replaced, self.END]
+            dates.extend(pd.date_range(start, end).tolist())
+        return (min(dates), max(dates))

--- a/covsirphy/analysis/phase_tracker.py
+++ b/covsirphy/analysis/phase_tracker.py
@@ -403,6 +403,9 @@ class PhaseTracker(Term):
             When @past_days was specified, (today - @past_days, today) will be returned.
 
         Note:
+            In @phases, 'last' means the last registered phase.
+
+        Note:
             Priority is given in the order of @dates, @past_days, @phases.
         """
         if not len(self):
@@ -434,6 +437,9 @@ class PhaseTracker(Term):
         # Read @phases
         if phases is not None:
             self._ensure_list(phases, name="phases")
+            if "last" in phases:
+                last_phase = df.index[-1]
+                phases = [last_phase if ph == "last" else ph for ph in phases]
             dates = []
             for phase in phases:
                 self._ensure_selectable(phase, df.index.tolist(), name="phase")

--- a/covsirphy/analysis/phase_tracker.py
+++ b/covsirphy/analysis/phase_tracker.py
@@ -382,7 +382,7 @@ class PhaseTracker(Term):
         Args:
             dates (tuple(str or pandas.Timestamp or None, ) or None): start date and end date
             past_days (int or None): how many past days to use in calculation from today (property)
-            phases (list[str] or None): phase namess to use in calculation
+            phases (list[str] or None): phase names to use in calculation
 
         Raises:
             covsirphy.UnExecutedError: no phases were registered

--- a/covsirphy/analysis/phase_tracker.py
+++ b/covsirphy/analysis/phase_tracker.py
@@ -408,7 +408,7 @@ class PhaseTracker(Term):
         Note:
             Priority is given in the order of @dates, @past_days, @phases.
         """
-        if not len(self):
+        if not self:
             raise UnExecutedError("PhaseTracker.define_phase()")
         # Get list of phases: index=phase names, columns=Start/End
         track_df = self._track_df.reset_index()

--- a/covsirphy/util/term.py
+++ b/covsirphy/util/term.py
@@ -346,7 +346,7 @@ class Term(object):
             raise TypeError(s)
         return target
 
-    @ staticmethod
+    @staticmethod
     def _ensure_instance(target, class_obj, name="target"):
         """
         Ensure the target is a instance of the class object.
@@ -364,7 +364,7 @@ class Term(object):
             raise TypeError(s)
         return target
 
-    @ staticmethod
+    @staticmethod
     def _ensure_list(target, candidates=None, name="target"):
         """
         Ensure the target is a sub-list of the candidates.
@@ -392,7 +392,7 @@ class Term(object):
         candidate_str = ", ".join(strings)
         raise KeyError(f"@{name} must be a sub-list of [{candidate_str}], but {target} was applied.") from None
 
-    @ classmethod
+    @classmethod
     def divisors(cls, value):
         """
         Return the list of divisors of the value.
@@ -444,7 +444,7 @@ class Term(object):
         date = cls._ensure_date(date_str) + timedelta(days=days)
         return date.strftime(cls.DATE_FORMAT)
 
-    @ classmethod
+    @classmethod
     def tomorrow(cls, date_str):
         """
         Tomorrow of the date.
@@ -457,7 +457,7 @@ class Term(object):
         """
         return cls.date_change(date_str, days=1)
 
-    @ classmethod
+    @classmethod
     def yesterday(cls, date_str):
         """
         Yesterday of the date.
@@ -470,7 +470,7 @@ class Term(object):
         """
         return cls.date_change(date_str, days=-1)
 
-    @ classmethod
+    @classmethod
     def steps(cls, start_date, end_date, tau):
         """
         Return the number of days (round up).
@@ -485,7 +485,7 @@ class Term(object):
         tau = cls._ensure_tau(tau)
         return math.ceil((end - sta) / timedelta(minutes=tau))
 
-    @ classmethod
+    @classmethod
     def _ensure_date_order(cls, previous_date, following_date, name="following_date"):
         """
         Ensure that the order of dates.

--- a/example/usage_quick.ipynb
+++ b/example/usage_quick.ipynb
@@ -881,11 +881,13 @@
   },
   {
    "source": [
-    "We can focus on some dates with the following arguments.\n",
+    "From version 2.19.1-eta, we can focus on the values in specified date range with the following arguments.\n",
     "\n",
     "- `dates`: tuple of start date and end date\n",
     "- `past_days` (integer): how many past days to use in calculation from today (`Scenario.today` property)\n",
-    "- `phases` (list of str): phase names to use in calculation"
+    "- `phases` (list of str): phase names to use in calculation\n",
+    "\n",
+    "These arguments are effective with `Scenario.history()`, `Scenario.simulate()`, `Scenario.track()` and `Scenario.score()`."
    ],
    "cell_type": "markdown",
    "metadata": {}

--- a/example/usage_quick.ipynb
+++ b/example/usage_quick.ipynb
@@ -352,8 +352,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Hyperparameter estimation of ODE models\n",
-    "Here, we will estimate the parameter values of SIR-derived models. As an example, we use SIR-F model. Details of models will be explained in [Usage (details: theoritical datasets)](https://lisphilar.github.io/covid19-sir/usage_theoretical.html).  \n",
+    "### Parameter estimation of ODE models\n",
+    "Here, we will estimate the tau value [min] (using grid search) and parameter values of SIR-derived models using [Optuna](https://github.com/optuna/optuna) package (automated hyperparameter optimization framework). As an example, we use SIR-F model. Details of models will be explained in [Usage (details: theoritical datasets)](https://lisphilar.github.io/covid19-sir/usage_theoretical.html).  \n",
     "\n",
     "**We can select the model from SIR, SIRD and SIR-F model for parameter estimation. SIR-FV model (completely deprecated) and SEWIR-F model cannot be used.**"
    ]
@@ -366,7 +366,7 @@
    },
    "outputs": [],
    "source": [
-    "# Estimate the parameter values of SIR-F model\n",
+    "# Estimate the tau value and parameter values of SIR-F model\n",
     "# Default value of timeout in each phase is 180 sec\n",
     "snl.estimate(cs.SIRF, timeout=180)"
    ]
@@ -690,14 +690,11 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
-    "# Simulate the number of cases\n",
-    "_ = snl.simulate(name=\"Medicine\").tail()"
-   ]
+    "Simulate the number of cases."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
   },
   {
    "cell_type": "code",
@@ -705,10 +702,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Compare the number of cases with main scenario for the last two phases\n",
-    "all_phases = snl.summary(name=\"Medicine\").index.tolist()\n",
-    "# Should start with a past phase: the last phase, the first and the second future phase\n",
-    "_ = snl.history(\"Infected\", phases=all_phases[-3:])"
+    "_ = snl.simulate(name=\"Medicine\").tail()"
    ]
   },
   {
@@ -871,7 +865,7 @@
   },
   {
    "source": [
-    "Compare the number of cases with main scenario for the last three phases."
+    "Compare the number of cases of the all scenario with `Scenario.history()` and variable name."
    ],
    "cell_type": "markdown",
    "metadata": {}
@@ -882,9 +876,62 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "all_phases = snl.summary(name=\"Forecast\").index.tolist()\n",
-    "# Should start with a past phase: the last phase, the first and the second future phase\n",
-    "_ = snl.history(\"Infected\", phases=all_phases[-3:])"
+    "_ = snl.history(\"Infected\")"
+   ]
+  },
+  {
+   "source": [
+    "We can focus on some dates with the following arguments.\n",
+    "\n",
+    "- `dates`: tuple of start date and end date\n",
+    "- `past_days` (integer): how many past days to use in calculation from today (`Scenario.today` property)\n",
+    "- `phases` (list of str): phase names to use in calculation"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the minimum value (from today to future) to set lower limit of y-axis\n",
+    "lower_limit = snl.history(\"Infected\", dates=(snl.today, None), show_figure=False).min().min()\n",
+    "# From today to future (no limitation regarding end date)\n",
+    "_ = snl.history(\"Infected\", dates=(snl.today, None), ylim=(lower_limit, None))"
+   ]
+  },
+  {
+   "source": [
+    "In the past 20 days. Reference date is today (`Scenario.today` property)."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = snl.history(\"Infected\", past_days=20)"
+   ]
+  },
+  {
+   "source": [
+    "In the selected phases. Here, we will show the 3rd, 4th and 5th phase."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "_ = snl.history(\"Infected\", phases=[\"3rd\", \"4th\", \"5th\"])"
    ]
   },
   {
@@ -1053,17 +1100,13 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1-final"
+   "version": "3.9.4"
   },
   "orig_nbformat": 2,
   "kernelspec": {
-   "name": "python3",
-   "display_name": "Python 3.9.1 64-bit ('.venv')",
-   "metadata": {
-    "interpreter": {
-     "hash": "aa53c8c6e6798222a2084c11cc25017700a8d3ad495b587e3a634f357767115f"
-    }
-   }
+   "name": "python394jvsc74a57bd0e7a5033076b597f81e5ae7ba1abbcc3e4e4f13c94c7fa961e9c6d3be8b84fac4",
+   "display_name": "Python 3.9.4 64-bit ('.venv': venv)",
+   "language": "python"
   }
  },
  "nbformat": 4,

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -249,12 +249,10 @@ class TestScenario(object):
         sel_score = snl.score(phases=all_phases[-2:], name="Score")
         # Selected past days (when the beginning date is a start date)
         beginning_date = df.loc[df.index[-2], Term.START]
-        past_days = Term.steps(beginning_date, snl.last_date, tau=1440)
+        past_days = Term.steps(beginning_date, snl.today, tau=1440)
         assert snl.score(past_days=past_days, name="Score") == sel_score
         # Selected past days
         snl.score(past_days=60, name="Score")
-        with pytest.raises(ValueError):
-            snl.score(phases=["1st"], past_days=60, name="Score")
 
     @pytest.mark.parametrize("indicator", ["Stringency_index"])
     @pytest.mark.parametrize("target", ["Confirmed"])


### PR DESCRIPTION
## Related issues
#718 and #725

## What was changed
With pull request, we can focus on the values in specified date range with the following arguments. Internally, these arguments are parsed by `PhaseTracker.parse_range()`.

- `dates`: tuple of start date and end date
- `past_days` (integer): how many past days to use in calculation from today (`Scenario.today` property)
- `phases` (list of str): phase names to use in calculation

These arguments are effective with `Scenario.history()`, `Scenario.simulate()`, `Scenario.track()` and `Scenario.score()`.

Regarding #718 and #725, Documentation will be also updated with usage_quick.ipynb.
https://lisphilar.github.io/covid19-sir/usage_quick.html