### PR TITLE
Issue803

### DIFF
--- a/covsirphy/regression/param_decision_tree.py
+++ b/covsirphy/regression/param_decision_tree.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from math import log10, floor
 import warnings
-import numpy as np
 import pandas as pd
 from sklearn.decomposition import PCA
 from sklearn.exceptions import ConvergenceWarning
@@ -71,20 +69,3 @@ class _ParamDecisionTreeRegressor(_RegressorBase):
             "coef": pd.DataFrame(),
         }
         self._param.update(param_dict)
-
-    def predict(self):
-        """
-        Predict parameter values (via y) with self._regressor and X_target.
-
-        Returns:
-            pandas.DataFrame:
-                Index
-                    Date (pandas.Timestamp): future dates
-                Columns
-                    (float): parameter values (4 digits)
-        """
-        # Predict parameter values
-        predicted = self._regressor.predict(self._X_target)
-        df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
-        # parameter values: 4 digits
-        return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))

--- a/covsirphy/regression/param_elastic_net.py
+++ b/covsirphy/regression/param_elastic_net.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from math import log10, floor
 import warnings
-import numpy as np
 import pandas as pd
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.linear_model import MultiTaskElasticNetCV
@@ -78,20 +76,3 @@ class _ParamElasticNetRegressor(_RegressorBase):
             "coef": intercept_df,
         }
         self._param.update(param_dict)
-
-    def predict(self):
-        """
-        Predict parameter values (via y) with self._regressor and X_target.
-
-        Returns:
-            pandas.DataFrame:
-                Index
-                    Date (pandas.Timestamp): future dates
-                Columns
-                    (float): parameter values (4 digits)
-        """
-        # Predict parameter values
-        predicted = self._regressor.predict(self._X_target)
-        df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
-        # parameter values: 4 digits
-        return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))

--- a/covsirphy/regression/param_svr.py
+++ b/covsirphy/regression/param_svr.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from math import log10, floor
+import warnings
+import numpy as np
+import pandas as pd
+from sklearn.exceptions import ConvergenceWarning
+from sklearn.model_selection import GridSearchCV
+from sklearn.multioutput import MultiOutputRegressor
+from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MinMaxScaler
+from sklearn.svm import SVR
+from covsirphy.regression.regbase import _RegressorBase
+
+
+class _ParamSVRegressor(_RegressorBase):
+    """
+    Predict parameter values of ODE models with epsilon-supprot vector regressor.
+
+    Args:
+        X (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float): indicators
+        y (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float) target values
+        delay (int): delay period [days]
+        kwargs: keyword arguments of sklearn.model_selection.train_test_split()
+
+    Note:
+        If @seed is included in kwargs, this will be converted to @random_state.
+
+    Note:
+        default values regarding sklearn.model_selection.train_test_split() are
+        test_size=0.2, random_state=0, shuffle=False.
+    """
+    # Description of regressor
+    DESC = "Indicators -> Parameters with Epsilon-Supprot Vector Regressor"
+
+    def __init__(self, X, y, delay, **kwargs):
+        super().__init__(X, y, delay, **kwargs)
+
+    def _fit(self):
+        """
+        Fit regression model with training dataset, update self._regressor and self._param.
+        """
+        warnings.simplefilter("ignore", category=ConvergenceWarning)
+        # Paramters of the steps
+        param_grid = {
+            "regressor__estimator__kernel": ["linear", "rbf"],
+            "regressor__estimator__C": [1, 10, 100],
+            "regressor__estimator__gamma": [0.01, 0.1],
+            "regressor__estimator__epsilon": [0.001, 0.01, 0.02, 0.05],
+        }
+        # Fit with pipeline
+        steps = [
+            ("scaler", MinMaxScaler()),
+            ("regressor", MultiOutputRegressor(SVR())),
+        ]
+        pipeline = GridSearchCV(Pipeline(steps=steps), param_grid, n_jobs=-1, cv=5)
+        pipeline.fit(self._X_train, self._y_train)
+        # Update regressor
+        self._regressor = pipeline
+        # Update param
+        estimators = pipeline.best_estimator_.named_steps.regressor.estimators_
+        param_dict = {
+            **{k: type(v) for (k, v) in steps},
+            "kernel": [output.kernel for output in estimators],
+            "C": [output.C for output in estimators],
+            "gamma": [output.gamma for output in estimators],
+            "epsilon": [output.epsilon for output in estimators],
+            "intercept": pd.DataFrame(),
+            "coef": pd.DataFrame(),
+        }
+        self._param.update(param_dict)
+
+    def predict(self):
+        """
+        Predict parameter values (via y) with self._regressor and X_target.
+
+        Returns:
+            pandas.DataFrame:
+                Index
+                    Date (pandas.Timestamp): future dates
+                Columns
+                    (float): parameter values (4 digits)
+        """
+        # Predict parameter values
+        predicted = self._regressor.predict(self._X_target)
+        df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
+        # parameter values: 4 digits
+        return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))

--- a/covsirphy/regression/param_svr.py
+++ b/covsirphy/regression/param_svr.py
@@ -6,7 +6,7 @@ import warnings
 import numpy as np
 import pandas as pd
 from sklearn.exceptions import ConvergenceWarning
-from sklearn.model_selection import GridSearchCV
+from sklearn.model_selection import RandomizedSearchCV
 from sklearn.multioutput import MultiOutputRegressor
 from sklearn.pipeline import Pipeline
 from sklearn.preprocessing import MinMaxScaler
@@ -62,7 +62,7 @@ class _ParamSVRegressor(_RegressorBase):
             ("scaler", MinMaxScaler()),
             ("regressor", MultiOutputRegressor(SVR())),
         ]
