### PR TITLE
test: #1173, move created files with test_japan_data.py to input dir

### DIFF
--- a/tests/test_cleaning/test_japan_data.py
+++ b/tests/test_cleaning/test_japan_data.py
@@ -9,7 +9,7 @@ from covsirphy import Term, JapanData
 
 @pytest.fixture(scope="module")
 def japan_data():
-    return JapanData(filename="japan.csv")
+    return JapanData(filename="input/japan.csv")
 
 
 class TestJapanData(object):


### PR DESCRIPTION
## Related issues
#1173

## What was changed
`japan.csv" and "covid_japan_metadata.csv" created with `JapanData` class and test workflow will be moved to "input" directory from top directory.