### PR TITLE
Issue851 lock PCR data from OWID

### DIFF
--- a/covsirphy/__version__.py
+++ b/covsirphy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = "2.21.0-iota-fu3"
+__version__ = "2.21.0-iota-fu4"

--- a/covsirphy/cleaning/pcr_data.py
+++ b/covsirphy/cleaning/pcr_data.py
@@ -93,15 +93,15 @@ class PCRData(CleaningBase):
                     - Confirmed (int): the number of confirmed cases
         """
         df = self._raw.copy()
+        df = df.loc[:, self.CLEANED_COLS].reset_index(drop=True)
         # Datetime columns
         df[self.DATE] = pd.to_datetime(df[self.DATE])
         # Province
         df[self.PROVINCE] = df[self.PROVINCE].fillna(self.UNKNOWN)
         # Values
-        df = df.ffill().fillna(0)
-        df[self.TESTS] = df[self.TESTS].astype(np.int64)
-        df[self.C] = df[self.C].astype(np.int64)
-        df = df.loc[:, self.CLEANED_COLS].reset_index(drop=True)
+        df = df.dropna(subset=[self.TESTS, self.C], how="any")
+        for col in [self.TESTS, self.C]:
+            df[col] = df.groupby([self.COUNTRY, self.PROVINCE])[col].ffill().fillna(0).astype(np.int64)
         # Update data types to reduce memory
         df[self.AREA_ABBR_COLS] = df[self.AREA_ABBR_COLS].astype("category")
         return df

--- a/covsirphy/cleaning/pcr_data.py
+++ b/covsirphy/cleaning/pcr_data.py
@@ -138,6 +138,7 @@ class PCRData(CleaningBase):
 
     def _download_ourworldindata(self, filename):
         """
+        Deprecated, but used for self.use_ourworldindata().
         Download the dataset (ISO code/date/the number of tests) from "Our World In Data" site.
         https://github.com/owid/covid-19-data/tree/master/public/data
         https://ourworldindata.org/coronavirus
@@ -172,6 +173,7 @@ class PCRData(CleaningBase):
         df.to_csv(filename, index=False)
         return df
 