-        pipeline = GridSearchCV(Pipeline(steps=steps), param_grid, n_jobs=-1, cv=5)
+        pipeline = RandomizedSearchCV(Pipeline(steps=steps), param_grid, n_jobs=-1, cv=5, n_iter=10)
         pipeline.fit(self._X_train, self._y_train)
         # Update regressor
         self._regressor = pipeline

--- a/covsirphy/regression/param_svr.py
+++ b/covsirphy/regression/param_svr.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from math import log10, floor
 import warnings
-import numpy as np
 import pandas as pd
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import RandomizedSearchCV
@@ -78,20 +76,3 @@ class _ParamSVRegressor(_RegressorBase):
             "coef": pd.DataFrame(),
         }
         self._param.update(param_dict)
-
-    def predict(self):
-        """
-        Predict parameter values (via y) with self._regressor and X_target.
-
-        Returns:
-            pandas.DataFrame:
-                Index
-                    Date (pandas.Timestamp): future dates
-                Columns
-                    (float): parameter values (4 digits)
-        """
-        # Predict parameter values
-        predicted = self._regressor.predict(self._X_target)
-        df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
-        # parameter values: 4 digits
-        return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))

--- a/covsirphy/regression/rate_svr.py
+++ b/covsirphy/regression/rate_svr.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+from covsirphy.regression.param_svr import _ParamSVRegressor
+from covsirphy.regression.rate_elastic_net import _RateElasticNetRegressor
+
+
+class _RateSVRegressor(_ParamSVRegressor, _RateElasticNetRegressor):
+    """
+    Predict parameter values of ODE models with epsilon-support vector regressor,
+    and Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) approach.
+
+    Args:
+        X (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float): indicators
+        y (pandas.DataFrame):
+            Index
+                Date (pandas.Timestamp): observation date
+            Columns
+                (int/float) target values
+        delay (int): delay period [days]
+        kwargs: keyword arguments of sklearn.model_selection.train_test_split()
+
+    Note:
+        If @seed is included in kwargs, this will be converted to @random_state.
+
+    Note:
+        default values regarding sklearn.model_selection.train_test_split() are
+        test_size=0.2, random_state=0, shuffle=False.
+    """
+    # Description of regressor
+    DESC = "Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) with Epsilon-Support Vecter Regressor"
+
+    def __init__(self, X, y, delay, **kwargs):
+        _RateElasticNetRegressor.__init__(self, X, y, delay, **kwargs)
+
+    def predict(self):
+        """
+        Predict parameter values (via y) with self._regressor and X_target.
+
+        Returns:
+            pandas.DataFrame:
+                Index
+                    Date (pandas.Timestamp): future dates
+                Columns
+                    (float): parameter values (4 digits)
+        """
+        return _RateElasticNetRegressor.predict(self)

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -7,8 +7,10 @@ from covsirphy.util.term import Term
 from covsirphy.ode.mbase import ModelBase
 from covsirphy.regression.param_elastic_net import _ParamElasticNetRegressor
 from covsirphy.regression.param_decision_tree import _ParamDecisionTreeRegressor
+from covsirphy.regression.param_svr import _ParamSVRegressor
 from covsirphy.regression.rate_elastic_net import _RateElasticNetRegressor
 from covsirphy.regression.rate_decision_tree import _RateDecisionTreeRegressor
+from covsirphy.regression.rate_svr import _RateSVRegressor
 
 
 class RegressionHandler(Term):
@@ -76,15 +78,19 @@ class RegressionHandler(Term):
             All regressors are here.
             - Indicators -> Parameters with Elastic Net
             - Indicators -> Parameters with Decision Tree Regressor
+            - Indicators -> Parameters with Epsilon-Supprot Vector Regressor
             - Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) with Elastic Net
             - Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) with Decision Tree Regressor
+            - Indicators(n)/Indicators(n-1) -> Parameters(n)/Parameters(n-1) with Epsilon-Supprot Vector Regressor
         """
         # All approaches
         regressors = [
             _ParamElasticNetRegressor,
             _ParamDecisionTreeRegressor,
+            _ParamSVRegressor,
             _RateElasticNetRegressor,
             _RateDecisionTreeRegressor,
+            _RateSVRegressor,
         ]
         approach_dict = {
             (reg.DESC, delay): self._fit_param_reg(reg, delay)

--- a/covsirphy/regression/regbase.py
+++ b/covsirphy/regression/regbase.py
@@ -2,6 +2,8 @@
 # -*- coding: utf-8 -*-
 
 from datetime import timedelta
+from math import log10, floor
+import numpy as np
 import pandas as pd
 from sklearn.model_selection import train_test_split
 from covsirphy.util.argument import find_args
@@ -147,13 +149,16 @@ class _RegressorBase(Term):
     def predict(self):
         """
         Predict parameter values (via y) with self._regressor and X_target.
-        This method should be overwritten by child classes.
 
         Returns:
             pandas.DataFrame:
                 Index
                     Date (pandas.Timestamp): future dates
                 Columns
-                    (float): parameter values
+                    (float): parameter values (4 digits)
         """
-        raise NotImplementedError
+        # Predict parameter values
+        predicted = self._regressor.predict(self._X_target)
+        df = pd.DataFrame(predicted, index=self._X_target.index, columns=self._y_train.columns)
+        # parameter values: 4 digits
+        return df.applymap(lambda x: np.around(x, 4 - int(floor(log10(abs(x)))) - 1))


### PR DESCRIPTION
## Related issues
#803

## What was changed
- use SVR (Epsilon-support vector regressor) as a candidate of regressors in forecasting.
- use `RandomizedSearchCV(n_iter=10)` (not `GridSearchCV`) to select hyperparameter of SVR quickly.