### PR TITLE
fix: some province names include unicodes

### DIFF
--- a/covsirphy/loading/db_google.py
+++ b/covsirphy/loading/db_google.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import pandas as pd
+from unidecode import unidecode
 from covsirphy.util.term import Term
 from covsirphy.loading.db_base import _RemoteDatabase
 
@@ -73,7 +74,7 @@ class _GoogleOpenData(_RemoteDatabase):
         df = m_df.merge(i_df, how="left", on="location_key")
         # Location (country/province)
         df = df.loc[df["subregion2_name"].isna()]
-        df[self.PROVINCE] = df["subregion1_name"].fillna(self.UNKNOWN)
+        df[self.PROVINCE] = df["subregion1_name"].fillna(self.UNKNOWN).apply(unidecode)
         df["country_name"] = df["country_name"].replace(
             {
                 # CIV

--- a/covsirphy/visualization/colored_map.py
+++ b/covsirphy/visualization/colored_map.py
@@ -259,6 +259,7 @@ class ColoredMap(VisualizeBase):
             with geo_dirpath.joinpath(basename).open("wb") as fh:
                 fh.write(response.content)
         # Data cleaning
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         gdf = gpd.read_file(geo_dirpath.joinpath(f"{title}.shp"))
         gdf["name"] = gdf["name"].fillna("").apply(unidecode)
         gdf.rename(columns={"name": self.PROVINCE, "adm0_a3": self.ISO3}, inplace=True)

--- a/covsirphy/visualization/colored_map.py
+++ b/covsirphy/visualization/colored_map.py
@@ -211,6 +211,7 @@ class ColoredMap(VisualizeBase):
         """
         # Geometry information from Natural Earth
         # pop_est, continent, name, iso_a3, gdp_md_est, geometry
+        warnings.filterwarnings("ignore", category=DeprecationWarning)
         geopath = gpd.datasets.get_path("naturalearth_lowres")
         gdf = gpd.read_file(geopath)
         # Data cleaning


### PR DESCRIPTION
## Related issues
#862 and #909

## What was changed
- Close #862 
- Fix: Some province names are registered with unicodes in mobility data and this raises name discrepancies with the other recommended datasets.
- Close #909