+    @deprecate("PCRData.use_ourworldindata()", new="DataLoader.pcr()", version="2.21.0-iota-fu4")
     def use_ourworldindata(self, filename, force=False):
         """
         Set the cleaned dataset retrieved from "Our World In Data" site.

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -483,10 +483,6 @@ class DataLoader(Term):
             return pcr_data
         # Update with Japan data
         pcr_data.replace(self.japan())
-        # Update the values using "Our World In Data" dataset
-        owid_filename = self._filename_dict["owid_pcr"]
-        owid_force = self._download_necessity(filename=owid_filename)
-        pcr_data.use_ourworldindata(filename=owid_filename, force=owid_force)
         return pcr_data
 
     def vaccine(self, **kwargs):

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -261,7 +261,7 @@ class DataLoader(Term):
             df, citation_dict, dh_handler = self._add_remote(df, _COVID19dh, dh_filename, citation_dict)
             self._covid19dh_primary = dh_handler.primary
             # Our World In Data
-            owid_filename = self._filename_dict["owid_vaccine"]
+            owid_filename = self._filename_dict["owid"]
             df, citation_dict, _ = self._add_remote(df, _OWID, owid_filename, citation_dict)
         # Complete database lock
         df = df.reset_index()

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -29,8 +29,7 @@ class DataLoader(Term):
         update_interval (int or None): update interval of downloaded or None (avoid downloading)
         basename_dict (dict[str, str]): basename of downloaded CSV files,
             "covid19dh": COVID-19 Data Hub (default: covid19dh.csv),
-            "owid_pcr": Our World In Data (the number of tests, default: ourworldindata_pcr.csv),
-            "owid_vaccine": Our World In Data (vaccination, default: ourworldindata_vaccine.csv),
+            "owid": Our World In Data (default: ourworldindata.csv),
             "wbdata": World Bank Open Data (default: wbdata_population_pyramid.csv),
             "japan": COVID-19 Dataset in Japan (default: covid_japan.csv).
         verbose (int): level of verbosity when downloading
@@ -59,8 +58,7 @@ class DataLoader(Term):
         # Dictionary of filenames to save remote datasets
         filename_dict = {
             "covid19dh": "covid19dh.csv",
-            "owid_pcr": "ourworldindata_pcr.csv",
-            "owid_vaccine": "ourworldindata_vaccine.csv",
+            "owid": "ourworldindata.csv",
             "wbdata_pyramid": "wbdata_population_pyramid.csv",
             "japan": "covid_japan.csv",
         }
@@ -82,6 +80,19 @@ class DataLoader(Term):
         self._covid19dh_primary = []
         # COVID-19 dataset in Japan
         self._japan_data = None
+        # Explain changes
+        dep_pcf_file = self.dir_path.joinpath("ourworldindata_pcr.csv")
+        dep_vac_file = self.dir_path.joinpath("ourworldindata_vaccine.csv")
+        for filepath in [dep_pcf_file, dep_vac_file]:
+            if filepath.exists() and filepath not in self._filename_dict.values():
+                warnings.warn(
+                    "The following file might be created with covsirphy.DataLoader, "
+                    "but not used at this version as default. Please delete it.\n"
+                    f"{filepath}"
+                    "\n\nAt this version, ourworldindata.csv will be created.\n\n",
+                    DeprecationWarning,
+                    stacklevel=2
+                )
 
     @property
     def local(self):
@@ -350,7 +361,8 @@ class DataLoader(Term):
             raise TypeError("local_file argument was deprecated. Please use DataLoader.read_csv().")
         if verbose is not None:
             warnings.warn(
-                "verbose argument was deprecated. Please use DataLoader(verbose).", DeprecationWarning)
+                "verbose argument was deprecated. Please use DataLoader(verbose).",
+                DeprecationWarning, stacklevel=2)
             self._verbose = self._ensure_natural_int(verbose, name="verbose")
 
     def _auto_lock(self, variables):

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -338,7 +338,7 @@ class DataLoader(Term):
         remote_df[self.PROVINCE] = remote_df[self.PROVINCE].fillna(self.UNKNOWN)
         remote_df = remote_df.set_index(self._id_cols)
         # Update the current database
-        df = df.combine_first(remote_df).reset_index().set_index(self._id_cols)
+        df = df.replace(0, None).combine_first(remote_df).reset_index().set_index(self._id_cols)
         # Update citations
         cite_dict = {k: [*v, handler.CITATION] if k in remote_df else v for (k, v) in cite_dict.items()}
         return (df, cite_dict, handler)

--- a/covsirphy/loading/db_base.py
+++ b/covsirphy/loading/db_base.py
@@ -16,7 +16,7 @@ class _RemoteDatabase(Term):
     # Citation
     CITATION = ""
     # Column names and data types
-    # {"name in database": ("name defined in Term class", "data type")}
+    # {"name in database": "name defined in Term class"}
     COL_DICT = {}
 
     def __init__(self, filename):
@@ -28,12 +28,8 @@ class _RemoteDatabase(Term):
         self.filepath.parent.mkdir(exist_ok=True, parents=True)
         # List of primary sources
         self.primary_list = []
-        # {"name in database": "name defined in Term class"}
-        self.col_convert_dict = {k: v[0] for (k, v) in self.COL_DICT.items()}
         # List of column names (defined in Term class)
-        self.saved_cols = [line[0] for line in self.COL_DICT.values()]
-        # Dictionary of data types (defined in Term class)
-        self.dtype_dict = {line[0]: line[1] for line in self.COL_DICT.values()}
+        self.saved_cols = list(self.COL_DICT.values())
 
     def to_dataframe(self, force, verbose):
         """
