### PR TITLE
Issue851 lock OWID coutry level vaccine data

### DIFF
--- a/covsirphy/cleaning/cbase.py
+++ b/covsirphy/cleaning/cbase.py
@@ -466,9 +466,12 @@ class CleaningBase(Term):
         df = df.loc[df[self.COUNTRY] != self.OTHERS]
         # Recognize province as a region/country
         if self.PROVINCE in df:
-            df[self.ISO3] = df[self.ISO3].cat.add_categories(["GRL"])
-            df[self.COUNTRY] = df[self.COUNTRY].cat.add_categories(["Greenland"])
-            df.loc[df[self.PROVINCE] == "Greenland", self.AREA_ABBR_COLS] = ["GRL", "Greenland", self.UNKNOWN]
+            try:
+                df[self.ISO3] = df[self.ISO3].cat.add_categories(["GRL"])
+                df[self.COUNTRY] = df[self.COUNTRY].cat.add_categories(["Greenland"])
+                df.loc[df[self.PROVINCE] == "Greenland", self.AREA_ABBR_COLS] = ["GRL", "Greenland", self.UNKNOWN]
+            except ValueError:
+                pass
         # Select country level data
         if self.PROVINCE in df.columns:
             df = df.loc[df[self.PROVINCE] == self.UNKNOWN]

--- a/covsirphy/cleaning/population.py
+++ b/covsirphy/cleaning/population.py
@@ -72,7 +72,7 @@ class PopulationData(CleaningBase):
         df[self.DATE] = pd.to_datetime(df[self.DATE])
         # Province
         df[self.PROVINCE] = df[self.PROVINCE].fillna(self.UNKNOWN)
-        df[self.N] = df[self.N].astype(np.int64)
+        df[self.N] = df[self.N].fillna(0).astype(np.int64)
         # Columns to use
         df = df.loc[:, self.CLEANED_COLS]
         # Remove duplicates

--- a/covsirphy/cleaning/vaccine_data.py
+++ b/covsirphy/cleaning/vaccine_data.py
@@ -233,7 +233,7 @@ class VaccineData(CleaningBase):
         df = df.loc[df[self.COUNTRY] == "World"]
         # Resampling
         df = df.set_index(self.DATE).resample("D").sum()
-        return df.reset_index()
+        return df.reset_index()[self.SUBSET_COLS]
 
     def map(self, country=None, variable="Vaccinations", date=None, **kwargs):
         """

--- a/covsirphy/cleaning/vaccine_data.py
+++ b/covsirphy/cleaning/vaccine_data.py
@@ -53,7 +53,12 @@ class VaccineData(CleaningBase):
 
     def __init__(self, filename=None, data=None, citation=None, **kwargs):
         # Raw data
-        self._raw = self._parse_raw(filename, data, self.RAW_COLS)
+        if data is not None and self.PROVINCE in data:
+            data_c = data.loc[data[self.PROVINCE] == self.UNKNOWN]
+            self._raw = self._parse_raw(filename, data_c, self.RAW_COLS)
+        else:
+            self._raw = self._parse_raw(filename, data, self.RAW_COLS)
+        # Backward compatibility
         if self._raw.empty:
             self._raw = self._retrieve(filename, **kwargs)
         # Data cleaning

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -506,7 +506,7 @@ class DataLoader(Term):
         df, citation_dict = self._auto_lock()
         variables = VaccineData.RAW_COLS[:]
         citations = [c for (v, line) in citation_dict.items() for c in line if v in variables]
-        return VaccineData(data=df, citation="\n".join(citations))
+        return VaccineData(data=df.dropna(), citation="\n".join(citations))
 
     def pyramid(self, **kwargs):
         """

--- a/covsirphy/loading/db_base.py
+++ b/covsirphy/loading/db_base.py
@@ -52,9 +52,14 @@ class _RemoteDatabase(Term):
         """
         # Read local file if available and usable
         if not force and self.filepath.exists():
-            return self._ensure_dataframe(self.read(), columns=self.saved_cols)
+            try:
+                return self._ensure_dataframe(self.read(), columns=self.saved_cols)
+            except Exception:
+                pass
         # Download dataset from server
-        df = self._ensure_dataframe(self.download(verbose=verbose), columns=self.saved_cols)
+        df = self.download(verbose=verbose)
+        df = df.rename(columns=self.col_convert_dict)
+        df = self._ensure_dataframe(df, columns=self.saved_cols)
         df.to_csv(self.filepath, index=False)
         return df
 

--- a/covsirphy/loading/db_base.py
+++ b/covsirphy/loading/db_base.py
@@ -52,10 +52,7 @@ class _RemoteDatabase(Term):
         """
         # Read local file if available and usable
         if not force and self.filepath.exists():
-            try:
-                return self._ensure_dataframe(self.read(), columns=self.saved_cols)
-            except Exception:
-                pass
+            return self._ensure_dataframe(self.read(), columns=self.saved_cols)
         # Download dataset from server
         df = self.download(verbose=verbose)
         df = df.rename(columns=self.col_convert_dict)
@@ -74,7 +71,7 @@ class _RemoteDatabase(Term):
                 Columns
                     defined by .COL_DICT
         """
-        kwargs = {"low_memory": False, "dtype": self.dtype_dict, "header": 0, "usecols": self.saved_cols}
+        kwargs = {"low_memory": False, "header": 0, "usecols": self.saved_cols}
         return pd.read_csv(self.filepath, **kwargs)
 
     def download(self, verbose):

--- a/covsirphy/loading/db_covid19dh.py
+++ b/covsirphy/loading/db_covid19dh.py
@@ -158,10 +158,9 @@ class _COVID19dh(_RemoteDatabase):
             Data types are not confirmed.
         """
         df = raw.copy()
