### PR TITLE
config: #1161. use deptry 0.2.3 to remove warning

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -434,7 +434,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "deptry"
-version = "0.2.1"
+version = "0.2.3"
 description = "A repository to check for unused dependencies in a poetry managed python project"
 category = "dev"
 optional = false
@@ -2411,7 +2411,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7.12,<3.11"
-content-hash = "af14a9a43118accd91e252247f70b8df55f82aa830e2b733f56001e641fce2e6"
+content-hash = "9cc2620392b14c4f0eb138594d57cd124e18aa73e9ad53e4a4972127dfb55317"
 
 [metadata.files]
 alabaster = [
@@ -2719,8 +2719,8 @@ defusedxml = [
     {file = "defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69"},
 ]
 deptry = [
-    {file = "deptry-0.2.1-py3-none-any.whl", hash = "sha256:ea3d5dea834fa89b3e53eb8957ed03d29f8ffae9d1188341734203d104c205ad"},
-    {file = "deptry-0.2.1.tar.gz", hash = "sha256:22be9d368c57a61e4eee8dbd8d468548377194feddbe690449ebd50f97ceef77"},
+    {file = "deptry-0.2.3-py3-none-any.whl", hash = "sha256:0275351bf49e049017f5f99ad574a6cf2697f5b368a1a4f03bdfbe5951c4635d"},
+    {file = "deptry-0.2.3.tar.gz", hash = "sha256:9fbd64bd77e653fd2873726c4195ed0118881ef9f4a9f22a44b808ec5156a988"},
 ]
 dill = [
     {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,12 +51,12 @@ tabulate = "^0.8.7"
 optional = true
 [tool.poetry.group.test.dependencies]
 autopep8 = "^1.5.6"
-deptry = "^0.2.1"
 flake8 = "^4.0.1"
 pytest = "^7.1.3"
 pytest-profiling = "^1.7.0"
 pytest-cov = "^2.12.1"
 pyproject-flake8 = "^0.0.1-alpha.5"
+deptry = "^0.2.3"
 
 [tool.poetry.group.docs]
 # poetry install --with docs


### PR DESCRIPTION
## Related issues
#1161

## What was changed
- Use deptry version 0.23 to suppress the warning regarding `mpl_toolkit`.