### PR TITLE
[New] Specify strftime format with CountryData.cleaned(date_format)

### DIFF
--- a/covsirphy/cleaning/country_data.py
+++ b/covsirphy/cleaning/country_data.py
@@ -70,7 +70,7 @@ class CountryData(CleaningBase):
             recovered: self.R
         }
 
-    def _cleaning(self):
+    def _cleaning(self, date_format):
         """
         Perform data cleaning of the raw data.
         This method overwrite super()._cleaning() method.
@@ -87,6 +87,7 @@ class CountryData(CleaningBase):
                     - Infected (int): the number of currently infected cases
                     - Fatal (int): the number of fatal cases
                     - Recovered (int): the number of recovered cases
+            date_format (str or None): the strftime to parse time (e.g. "%d/%m/%Y") or None (automated)
         """
         if not self.var_dict:
             raise UnExecutedError("CountryData.set_variables()")
@@ -112,7 +113,7 @@ class CountryData(CleaningBase):
         df[v_cols] = df[v_cols].fillna(0).astype(np.int64)
         df[self.CI] = df[self.C] - df[self.F] - df[self.R]
         # Groupby date and province
-        df[self.DATE] = pd.to_datetime(df[self.DATE]).dt.round("D")
+        df[self.DATE] = pd.to_datetime(df[self.DATE], format=date_format).dt.round("D")
         try:
             df[self.DATE] = df[self.DATE].dt.tz_convert(None)
         except TypeError:
@@ -125,7 +126,7 @@ class CountryData(CleaningBase):
         df[self.AREA_COLUMNS] = df[self.AREA_COLUMNS].astype("category")
         return df
 
-    def cleaned(self):
+    def cleaned(self, date_format=None):
         """
         Return the cleaned dataset.
         Cleaning method is defined by CountryData._cleaning() method.
@@ -142,9 +143,16 @@ class CountryData(CleaningBase):
                     - Infected (int): the number of currently infected cases
                     - Fatal (int): the number of fatal cases
                     - Recovered (int): the number of recovered cases
+            date_format (str or None): the strftime to parse time (e.g. "%d/%m/%Y") or None (automated)
+
+        Note:
+            Please specify @date_format if dates are parsed incorrectly.
+
+        Note:
+            Format codes: refer to https://docs.python.org/3/library/datetime.html#strftime-and-strptime-format-codes
         """
         if self._cleaned_df.empty:
-            self._cleaned_df = self._cleaning()
+            self._cleaned_df = self._cleaning(date_format=date_format)
         return self._cleaned_df
 
     def total(self):

--- a/docs/markdown/INSTALLATION.md
+++ b/docs/markdown/INSTALLATION.md
@@ -178,6 +178,25 @@ country_data.set_variables(
 country_data.cleaned()
 ```
 
+If dates are parsed incorrectly (e.g. the last date of raw dataset was 12Jun2021, but that of cleaned dataset was 06Dec2021), please try the following codes with appropreate date format for a while.
+
+```Python
+import pandas as pd
+# Remove cleaned data with wrong time format
+country_data._cleaned_df = pd.DataFrame()
+# Update raw dataframe with appropreate time format
+country_data.raw["Date"] = pd.to_datetime(country_data.raw["Date"], format="%d/%m/%Y")
+# Data cleaning
+country_data.cleaned()
+```
+
+From development version 2.21.0-delta, we can use the following. This will be implemented at the next stable version 2.22.0.
+
+```Python
+country_data.cleaned(date_format="%d/%m/%Y")
+```
+
+
 ### 3.2. Convert to JHUData instance
 
 Then, convert the `CountryData` instance to a `JHUData` instance.


### PR DESCRIPTION
## Related issues
#856

## What was changed
- Add `CountryData.cleaned(date_format)` argument to specify appropreate date format.
- When `None` (default), `pandas.to_datetime()` will parse date strings automatically.
- When `"%d/%m/%Y"`, date strings will be parsed with this format.
- Update documentation: https://lisphilar.github.io/covid19-sir/markdown/INSTALLATION.html#use-a-local-csv-file-which-has-the-number-of-cases