@@ -55,7 +51,7 @@ class _RemoteDatabase(Term):
             return self._ensure_dataframe(self.read(), columns=self.saved_cols)
         # Download dataset from server
         df = self.download(verbose=verbose)
-        df = df.rename(columns=self.col_convert_dict)
+        df = df.rename(columns=self.COL_DICT)
         df = self._ensure_dataframe(df, columns=self.saved_cols)
         df.to_csv(self.filepath, index=False)
         return df
@@ -69,7 +65,7 @@ class _RemoteDatabase(Term):
                 Index
                     reset index
                 Columns
-                    defined by .COL_DICT
+                    defined by .COL_DICT.values()
         """
         kwargs = {"low_memory": False, "header": 0, "usecols": self.saved_cols}
         return pd.read_csv(self.filepath, **kwargs)
@@ -86,7 +82,7 @@ class _RemoteDatabase(Term):
                 Index
                     reset index
                 Columns
-                    defined by .COL_DICT
+                    defined by .COL_DICT.values()
         """
         raise NotImplementedError
 

--- a/covsirphy/loading/db_base.py
+++ b/covsirphy/loading/db_base.py
@@ -48,7 +48,11 @@ class _RemoteDatabase(Term):
         """
         # Read local file if available and usable
         if not force and self.filepath.exists():
-            return self._ensure_dataframe(self.read(), columns=self.saved_cols)
+            try:
+                return self._ensure_dataframe(self.read(), columns=self.saved_cols)
+            except ValueError:
+                # ValueError: Usecols do not match columns
+                pass
         # Download dataset from server
         df = self.download(verbose=verbose)
         df = df.rename(columns=self.COL_DICT)

--- a/covsirphy/loading/db_covid19dh.py
+++ b/covsirphy/loading/db_covid19dh.py
@@ -20,7 +20,7 @@ class _COVID19dh(_RemoteDatabase):
         ' Guidotti, E., Ardia, D., (2020), "COVID-19 Data Hub",' \
         ' Journal of Open Source Software 5(51):2376, doi: 10.21105/joss.02376.'
     # Column names and data types
-    # {"name in database": ("name defined in Term class", "data type")}
+    # {"name in database": "name defined in Term class"}
     _OXCGRT_COLS_RAW_INT = [
         "school_closing",
         "workplace_closing",
@@ -35,17 +35,17 @@ class _COVID19dh(_RemoteDatabase):
         "contact_tracing",
     ]
     COL_DICT = {
-        "date": (Term.DATE, "object"),
-        "administrative_area_level_1": (Term.COUNTRY, "object"),
-        "administrative_area_level_2": (Term.PROVINCE, "object"),
-        "tests": (Term.TESTS, "int"),
-        "confirmed": (Term.C, "int"),
-        "deaths": (Term.F, "int"),
-        "recovered": (Term.R, "int"),
-        "population": (Term.N, "int"),
-        "iso_alpha_3": (Term.ISO3, "object"),
-        **{v: (v.capitalize(), "float") for v in _OXCGRT_COLS_RAW_INT},
-        "stringency_index": ("Stringency_index", "float"),
+        "date": Term.DATE,
+        "administrative_area_level_1": Term.COUNTRY,
+        "administrative_area_level_2": Term.PROVINCE,
+        "tests": Term.TESTS,
+        "confirmed": Term.C,
+        "deaths": Term.F,
+        "recovered": Term.R,
+        "population": Term.N,
+        "iso_alpha_3": Term.ISO3,
+        **{v: v.capitalize() for v in _OXCGRT_COLS_RAW_INT},
+        "stringency_index": "Stringency_index",
     }
 
     def download(self, verbose):

--- a/covsirphy/loading/db_covid19dh.py
+++ b/covsirphy/loading/db_covid19dh.py
@@ -101,12 +101,12 @@ class _COVID19dh(_RemoteDatabase):
         levels = [f"administrative_area_level_{i}" for i in range(1, 4)]
         # Level 1 (country/region)
         c_raw, c_cite = covid19dh.covid19(country=None, level=1, verbose=False, raw=True)
-        c_df = c_raw.groupby(levels[0]).ffill().fillna(0)
+        c_df = c_raw.groupby(levels[0]).ffill()
         for num in range(3):
             c_df.loc[:, levels[num]] = c_raw[levels[num]]
         # Level 2 (province/state)
         p_raw, p_cite = covid19dh.covid19(country=None, level=2, verbose=False, raw=True)
-        p_df = p_raw.groupby(levels[:2]).ffill().fillna(0)
+        p_df = p_raw.groupby(levels[:2]).ffill()
         for num in range(3):
             p_df.loc[:, levels[num]] = p_raw[levels[num]]
         # Citation

--- a/covsirphy/loading/db_owid.py
+++ b/covsirphy/loading/db_owid.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import country_converter as coco
 import pandas as pd
 from covsirphy.util.term import Term
 from covsirphy.loading.db_base import _RemoteDatabase
@@ -19,6 +20,9 @@ class _OWID(_RemoteDatabase):
     URL_V = "https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/vaccinations/"
     URL_V_REC = f"{URL_V}vaccinations.csv"
     URL_V_LOC = f"{URL_V}locations.csv"
+    # URL for PCR data
+    URL_P = "https://raw.githubusercontent.com/owid/covid-19-data/master/public/data/testing/"
+    URL_P_REC = f"{URL_P}covid-testing-all-observations.csv"
     # Citation
     CITATION = "Hasell, J., Mathieu, E., Beltekian, D. et al." \
         " A cross-country database of COVID-19 testing. Sci Data 7, 345 (2020)." \
@@ -34,6 +38,7 @@ class _OWID(_RemoteDatabase):
         "total_vaccinations": Term.VAC,
         "people_vaccinated": Term.V_ONCE,
         "people_fully_vaccinated": Term.V_FULL,
+        "tests": Term.TESTS,
     }
 
     def download(self, verbose):
@@ -57,17 +62,29 @@ class _OWID(_RemoteDatabase):
         # Download datasets
         if verbose:
             print("Retrieving datasets from Our World In Data https://github.com/owid/covid-19-data/")
-        # Vaccination
+        # Vaccinations
         v_rec_cols = [
             "date", "location", "iso_code", "total_vaccinations", "people_vaccinated", "people_fully_vaccinated"]
         v_rec_df = pd.read_csv(self.URL_V_REC, usecols=v_rec_cols)
         v_loc_df = pd.read_csv(self.URL_V_LOC, usecols=["location", "vaccines"])
         v_df = v_rec_df.merge(v_loc_df, how="left", on="location")
-        v_df[self.PROVINCE] = self.UNKNOWN
-        v_df["location"] = v_df["location"].replace(
+        # Tests
+        pcr_rec_cols = ["ISO code", "Date", "Daily change in cumulative total", "Cumulative total"]
+        pcr_df = pd.read_csv(self.URL_P_REC, usecols=pcr_rec_cols)
+        pcr_df = pcr_df.rename(columns={"ISO code": "iso_code", "Date": "date"})
+        pcr_df["cumsum"] = pcr_df.groupby("iso_code")["Daily change in cumulative total"].cumsum()
+        pcr_df = pcr_df.assign(tests=lambda x: x["Cumulative total"].fillna(x["cumsum"]))
+        # Combine data (vaccinations/tests)
+        df = v_df.set_index(["iso_code", "date"])
+        df = df.combine_first(pcr_df.set_index(["iso_code", "date"]).loc[:, ["tests"]])
+        # Location (country/province)
+        df["location"] = df["location"].replace(
             {
                 # COG
                 "Congo": "Republic of the Congo",
             }
         )
-        return v_df
+        df["location"] = df["location"].apply(
+            lambda x: x or coco.convert(x, to="name_short", not_found=None))
+        df[self.PROVINCE] = self.UNKNOWN
+        return df.reset_index()

--- a/covsirphy/loading/db_owid.py
+++ b/covsirphy/loading/db_owid.py
@@ -24,16 +24,16 @@ class _OWID(_RemoteDatabase):
         " A cross-country database of COVID-19 testing. Sci Data 7, 345 (2020)." \
         " https://doi.org/10.1038/s41597-020-00688-8"
     # Column names and data types
-    # {"name in database": ("name defined in Term class", "data type")}
+    # {"name in database": "name defined in Term class"}
     COL_DICT = {
-        "date": (Term.DATE, "object"),
-        "location": (Term.COUNTRY, "object"),
-        Term.PROVINCE: (Term.PROVINCE, "object"),
-        "iso_code": (Term.ISO3, "object"),
-        "vaccines": (Term.PRODUCT, "object"),
-        "total_vaccinations": (Term.VAC, "int"),
-        "people_vaccinated": (Term.V_ONCE, "int"),
-        "people_fully_vaccinated": (Term.V_FULL, "int"),
+        "date": Term.DATE,
+        "location": Term.COUNTRY,
+        Term.PROVINCE: Term.PROVINCE,
+        "iso_code": Term.ISO3,
+        "vaccines": Term.PRODUCT,
+        "total_vaccinations": Term.VAC,
+        "people_vaccinated": Term.V_ONCE,
+        "people_fully_vaccinated": Term.V_FULL,
     }
 
     def download(self, verbose):

--- a/tests/test_cleaning/test_pcr.py
+++ b/tests/test_cleaning/test_pcr.py
@@ -13,15 +13,6 @@ class TestPCRData(object):
         df = pcr_data.cleaned()
         assert set(df.columns) == set(PCRData.CLEANED_COLS) - set([PCRData.ISO3])
 
-    def test_from_dataframe(self, pcr_data):
-        warnings.filterwarnings("ignore", category=DeprecationWarning)
-        df = pcr_data.cleaned()
-        assert isinstance(PCRData.from_dataframe(df), PCRData)
-
-    def test_use_ourworldindata(self, pcr_data):
-        pcr_data.use_ourworldindata(
-            filename="input/ourworldindata_pcr.csv")
-
     @pytest.mark.parametrize("country", ["Japan"])
     def test_subset(self, pcr_data, country):
         with pytest.raises(SubsetNotFoundError):

--- a/tests/test_cleaning/test_pcr.py
+++ b/tests/test_cleaning/test_pcr.py
@@ -4,7 +4,7 @@
 import warnings
 import pytest
 import pandas as pd
-from covsirphy import SubsetNotFoundError, PCRIncorrectPreconditionError
+from covsirphy import SubsetNotFoundError
 from covsirphy import PCRData
 
 
@@ -42,11 +42,6 @@ class TestPCRData(object):
         assert set([PCRData.T_DIFF, PCRData.C_DIFF, PCRData.PCR_RATE]).issubset(df.columns)
         if last_date is not None:
             assert df[pcr_data.DATE].max() <= pd.to_datetime(last_date)
-
-    @pytest.mark.parametrize("country", ["China"])
-    def test_positive_rate_error(self, pcr_data, country):
-        with pytest.raises(PCRIncorrectPreconditionError):
-            pcr_data.positive_rate(country, show_figure=False)
 
     def test_map(self, pcr_data):
         warnings.filterwarnings("ignore", category=UserWarning)


### PR DESCRIPTION
## Related issues
#851

## What was changed
Include PCR data to locked database  by `DataLoader.lock()`.
Records of the number of vaccinations and tests will be saved in ourworldindata.csv as default.
(Before ourworldindata_vaccine.csv and ourworldindata_pcr.csv)