### PR TITLE
Issue741

### DIFF
--- a/covsirphy/__version__.py
+++ b/covsirphy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = "2.19.1-iota-fu1"
+__version__ = "2.19.1-kappa"

--- a/covsirphy/util/filer.py
+++ b/covsirphy/util/filer.py
@@ -22,6 +22,8 @@ class Filer(object):
         {"filename": "<absolute path>/output/jpn_01_records.png"}
         >>> filer.jpg("records")
         {"filename": "<absolute path>/output/jpn_01_records.jpg"}
+        >>> filer.json("backup")
+        {"filename": "<absolute path>/output/jpn_01_backup.json"}
         >>> filer.csv("records", index=True)
         {"path_or_buf": "<absolute path>/output/jpn_01_records.csv", index: True}
     """
@@ -72,7 +74,7 @@ class Filer(object):
             list[str]: list of files
         """
         if ext is None:
-            return [file for (ext, filenames) in self._file_dict.items() for file in filenames]
+            return [file for filenames in self._file_dict.values() for file in filenames]
         return self._file_dict.get(ext, [])
 
     def png(self, title, **kwargs):
@@ -101,6 +103,20 @@ class Filer(object):
             dict[str, str]: absolute filename (key: 'filename') and kwargs
         """
         filename = self._register(title=title, ext="jpg")
+        return {"filename": filename, **kwargs}
+
+    def json(self, title, **kwargs):
+        """
+        Create JSON filename and register it.
+
+        Args:
+            title (str): title of the filename, like 'records'
+            kwargs: keyword arguments to be included in the output
+
+        Returns:
+            dict[str, str]: absolute filename (key: 'filename') and kwargs
+        """
+        filename = self._register(title=title, ext="json")
         return {"filename": filename, **kwargs}
 
     def csv(self, title, **kwargs):

--- a/example/scenario_analysis.py
+++ b/example/scenario_analysis.py
@@ -45,12 +45,22 @@ def main(country="Italy", province=None, file_prefix="ita"):
     # Show records
     record_df = snl.records(**filer.png("records"))
     record_df.to_csv(**filer.csv("records", index=False))
-    # Show S-R trend
-    snl.trend(**filer.png("trend"))
-    print(snl.summary())
-    # Parameter estimation
-    snl.estimate(cs.SIRF)
-    snl.estimate_accuracy("10th", name="Main", **filer.png("estimate_accuracy"))
+    # Load information if available
+    backupfile_dict = filer.json("backup")
+    if Path(backupfile_dict["filename"]).exists():
+        # Restore phase setting (Main scenario)
+        print("Restore phase settings of Main scenario with backup JSON file.")
+        snl.restore(**backupfile_dict)
+    else:
+        # S-R trend analysis
+        snl.trend(**filer.png("trend"))
+        print(snl.summary())
+        # Parameter estimation
+        snl.estimate(cs.SIRF)
+        snl.estimate_accuracy("10th", name="Main", **filer.png("estimate_accuracy"))
+        # Backup
+        snl.backup(**backupfile_dict)
+    print(snl.summary(columns=["Type", "Start", "End", "Population", "Rt"]))
     # Score of parameter estimation
     metrics = ["MAE", "MSE", "MSLE", "RMSE", "RMSLE"]
     for metric in metrics:

--- a/example/scenario_analysis.py
+++ b/example/scenario_analysis.py
@@ -25,7 +25,7 @@ def main(country="Italy", province=None, file_prefix="ita"):
         pronvince (str or None): province name or None (country level)
         file_prefix (str): prefix of the filenames
     """
-    # This script works with version >= 2.18.0-beta
+    # This script works with version >= 2.19.1-kappa
     print(cs.get_version())
     # Create output directory in example directory
     code_path = Path(__file__)

--- a/example/usage_quick.ipynb
+++ b/example/usage_quick.ipynb
@@ -226,7 +226,7 @@
     "\n",
     "From development version 2.19.1-kappa, we have `Scenario.backup(filename)` and `Scenario.restore(filename)` to backup/restore timepoints and phase information. This will be helpful when we perform parameter estimation using a server and simulate with the estimated parameter values using local machines.  \n",
     "\n",
-    "Note that we need to execute `Scenario.register()` to set timepoints in advance."
+    "Note that we need to execute `Scenario.register()` in advance to set timepoints with `Scenario.restore()`."
    ],
    "cell_type": "markdown",
    "metadata": {}

--- a/example/usage_quick.ipynb
+++ b/example/usage_quick.ipynb
@@ -221,6 +221,60 @@
    ]
   },
   {
+   "source": [
+    "#### Backup/restore scenario\n",
+    "\n",
+    "From development version 2.19.1-kappa, we have `Scenario.backup(filename)` and `Scenario.restore(filename)` to backup/restore timepoints and phase information. This will be helpful when we perform parameter estimation using a server and simulate with the estimated parameter values using local machines.  \n",
+    "\n",
+    "Note that we need to execute `Scenario.register()` to set timepoints in advance."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "source": [
+    "Backup information:"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# backupfile_dict = cs.Filer(directory=\"output\")\n",
+    "# snl.backup(**backupfile_dict)"
+   ]
+  },
+  {
+   "source": [
+    "Restore information:"
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# backupfile_dict = cs.Filer(directory=\"output\")\n",
+    "# snl = cs.Scenario(country=\"Japan\")\n",
+    "# snl.register(jhu_data, population_data)\n",
+    "# snl.restore(**backupfile_dict).summary()"
+   ]
+  },
+  {
+   "source": [
+    "After restoring information, we can skip `Scenario.trend()` and `Scenario.estiate()` (their functionarities will be explaiend later)."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -22,11 +22,13 @@ class TestFiler(object):
         # Create filenames
         filer.png("records")
         filer.jpg("records")
+        filer.json("records")
         filer.csv("records", index=True)
         # Check files
-        assert len(filer.files(ext=None)) == 3
+        assert len(filer.files(ext=None)) == 4
         assert len(filer.files(ext="png")) == 1
         assert len(filer.files(ext="jpg")) == 1
+        assert len(filer.files(ext="json")) == 1
         assert len(filer.files(ext="csv")) == 1
         # Save CSV file
         warnings.filterwarnings("ignore", category=DeprecationWarning)


### PR DESCRIPTION
## Related issues
#741

## What was changed
We will have `Scenario.backup(filename)` and `Scenario.restore(filename)` to backup/restore timepoints and phase information.

Backup information:
```Python
backupfile_dict = cs.Filer(directory="output")
snl.backup(**backupfile_dict)
```

Restore information:
```Python
backupfile_dict = cs.Filer(directory="output")
snl = cs.Scenario(country="Japan")
snl.register(jhu_data, population_data)
snl.restore(**backupfile_dict).summary()
```

Note that we need to execute `Scenario.register()` in advance to set timepoints with `Scenario.restore()`. After restoring information, we can skip `Scenario.trend()` and `Scenario.estiate()`.

Documentation: https://lisphilar.github.io/covid19-sir/usage_quick.html#Start-scenario-analysis