### PR TITLE
update: include Japan data inlocked database

### DIFF
--- a/covsirphy/__version__.py
+++ b/covsirphy/__version__.py
@@ -1,4 +1,4 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-__version__ = "2.21.0-kappa-fu3"
+__version__ = "2.21.0-kappa-fu4"

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -261,6 +261,7 @@ class DataLoader(Term):
             # Our World In Data
             owid_filename = self._filename_dict["owid"]
             df, citation_dict, _ = self._add_remote(df, _OWID, owid_filename, citation_dict)
+            # Reset index
             df = df.reset_index()
         # Complete database lock
         all_cols = [*self._id_cols, *variables, *list(df.columns)]

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -16,6 +16,7 @@ from covsirphy.cleaning.pyramid import PopulationPyramidData
 from covsirphy.cleaning.linelist import LinelistData
 from covsirphy.cleaning.pcr_data import PCRData
 from covsirphy.cleaning.vaccine_data import VaccineData
+from covsirphy.loading.db_cs_japan import _CSJapan
 from covsirphy.loading.db_covid19dh import _COVID19dh
 from covsirphy.loading.db_owid import _OWID
 
@@ -250,6 +251,10 @@ class DataLoader(Term):
         # With Remote datasets
         if self.update_interval is not None:
             df = df.set_index(self._id_cols)
+            # COVID-19 Dataset in Japan
+            japan_filename = self._filename_dict["japan"]
+            df, citation_dict, _ = self._add_remote(df, _CSJapan, japan_filename, citation_dict)
+            df = df.reset_index()
             # COVID19 Data Hub
             dh_filename = self._filename_dict["covid19dh"]
             df, citation_dict, dh_handler = self._add_remote(df, _COVID19dh, dh_filename, citation_dict)
@@ -405,10 +410,7 @@ class DataLoader(Term):
         """
         self._read_dep(**kwargs)
         df, citations = self._auto_lock(variables=[*JHUData.REQUIRED_COLS, *JHUData.OPTINAL_COLS])
-        jhu_data = JHUData(data=df, citation="\n".join(citations))
-        if self.update_interval is None:
-            return jhu_data
-        return jhu_data.replace(self.japan())
+        return JHUData(data=df, citation="\n".join(citations))
 
     def population(self, **kwargs):
         """
@@ -486,12 +488,7 @@ class DataLoader(Term):
         """
         self._read_dep(**kwargs)
         df, citations = self._auto_lock(variables=PCRData.RAW_COLS)
-        pcr_data = PCRData(data=df, citation="\n".join(citations))
-        if self.update_interval is None:
-            return pcr_data
-        # Update with Japan data
-        pcr_data.replace(self.japan())
-        return pcr_data
+        return PCRData(data=df, citation="\n".join(citations))
 
     def vaccine(self, **kwargs):
         """

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -504,7 +504,7 @@ class DataLoader(Term):
         """
         self._read_dep(**kwargs)
         df, citations = self._auto_lock(variables=VaccineData.RAW_COLS)
-        return VaccineData(data=df.dropna(), citation="\n".join(citations))
+        return VaccineData(data=df.dropna(subset=VaccineData.RAW_COLS), citation="\n".join(citations))
 
     def pyramid(self, **kwargs):
         """

--- a/covsirphy/loading/dataloader.py
+++ b/covsirphy/loading/dataloader.py
@@ -254,7 +254,6 @@ class DataLoader(Term):
             # COVID-19 Dataset in Japan
             japan_filename = self._filename_dict["japan"]
             df, citation_dict, _ = self._add_remote(df, _CSJapan, japan_filename, citation_dict)
-            df = df.reset_index()
             # COVID19 Data Hub
             dh_filename = self._filename_dict["covid19dh"]
             df, citation_dict, dh_handler = self._add_remote(df, _COVID19dh, dh_filename, citation_dict)

--- a/covsirphy/loading/db_owid.py
+++ b/covsirphy/loading/db_owid.py
@@ -86,7 +86,8 @@ class _OWID(_RemoteDatabase):
             }
         )
         df["location"] = df.groupby("iso_code")["location"].bfill()
+        df.loc[df["location"] == df["iso_code"], "location"] = None
         df.loc[df["location"].isna(), "location"] = df.loc[df["location"].isna(), "iso_code"].apply(
-            lambda x: x or coco.convert(x, to="name_short", not_found=None))
+            lambda x: coco.convert(x, to="name_short", not_found=None))
         df[self.PROVINCE] = self.UNKNOWN
         return df

--- a/covsirphy/util/term.py
+++ b/covsirphy/util/term.py
@@ -24,6 +24,8 @@ class Term(object):
     E = "Exposed"
     W = "Waiting"
     TESTS = "Tests"
+    MODERATE = "Moderate"
+    SEVERE = "Severe"
     # Vaccination
     VAC = "Vaccinations"
     V = "Vaccinated"


### PR DESCRIPTION
## Related issues
#851

## What was changed
Include Japan dataset in database lock.
Because of this, `JHUData.replace()` will not be called in `DataLoader.jhu()` and the other methods. Downloading will be done with `_CSJapan` internally.

Fix inccorect country name setting with the loader for "Our World In Data".