### PR TITLE
fix: dropped necessary rows when simulating

### DIFF
--- a/covsirphy/analysis/phase_tracker.py
+++ b/covsirphy/analysis/phase_tracker.py
@@ -359,7 +359,7 @@ class PhaseTracker(Term):
             raise UnExecutedError("PhaseTracker.estimate() or PhaseTracker.set_ode()")
         # Get parameter sets and initial values
         record_df = self._track_df.copy()
-        record_df = record_df.loc[record_df[self.ID] != 0].ffill().dropna()
+        record_df = record_df.loc[record_df[self.ID] != 0].ffill().dropna(subset=self._model.PARAMETERS)
         start_dates = record_df.reset_index().groupby(self.ID).first()[self.DATE].sort_values()
         end_dates = record_df.reset_index().groupby(self.ID).last()[self.DATE].sort_values()
         # Set-up ODEHandler


### PR DESCRIPTION
## Related issues
#895 

## What was changed
Internal variable `PhaseTracker._track_df` is a dataframe with time index (Date) and many columns, including estimated parameter values and estimated **DAY** parameter values (1/beta [day] etc.). Simulation needs parameter values saved in this dataframe.

At the previous version 2.21.0-lambda-fu1, all rows which have any NA cells are ignored by `.dropna()`. When **DAY** parameters are NAs, this implementation lead to empty data for simulation unexpectedly and raised the error `covsirphy.util.error.UnExecutedError: Please execute ODEHandler.add() in advance.`

With this pull request, only rows which have NAs as parameter values  will be ignored. NAs of parameter values are not acceptable in simulation, but NAs of **DAY** parameter values are acceptable in simulation because *DAY** parameter values are not used for simulation.