### PR TITLE
update: #1160, specify encoding

### DIFF
--- a/covsirphy/downloading/provider.py
+++ b/covsirphy/downloading/provider.py
@@ -103,7 +103,7 @@ class _DataProvider(Term):
         """
         try:
             with contextlib.redirect_stdout(open(os.devnull, "w")):
-                df = datatable.fread(path, header=True).to_pandas()
+                df = datatable.fread(path, header=True, encoding="utf-8").to_pandas()
             df = df.loc[:, columns or df.columns]
             for col in df:
                 with contextlib.suppress(TypeError):
@@ -114,7 +114,7 @@ class _DataProvider(Term):
         except urllib.error.HTTPError:
             warnings.filterwarnings("ignore", category=pd.errors.DtypeWarning)
             kwargs = {
-                "header": 0, "usecols": columns,
+                "header": 0, "usecols": columns, "encoding": "utf-8",
                 "parse_dates": None if date is None else [date], "date_parser": lambda x: datetime.strptime(x, date_format)
             }
             return pd.read_csv(path, storage_options={"User-Agent": "Mozilla/5.0"}, **kwargs)


### PR DESCRIPTION
## Related issues
#1160

## What was changed
- Specify "utf-8" as the encoding when downloading CSV files.