### PR TITLE
Issue795

### DIFF
--- a/covsirphy/analysis/scenario.py
+++ b/covsirphy/analysis/scenario.py
@@ -1253,7 +1253,7 @@ class Scenario(Term):
                 - None: Scenario.estimate_delay() calculate automatically
             removed_cols (list[str] or None): list of variables to remove from X dataset or None (indicators used to estimate delay period)
             metric (str): metric name
-            kwargs: keyword arguments of sklearn.model_selection.train_test_split() and Scenario.fit_accuracy()
+            kwargs: keyword arguments of sklearn.model_selection.train_test_split(), RegressorHandler.fit() and Scenario.fit_accuracy()
 
         Raises:
             covsirphy.UnExecutedError: Scenario.estimate() or Scenario.add() were not performed
@@ -1310,7 +1310,7 @@ class Scenario(Term):
             delay = self._ensure_natural_int(delay, name="delay")
         # Fit regression models
         handler = RegressionHandler(data=data, model=self._model, delay=delay, **kwargs)
-        handler.fit(metric=metric)
+        handler.fit(metric=metric, **find_args(RegressionHandler.fit, **kwargs))
         self._reghandler_dict[name] = handler
         # Accuracy
         self.fit_accuracy(name=name, metric=metric, **kwargs)

--- a/example/usage_quick.ipynb
+++ b/example/usage_quick.ipynb
@@ -790,14 +790,14 @@
    "source": [
     "`Scenario.fit()` method learns the relationship of indicators (X) and the parameter values (y) with regresion models. X was registered with `Scenario.register()` and y was calculated with `Scenario.estimate()` in advance respectively.\n",
     "\n",
-    "Regression models:  \n",
+    "Regression models and abbreviations:  \n",
     "\n",
     "- \"en\": Indicators -> Parameters with Elastic Net\n",
     "- \"dt\": Indicators -> Parameters with Decision Tree Regressor\n",
     "- \"lgbm\": Indicators -> Parameters with Light Gradient Boosting Machine Regressor (Light GBM, from version 2.21.0)\n",
     "- \"svr\": Indicators -> Parameters with Epsilon-Support Vector Regressor (SVR, from version 2.21.0)\n",
     "\n",
-    "From version 2.21.0, we can specify regressors with `regressors` argument of `Scenario.fit()`. When `regreesors=[\"en\", \"svr\"]`, only Elastic Net and SVR will be used. As default, `regressors=None` and uses all registered regressors."
+    "From version 2.21.0, we can specify regressors with `regressors` argument of `Scenario.fit()` and abbreviations. When `regreesors=[\"en\", \"svr\"]`, only Elastic Net and SVR will be used. As default, `regressors=None` and we use all registered regressors."
    ],
    "cell_type": "markdown",
    "metadata": {}

--- a/example/usage_quick.ipynb
+++ b/example/usage_quick.ipynb
@@ -792,10 +792,12 @@
     "\n",
     "Regression models:  \n",
     "\n",
-    "- Indicators -> Parameters with Elastic Net\n",
-    "- Indicators -> Parameters with Decision Tree Regressor\n",
-    "- Indicators -> Parameters with Light Gradient Boosting Machine Regressor (from version 2.21.0)\n",
-    "- Indicators -> Parameters with Epsilon-Support Vector Regressor (from version 2.21.0)"
+    "- \"en\": Indicators -> Parameters with Elastic Net\n",
+    "- \"dt\": Indicators -> Parameters with Decision Tree Regressor\n",
+    "- \"lgbm\": Indicators -> Parameters with Light Gradient Boosting Machine Regressor (Light GBM, from version 2.21.0)\n",
+    "- \"svr\": Indicators -> Parameters with Epsilon-Support Vector Regressor (SVR, from version 2.21.0)\n",
+    "\n",
+    "From version 2.21.0, we can specify regressors with `regressors` argument of `Scenario.fit()`. When `regreesors=[\"en\", \"svr\"]`, only Elastic Net and SVR will be used. As default, `regressors=None` and uses all registered regressors."
    ],
    "cell_type": "markdown",
    "metadata": {}
@@ -837,7 +839,7 @@
     "snl.clear(name=\"Forecast\", template=\"Main\")\n",
     "# Fitting with linear regression model (Elastic Net regression)\n",
     "fit_dict = snl.fit(\n",
-    "    name=\"Forecast\", metric=\"MAPE\",\n",
+    "    name=\"Forecast\", metric=\"MAPE\", regressors=None,\n",
     "    removed_cols=[\"Stringency_index\", \"Tests\", \"Tests_diff\", \"Vaccinations\"]\n",
     ")"
    ]


### PR DESCRIPTION
## Related issues
#795

## What was changed
Users can specify regressors with `regressors` argument of `Scenario.fit()` and abbreviations of regressor names. When `regreesors=["en", "svr"]`, only Elastic Net and SVR will be used. As default, `regressors=None` and we use all registered regressors.

- "en": Indicators -> Parameters with Elastic Net
- "dt": Indicators -> Parameters with Decision Tree Regressor
- "lgbm": Indicators -> Parameters with Light Gradient Boosting Machine Regressor (Light GBM, from version 2.21.0)
- "svr": Indicators -> Parameters with Epsilon-Support Vector Regressor (SVR, from version 2.21.0)