### PR TITLE
add: log-transformed

### DIFF
--- a/covsirphy/regression/feature_engineer.py
+++ b/covsirphy/regression/feature_engineer.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import numpy as np
 from sklearn.model_selection import train_test_split
 from covsirphy.util.argument import find_args
 from covsirphy.util.term import Term
@@ -76,14 +77,27 @@ class _FeatureEngineer(Term):
             X[f"{name}_elapsed"] = col.groupby((col != col.shift()).cumsum()).cumcount() + 1
         self._X = X.copy()
 
+    def log_transform(self):
+        """
+        Add log-transforemd indeciator values to X as new features.
+        """
+        raw = self._X_raw.copy()
+        selected = raw.loc[:, raw.max(axis=0) >= 1000]
+        converted = np.log10(selected + 1)
+        self._X = self._X.join(converted, rsuffix="_log10")
+
     def apply_delay(self, delay_values):
         """
         Add delayed indicator values to X.
 
         Args:
             delay_values (list[int]): list of delay period [days]
+
+        Note:
+            This will be applied to all indicators, including features created by the other tools.
         """
-        X, raw = self._X.copy(), self._X_raw.copy()
+        X = self._X.copy()
+        X_copy = X.copy()
         for delay in delay_values:
-            X = X.join(raw.shift(delay, freq="D"), how="outer", rsuffix=f"_{delay}")
+            X = X.join(X_copy.shift(delay, freq="D"), how="outer", rsuffix=f"_{delay}")
         self._X = X.ffill()

--- a/covsirphy/regression/reg_handler.py
+++ b/covsirphy/regression/reg_handler.py
@@ -97,10 +97,14 @@ class RegressionHandler(Term):
         Note:
             All tools and names are
             - "elapsed": alculate elapsed days from the last change point of indicators
+            - "log": add log-transforemd indeciator values
             - "delay": add delayed (lagged) variables with @delay (must not be None)
 
         Note:
             "delay" must be included in the tools because delay is required to create target X.
+
+        Note:
+            "delay" will be applied to all indicators, including features created by the other tools.
         """
         # Delay period
         if engineering_tools is None or "delay" in engineering_tools:
@@ -110,6 +114,7 @@ class RegressionHandler(Term):
         # Tools of feature engineering
         tool_dict = {
             "elapsed": (self._engineer.add_elapsed, {}),
+            "log": (self._engineer.log_transform, {}),
             "delay": (self._engineer.apply_delay, {"delay_values": self._delay_candidates}),
         }
         all_tools = list(tool_dict.keys())


### PR DESCRIPTION
## Related issues
#842 and #860

## What was changed
- Close #860 
- #842: Because "delay" is necessary to create X_target, delay period should be applied to all indicators, including features created by the other tools.