### PR TITLE
Issue718 scenario with example data

### DIFF
--- a/covsirphy/analysis/example_data.py
+++ b/covsirphy/analysis/example_data.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 from datetime import timedelta
+import numpy as np
 import pandas as pd
 from covsirphy.util.argument import find_args
 from covsirphy.cleaning.jhu_data import JHUData
@@ -109,7 +110,12 @@ class ExampleData(JHUData):
         restored_df[self.PROVINCE] = province
         restored_df[self.C] = restored_df[[self.CI, self.F, self.R]].sum(axis=1)
         selected_df = restored_df.loc[:, self.COLUMNS]
-        self._cleaned_df = pd.concat([self._cleaned_df, selected_df], axis=0, ignore_index=True)
+        cleaned_df = pd.concat([self._cleaned_df, selected_df], axis=0, ignore_index=True)
+        for col in self.AREA_COLUMNS:
+            cleaned_df[col] = cleaned_df[col].astype("category")
+        for col in self.VALUE_COLUMNS:
+            cleaned_df[col] = cleaned_df[col].astype(np.int64)
+        self._cleaned_df = cleaned_df.copy()
 
     def specialized(self, model=None, country=None, province=None):
         """

--- a/covsirphy/analysis/phase_tracker.py
+++ b/covsirphy/analysis/phase_tracker.py
@@ -50,7 +50,9 @@ class PhaseTracker(Term):
         """
         int: the number of registered phases, including deactivated phases
         """
-        return self._track_df[self.ID].nunique() - 1
+        df = self._track_df.copy()
+        df = df.loc[df[self.ID] != 0]
+        return df[self.ID].nunique()
 
     def define_phase(self, start, end):
         """

--- a/covsirphy/ode/sewirf.py
+++ b/covsirphy/ode/sewirf.py
@@ -22,11 +22,11 @@ class SEWIRF(ModelBase):
     # Variable names in (non-dim, dimensional) ODEs
     VAR_DICT = {
         "x1": ModelBase.S,
+        "x2": ModelBase.E,
+        "x3": ModelBase.W,
         "y": ModelBase.CI,
         "z": ModelBase.R,
         "w": ModelBase.F,
-        "x2": ModelBase.E,
-        "x3": ModelBase.W,
     }
     VARIABLES = list(VAR_DICT.values())
     # Weights of variables in parameter estimation error function

--- a/tests/test_deprecated/test_param_tracker.py
+++ b/tests/test_deprecated/test_param_tracker.py
@@ -6,8 +6,6 @@ import warnings
 import pytest
 from covsirphy import SIRF, PhaseSeries, ParamTracker, ModelBase, PhaseUnit
 
-warnings.filterwarnings("ignore", category=DeprecationWarning)
-
 
 @pytest.fixture(scope="module")
 def tracker(jhu_data, population_data):
@@ -20,7 +18,9 @@ def tracker(jhu_data, population_data):
     )
 
 
+@pytest.mark.filterwarnings("ignore", category=DeprecationWarning)
 class TestParamTracker(object):
+
     def test_series(self, tracker):
         assert isinstance(tracker.series, PhaseSeries)
         assert len(tracker) == len(tracker.series)

--- a/tests/test_deprecated/test_phase_series.py
+++ b/tests/test_deprecated/test_phase_series.py
@@ -164,7 +164,6 @@ class TestPhaseSeries(object):
         unit_fol = PhaseUnit(change_date, unit_old.end_date, population)
         unit_fol.set_ode(tau=360)
         series.replaces(phase="1st", new_list=[unit_pre, unit_fol])
-        print(series.unit("1st"), unit_pre)
         assert series.unit("1st") == unit_pre
         assert series.unit("2nd") == unit_fol
         # TypeError of new_list

--- a/tests/test_deprecated/test_phase_series.py
+++ b/tests/test_deprecated/test_phase_series.py
@@ -9,6 +9,7 @@ from covsirphy import Term, PhaseUnit, SIR
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
+@pytest.mark.filterwarnings("ignore", category=DeprecationWarning)
 class TestPhaseSeries(object):
 
     @pytest.mark.parametrize("country", ["Japan"])

--- a/tests/test_deprecated/test_phase_unit.py
+++ b/tests/test_deprecated/test_phase_unit.py
@@ -9,6 +9,7 @@ from covsirphy import Term, SIR, Estimator, UnExecutedError
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
+@pytest.mark.filterwarnings("ignore", category=DeprecationWarning)
 class TestPhaseUnit(object):
     def test_start(self):
         unit = PhaseUnit("01Jan2020", "01Feb2020", 1000)

--- a/tests/test_deprecated/test_policy_measures.py
+++ b/tests/test_deprecated/test_policy_measures.py
@@ -10,6 +10,7 @@ from covsirphy import SIRF, Scenario
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
 
+@pytest.mark.filterwarnings("ignore", category=DeprecationWarning)
 class UnTestPolicyMeasures(object):
     # Skip this test at this time
     def test_start(self, jhu_data, population_data, oxcgrt_data):

--- a/tests/test_example_data.py
+++ b/tests/test_example_data.py
@@ -3,7 +3,8 @@
 
 from covsirphy.util.term import Term
 import pytest
-from covsirphy import ExampleData, SIRF
+from covsirphy import ExampleData, PopulationData, Scenario
+from covsirphy import SIR, SIRD, SIRF, SEWIRF
 
 
 class TestExampleData(object):
@@ -14,27 +15,95 @@ class TestExampleData(object):
         example_data.add(SIRF, country="Moon")
         assert example_data.country_to_iso3("Moon") == "---"
 
