### PR TITLE
fix: KeyError when lock local data

### DIFF
--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -259,6 +259,8 @@ class DataLoader(Term):
             df, citation_dict, _ = self._add_remote(df, _OWID, owid_filename, citation_dict)
             df = df.reset_index()
         # Complete database lock
+        all_cols = [*self._id_cols, *variables, *list(df.columns)]
+        df = df.reindex(columns=sorted(set(all_cols), key=all_cols.index))
         df[self.DATE] = pd.to_datetime(df[self.DATE])
         df[self.COUNTRY] = df[self.COUNTRY].fillna(self.UNKNOWN)
         df[self.PROVINCE] = df[self.PROVINCE].fillna(self.UNKNOWN)


### PR DESCRIPTION
## Related issues
#851

## What was changed
Use local dataset with the following script.

```Python
import covsirphy as cs
loader = cs.DataLoader(update_interval=None)
loader.read_csv("input/cook county.csv", parse_dates=["date"], dayfirst=False)
loader.local
loader.assign(country="US", population=5150233)
loader.local
loader.lock(date="date", country="country", province="province", confirmed="confirmed", fatal="fatal", population="population")
loader.locked
jhu_data = loader.jhu()
snl = cs.Scenario(country="US", province="Cook")
snl.register(jhu_data)
snl.interactive = False
snl.records(filename="input/cook.png")
```