### PR TITLE
Issue833 use `timeout_iteration=1` as default with `Scenario.estimate`

### DIFF
--- a/covsirphy/__version__.py
+++ b/covsirphy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = "2.20.3-theta"
+__version__ = "2.20.3-iota"

--- a/covsirphy/ode/param_estimator.py
+++ b/covsirphy/ode/param_estimator.py
@@ -79,7 +79,7 @@ class _ParamEstimator(Term):
             Please refer to covsirphy.Evaluator.score() for metric names.
         """
         timeout = check_dict.get("timeout", 180)
-        timeout_iteration = check_dict.get("timeout_iteration", 5)
+        timeout_iteration = check_dict.get("timeout_iteration", 1)
         tail_n = check_dict.get("tail_n", 4)
         allowance = check_dict.get("allowance", (0.99, 1.01))
         # Initialize optimization

--- a/covsirphy/ode/param_estimator.py
+++ b/covsirphy/ode/param_estimator.py
@@ -3,6 +3,7 @@
 
 import math
 import optuna
+from optuna.samplers import TPESampler
 from covsirphy.util.argument import find_args
 from covsirphy.util.evaluator import Evaluator
 from covsirphy.util.stopwatch import StopWatch
@@ -133,11 +134,11 @@ class _ParamEstimator(Term):
             "threshold": optuna.pruners.ThresholdPruner(upper=upper),
             "percentile": optuna.pruners.PercentilePruner(percentile=percentile),
         }
+        # constant_liar argument can be used from Optuna version 2.8.0
+        sampler_kwargs = {"seed": seed, "constant_liar": False}
+        sampler = TPESampler(find_args(TPESampler, **sampler_kwargs))
         return optuna.create_study(
-            direction="minimize",
-            sampler=optuna.samplers.TPESampler(seed=seed),
-            pruner=pruner_dict[pruner.lower()],
-        )
+            direction="minimize", sampler=sampler, pruner=pruner_dict[pruner.lower()])
 
     def _objective(self, trial):
         """


### PR DESCRIPTION
## Related issues
#833

## What was changed
- Use `Scenario.estimate(<model>, timeout_iteration=1)` as default.
- Use `constant_liar=False` explicitly.