### PR TITLE
update: remove bfill() in X

### DIFF
--- a/covsirphy/__version__.py
+++ b/covsirphy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = "2.20.3-zeta"
+__version__ = "2.20.3-eta"

--- a/covsirphy/regression/regbase.py
+++ b/covsirphy/regression/regbase.py
@@ -83,7 +83,7 @@ class _RegressorBase(Term):
         X_delayed = X.copy()
         for delay in delay_values:
             X_delayed = X_delayed.join(X.shift(delay, freq="D"), how="outer", rsuffix=f"_{delay}")
-        X_delayed = X_delayed.ffill().bfill()
+        X_delayed = X_delayed.ffill()
         # Training/test data
         df = X_delayed.join(y, how="inner").dropna().drop_duplicates()
         X_arranged = df.loc[:, X_delayed.columns]


### PR DESCRIPTION
## Related issues
#813

## What was changed
In `RegressorBase._split()`, backword filling (`pandas.DataFrame.bfill()`) was done with delayed indicator values to keep the number of train/test data. 
```Python
X_delayed = X.copy()
for delay in delay_values:
    X_delayed = X_delayed.join(X.shift(delay, freq="D"), how="outer", rsuffix=f"_{delay}")
X_delayed = X_delayed.ffill().bfill()
```
However, this lead over fitting because un-existed combination of parameter values and indicators were created. This should be like this.
```Python
X_delayed = X.copy()
for delay in delay_values:
    X_delayed = X_delayed.join(X.shift(delay, freq="D"), how="outer", rsuffix=f"_{delay}")
X_delayed = X_delayed.ffill() # .bfill()
```