-    def test_one_phase(self):
+    @pytest.mark.parametrize("model", [SIR, SIRD, SIRF, SEWIRF])
+    def test_one_phase(self, model):
         example_data = ExampleData()
-        example_data.add(SIRF)
+        example_data.add(model)
         with pytest.raises(ValueError):
             example_data.subset()
         # Subset
-        subset_df = example_data.subset(model=SIRF)
+        subset_df = example_data.subset(model=model)
         assert subset_df.columns.tolist() == Term.SUB_COLUMNS
-        example_data.subset(country=SIRF.NAME)
-        example_data.subset_complement(model=SIRF)
-        example_data.records(model=SIRF)
+        example_data.subset(country=model.NAME)
+        example_data.subset_complement(model=model)
+        example_data.records(model=model)
         # Specialized
-        specialized_df = example_data.specialized(model=SIRF)
-        assert specialized_df.columns.tolist() == [Term.DATE, *SIRF.VARIABLES]
+        specialized_df = example_data.specialized(model=model)
+        assert specialized_df.columns.tolist() == [Term.DATE, *model.VARIABLES]
         # Non-dimensional
-        nondim_df = example_data.non_dim(model=SIRF)
-        assert nondim_df.columns.tolist() == SIRF.VARIABLES
+        nondim_df = example_data.non_dim(model=model)
+        assert nondim_df.columns.tolist() == model.VARIABLES
         assert round(nondim_df.sum().sum()) == len(nondim_df)
 
-    def test_two_phases(self):
+    @pytest.mark.parametrize("model", [SIR, SIRD, SIRF, SEWIRF])
+    def test_two_phases(self, model):
         example_data = ExampleData()
-        example_data.add(SIRF)
-        example_data.add(SIRF)
-        example_data.subset(model=SIRF)
+        example_data.add(model)
+        example_data.add(model)
+        example_data.subset(model=model)
+
+    @pytest.mark.parametrize("model", [SIR, SIRD, SIRF])
+    def test_r0(self, model):
+        eg_dict = model.EXAMPLE.copy()
+        # Calculate r0
+        model_ins = model(eg_dict["population"], **eg_dict["param_dict"])
+        eg_r0 = model_ins.calc_r0()
+        # Set-up example dataset (from 01Jan2020 to 31Jan2020)
+        area = {"country": "Theoretical"}
+        example_data = ExampleData(tau=1440, start_date="01Jan2020")
+        example_data.add(model, step_n=180, **area)
+        # Check the nature of r0
+        df = example_data.specialized(model, **area)
+        x_max = df.loc[df[Term.CI].idxmax(), Term.S] / eg_dict["population"]
+        assert round(x_max, 2) == round(1 / eg_r0, 2)
+
+    def test_scenario(self):
+        area = {"country": "Theoretical"}
+        # Set-up example dataset (from 01Jan2020 to 31Jan2020)
+        example_data = ExampleData(tau=1440, start_date="01Jan2020")
+        example_data.add(SIRF, step_n=30, **area)
+        # Population value
+        population_data = PopulationData(filename=None)
+        population_data.update(SIRF.EXAMPLE["population"], **area)
+        # Set-up Scenario instance
+        snl = Scenario(tau=1440, **area)
+        snl.register(example_data, population_data)
+        # Check records
+        record_df = snl.records(variables="CFR")
+        assert set(record_df.columns) == set([Term.DATE, Term.C, Term.F, Term.R])
+        # Add a past phase to 31Jan2020 with parameter values
+        snl.add(model=SIRF, **SIRF.EXAMPLE["param_dict"])
+        # Check summary
+        df = snl.summary()
+        assert not df.empty
+        assert len(df) == 1
+        assert Term.RT in df
+        # Main scenario
+        snl.add(end_date="31Dec2020", name="Main")
+        assert snl.get(Term.RT, phase="last", name="Main") == 2.50
+        # Lockdown scenario
+        snl.clear(name="Lockdown")
+        rho_lock = snl.get("rho", phase="0th") * 0.5
+        snl.add(end_date="31Dec2020", name="Lockdown", rho=rho_lock)
+        assert snl.get(Term.RT, phase="last", name="Lockdown") == 1.25
+        # Medicine scenario
+        snl.clear(name="Medicine")
+        kappa_med = snl.get("kappa", phase="0th") * 0.5
+        sigma_med = snl.get("sigma", phase="0th") * 2
+        snl.add(end_date="31Dec2020", name="Medicine", kappa=kappa_med, sigma=sigma_med)
+        assert snl.get(Term.RT, phase="last", name="Medicine") == 1.31
+        # Add vaccine scenario
+        snl.clear(name="Vaccine")
+        rho_vac = snl.get("rho", phase="0th") * 0.8
+        kappa_vac = snl.get("kappa", phase="0th") * 0.6
+        sigma_vac = snl.get("sigma", phase="0th") * 1.2
+        snl.add(end_date="31Dec2020", name="Vaccine", rho=rho_vac, kappa=kappa_vac, sigma=sigma_vac)
+        assert snl.get(Term.RT, phase="last", name="Vaccine") == 1.72
+        # Description
+        snl.describe()
+        # History
+        snl.history("Rt")
+        snl.history("rho")
+        snl.history("Infected")
+        snl.history_rate(name="Medicine")
+        snl.simulate(name="Vaccine")


### PR DESCRIPTION
## Related issues
#718

## What was changed
Fix some bugs related to #718.
- `Scenario.add()` did not work when we used `ExampleData` as `JHUData`
- Unexpected dtype (expected: `np.int64`, un-expected: `object`) was returend by `ExampleData.subset()`
- The order of variables defined by `SEWIRF.VARIBLES` was not S/E/W/I/R/F. S/I/R/F/E/W was returned.