-        # Replace column names
-        df = df.rename(columns=self.col_convert_dict)
+        c, p = "administrative_area_level_1", "administrative_area_level_2"
         # Country
-        df[self.COUNTRY] = df[self.COUNTRY].replace(
+        df[c] = df[c].replace(
             {
                 # COD
                 "Congo, the Democratic Republic of the": "Democratic Republic of the Congo",
@@ -174,5 +173,5 @@ class _COVID19dh(_RemoteDatabase):
         # Set 'Others' as the country name of cruise ships
         ships = ["Diamond Princess", "Costa Atlantica", "Grand Princess", "MS Zaandam"]
         for ship in ships:
-            df.loc[df[self.COUNTRY] == ship, [self.COUNTRY, self.PROVINCE]] = [self.OTHERS, ship]
+            df.loc[df[c] == ship, [c, p]] = [self.OTHERS, ship]
         return df

--- a/covsirphy/loading/db_owid.py
+++ b/covsirphy/loading/db_owid.py
@@ -64,4 +64,10 @@ class _OWID(_RemoteDatabase):
         v_loc_df = pd.read_csv(self.URL_V_LOC, usecols=["location", "vaccines"])
         v_df = v_rec_df.merge(v_loc_df, how="left", on="location")
         v_df[self.PROVINCE] = self.UNKNOWN
+        v_df["location"] = v_df["location"].replace(
+            {
+                # COG
+                "Congo": "Republic of the Congo",
+            }
+        )
         return v_df

--- a/covsirphy/loading/db_owid.py
+++ b/covsirphy/loading/db_owid.py
@@ -56,7 +56,7 @@ class _OWID(_RemoteDatabase):
 
         # Download datasets
         if verbose:
-            print("Retrieving datasets from Our World In Data https://covid19datahub.io/")
+            print("Retrieving datasets from Our World In Data https://github.com/owid/covid-19-data/")
         # Vaccination
         v_rec_cols = [
             "date", "location", "iso_code", "total_vaccinations", "people_vaccinated", "people_fully_vaccinated"]

--- a/covsirphy/loading/db_owid.py
+++ b/covsirphy/loading/db_owid.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import pandas as pd
+from covsirphy.util.term import Term
+from covsirphy.loading.db_base import _RemoteDatabase
+
+
+class _OWID(_RemoteDatabase):
+    """
+    Access "Our World In Data".
+    https://github.com/owid/covid-19-data/tree/master/public/data
+    https://ourworldindata.org/coronavirus
+
+    Args:
+        filename (str): CSV filename to save records
+    """
+    # URL for vaccine data
+    URL_V = "https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/"
+    URL_V_REC = f"{URL_V}vaccinations.csv"
+    URL_V_LOC = f"{URL_V}locations.csv"
+    # Citation
+    CITATION = "Hasell, J., Mathieu, E., Beltekian, D. et al." \
+        " A cross-country database of COVID-19 testing. Sci Data 7, 345 (2020)." \
+        " https://doi.org/10.1038/s41597-020-00688-8"
+    # Column names and data types
+    # {"name in database": ("name defined in Term class", "data type")}
+    COL_DICT = {
+        "date": (Term.DATE, "object"),
+        "location": (Term.COUNTRY, "object"),
+        Term.PROVINCE: (Term.PROVINCE, "object"),
+        "iso_code": (Term.ISO3, "object"),
+        "vaccines": (Term.PRODUCT, "object"),
+        "total_vaccinations": (Term.VAC, "int"),
+        "people_vaccinated": (Term.V_ONCE, "int"),
+        "people_fully_vaccinated": (Term.V_FULL, "int"),
+    }
+
+    def download(self, verbose):
+        """
+        Download the dataset from the server and set the list of primary sources.
+
+        Args:
+            verbose (int): level of verbosity
+
+        Returns:
+            pandas.DataFrame
+                Index
+                    reset index
+                Columns
+                    defined by the first values of self.COL_DICT.values()
+
+        Note:
+            If @verbose is equal to or over 1, how to show the list will be explained.
+        """
+
+        # Download datasets
+        if verbose:
+            print("Retrieving datasets from Our World In Data https://covid19datahub.io/")
+        # Vaccination
+        v_rec_cols = [
+            "date", "location", "iso_code", "total_vaccinations", "people_vaccinated", "people_fully_vaccinated"]
+        v_rec_df = pd.read_csv(self.URL_V_REC, usecols=v_rec_cols)
+        v_loc_df = pd.read_csv(self.URL_V_LOC, usecols=["location", "vaccines"])
+        v_df = v_rec_df.merge(v_loc_df, how="left", on="location")
+        v_df[self.PROVINCE] = self.UNKNOWN
+        return v_df


### PR DESCRIPTION
## Related issues
#851

## What was changed
Lock "Our World In Data" vaccine dataset before calling `DataLoader.vaccine()` as well as "COVID-19 Data Hub" data. This was required to use local datasets at country level with `VaccineData`.

Not included in this pull request:
- `VaccineData` parses province level data
- Lock PCR data before calling `DataLoader.pcr()`