### PR TITLE
Issue718 retrospective

### DIFF
--- a/covsirphy/analysis/phase_tracker.py
+++ b/covsirphy/analysis/phase_tracker.py
@@ -194,7 +194,7 @@ class PhaseTracker(Term):
         # Calculate phase types: Past or Future
         df[self.TENSE] = (df[self.START] <= self._today).map({True: self.PAST, False: self.FUTURE})
         # Calculate population values
-        df[self.N] = df[[self.S, self.C]].sum(axis=1).replace(0.0, np.nan).ffill()
+        df[self.N] = df[[self.S, self.C]].sum(axis=1).replace(0.0, np.nan).ffill().astype(np.int64)
         # Fill in blanks of ODE model name and tau
         if self.ODE in df:
             df[self.ODE] = df[self.ODE].ffill()

--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -749,10 +749,14 @@ class Scenario(Term):
             raise ValueError(
                 "@tau must be specified when scenario = Scenario(), and cannot be specified here.")
         if phases is not None:
-            start, end = tracker.parse_range(phases=phases)
-            tracker.deactivate(start, end)
+            df = tracker.summary()
+            all_phases = df.loc[df[self.TENSE] == self.PAST].index.tolist()
+            self.disable(phases=all_phases, name=name)
+            self.enable(phases, name=name)
         self._model = self._ensure_subclass(model, ModelBase, name="model")
         self._tau = tracker.estimate(self._model, tau=self._tau, **kwargs)
+        if phases is not None:
+            self.enable(phases=all_phases, name=name)
         self[name] = tracker
 
     @deprecate("Scenario.phase_estimator()", version="2.19.1-delta-fu1")
@@ -1130,7 +1134,7 @@ class Scenario(Term):
         phases_changed = df.loc[df[self.START] >= pd.to_datetime(beginning_date)].index.tolist()
         self.delete(phases=phases_changed, name=target)
         self.add(name=target, **param_dict)
-        self.estimate(model, name=target, **kwargs)
+        self.estimate(model, phases=[phases_changed[0]], name=target, **kwargs)
 
     def score(self, variables=None, name="Main", **kwargs):
         """


### PR DESCRIPTION
## Related issues
#718

## What was changed
Bug fix related to #718 updating.
- When we future phases, population values were float values, not integers, in summary.
- In retrospective study, parameter estimation was done for all phases. This should be done in the phases which start after the beginning date.