### PR TITLE
update: use min-max scaler just before PCA

### DIFF
--- a/covsirphy/__version__.py
+++ b/covsirphy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = "2.20.3-alpha"
+__version__ = "2.20.3-beta"

--- a/covsirphy/regression/param_decision_tree.py
+++ b/covsirphy/regression/param_decision_tree.py
@@ -7,6 +7,7 @@ from sklearn.decomposition import PCA
 from sklearn.exceptions import ConvergenceWarning
 from sklearn.model_selection import GridSearchCV, TimeSeriesSplit
 from sklearn.pipeline import Pipeline
+from sklearn.preprocessing import MinMaxScaler
 from sklearn.tree import DecisionTreeRegressor
 from covsirphy.regression.regbase import _RegressorBase
 
@@ -50,10 +51,11 @@ class _ParamDecisionTreeRegressor(_RegressorBase):
         # Paramters of the steps
         param_grid = {
             "pca__n_components": [0.3, 0.5, 0.7, 0.9],
-            "regressor__max_depth": [3, 5, 7, 9],
+            "regressor__max_depth": list(range(1, 10)),
         }
         # Fit with pipeline
         steps = [
+            ("scaler", MinMaxScaler()),
             ("pca", PCA(random_state=0)),
             ("regressor", DecisionTreeRegressor(random_state=0)),
         ]


### PR DESCRIPTION
## Related issues
#813

## What was changed
- Use `regressor__max_depth": list(range(1, 10))` as the grid of max depth of decision tree regressor
- Use min-max scaler just before PCA and decision tree regrression