### PR TITLE
Issue842

### DIFF
--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -16,7 +16,7 @@ from covsirphy.util.error import deprecate
 from covsirphy.util.error import SubsetNotFoundError, ScenarioNotFoundError, UnExecutedError
 from covsirphy.util.error import PCRIncorrectPreconditionError, NotInteractiveError, UnExpectedValueError
 from covsirphy.util.error import NotRegisteredMainError, NotRegisteredExtraError
-from covsirphy.util.error import UnExpectedReturnValueError
+from covsirphy.util.error import UnExpectedReturnValueError, NotIncludedError
 from covsirphy.util.filer import save_dataframe
 from covsirphy.util.argument import find_args
 from covsirphy.util.filer import Filer
@@ -101,7 +101,7 @@ __all__ = [
     "SubsetNotFoundError", "ScenarioNotFoundError", "UnExecutedError",
     "PCRIncorrectPreconditionError", "NotInteractiveError",
     "UnExpectedValueError", "NotRegisteredMainError", "NotRegisteredExtraError",
-    "UnExpectedReturnValueError",
+    "UnExpectedReturnValueError", "NotIncludedError",
     # visualization
     "VisualizeBase", "ColoredMap", "LinePlot", "line_plot", "BarPlot", "bar_plot",
     "ComparePlot", "compare_plot", "ScatterPlot", "scatter_plot",

--- a/covsirphy/regression/feature_engineer.py
+++ b/covsirphy/regression/feature_engineer.py
@@ -67,6 +67,15 @@ class _FeatureEngineer(Term):
         data_dict["X_target"] = X.loc[X.index > Y.index.max()]
         return data_dict
 
+    def add_elapsed(self):
+        """
+        Calculate elapsed days from the last change point of indicators and add them as new features.
+        """
+        X, raw = self._X.copy(), self._X_raw.copy()
+        for (name, col) in raw.iteritems():
+            X[f"{name}_elapsed"] = col.groupby((col != col.shift()).cumsum()).cumcount() + 1
+        self._X = X.copy()
+
     def apply_delay(self, delay_values):
         """
         Add delayed indicator values to X.

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -95,6 +95,7 @@ class RegressionHandler(Term):
 
         Note:
             All tools and names are
+            - "elapsed": alculate elapsed days from the last change point of indicators
             - "delay": add delayed (lagged) variables with @delay (must not be None)
         """
         # Delay period
@@ -102,6 +103,7 @@ class RegressionHandler(Term):
             self._delay_candidates = self._convert_delay_value(delay)
         # Tools of feature engineering
         tool_dict = {
+            "elapsed": (self._engineer.add_elapsed, {}),
             "delay": (self._engineer.apply_delay, {"delay_values": self._delay_candidates}),
         }
         all_tools = list(tool_dict.keys())

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -82,16 +82,16 @@ class RegressionHandler(Term):
             return list(range(delay_min, delay_max + 1))
         return [self._ensure_natural_int(delay, name="delay")]
 
-    def feature_engineering(self, tools=None, delay=None):
+    def feature_engineering(self, engineering_tools=None, delay=None):
         """
         Perform feature engineering of X dataset.
 
         Args:
-            tools (list[str]): list of the feature engineering tools or None (all tools)
+            engineering_tools (list[str]): list of the feature engineering tools or None (all tools)
             delay (int or tuple(int, int) or None): exact (or value range of) delay period [days]
 
         Raises:
-            ValueError: @delay is None when @tools is None or 'delay' is included in @tools
+            ValueError: @delay is None when @tools is None or 'delay' is included in @engineering_tools
 
         Note:
             All tools and names are
@@ -99,7 +99,7 @@ class RegressionHandler(Term):
             - "delay": add delayed (lagged) variables with @delay (must not be None)
         """
         # Delay period
-        if tools is None or "delay" in tools:
+        if engineering_tools is None or "delay" in engineering_tools:
             self._delay_candidates = self._convert_delay_value(delay)
         # Tools of feature engineering
         tool_dict = {
@@ -107,7 +107,8 @@ class RegressionHandler(Term):
             "delay": (self._engineer.apply_delay, {"delay_values": self._delay_candidates}),
         }
         all_tools = list(tool_dict.keys())
-        selected_tools = self._ensure_list(tools or all_tools, candidates=all_tools, name="tools")
+        selected_tools = self._ensure_list(
+            engineering_tools or all_tools, candidates=all_tools, name="tools")
         # Perform feature engineering
         for name in selected_tools:
             method, arg_dict = tool_dict[name]

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-from covsirphy.util.error import UnExpectedReturnValueError
+from covsirphy.util.error import UnExpectedReturnValueError, NotIncludedError
 from covsirphy.util.evaluator import Evaluator
 from covsirphy.util.term import Term
 from covsirphy.ode.mbase import ModelBase
@@ -92,15 +92,21 @@ class RegressionHandler(Term):
 
         Raises:
             ValueError: @delay is None when @tools is None or 'delay' is included in @engineering_tools
+            NotIncludedError: @delay was not included in @engineering_tools
 
         Note:
             All tools and names are
             - "elapsed": alculate elapsed days from the last change point of indicators
             - "delay": add delayed (lagged) variables with @delay (must not be None)
+
+        Note:
+            "delay" must be included in the tools because delay is required to create target X.
         """
         # Delay period
         if engineering_tools is None or "delay" in engineering_tools:
             self._delay_candidates = self._convert_delay_value(delay)
+        else:
+            raise NotIncludedError(name="engineering_tools", value="delay")
         # Tools of feature engineering
         tool_dict = {
             "elapsed": (self._engineer.add_elapsed, {}),

--- a/covsirphy/util/error.py
+++ b/covsirphy/util/error.py
@@ -230,3 +230,22 @@ class UnExpectedReturnValueError(ValueError):
 
     def __str__(self):
         return f"Un-expected value{self.s}{self.value} {self.be} returned as {self.name}. {self.message}."
+
+
+class NotIncludedError(ValueError):
+    """
+    Error when an expected value was not included.
+
+    Args:
+        name (str): argument name
+        value (object): value user applied or None (will not be shown)
+        message (str or None): the other messages
+    """
+
+    def __init__(self, name, value, message=None):
+        self.name = str(name)
+        self.value = "" if value is None else f" ({value})"
+        self.message = "" if message is None else f" {message}"
+
+    def __str__(self):
+        return f"Expected value {self.value} was not included in {self.name}. {self.message}."

--- a/tests/test_scenario.py
+++ b/tests/test_scenario.py
@@ -6,6 +6,7 @@ import warnings
 import pytest
 import pandas as pd
 from covsirphy import ScenarioNotFoundError, UnExecutedError, NotInteractiveError
+from covsirphy import NotIncludedError
 from covsirphy import Scenario, Term, PhaseTracker, SIRF, Filer
 
 
@@ -300,6 +301,9 @@ class TestScenario(object):
         max_days = delay_est if days is None else max(days)
         end = pd.to_datetime(snl.today) + timedelta(days=max_days)
         assert pd.to_datetime(df.loc[df.index[-1], Term.END]) == end
+        # Feature engineering
+        with pytest.raises(NotIncludedError):
+            snl.fit(engineering_tools=[])
 
     def test_backup(self, snl, jhu_data, population_data):
         filer = Filer("input")


### PR DESCRIPTION
## Related issues
#842 and #843

## What was changed
- #843: argument `tools` of `Scenario.fit()` (`RegressionHandler.feature_engineering()`) was renamed to `engineering_tools` (default: `None` to use all feature engineering tools) to clarify its role.
- #843: when "delay" is not included in `engineering_tools`, "NotIncludedError` will be raised.
- #842: the number of elasped days from the change points of indicators will be calulated "elapsed" is included in `engineering_tools`.