### PR TITLE
test: refactor test workflow because datatable installation is un-necessary with Python 3.10

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout
@@ -82,30 +82,6 @@ jobs:
     - name: pip install and test
       run: |
         pip install pip --upgrade
-        pip install .
-        pip install pytest pytest-cov pytest-xdist
-        pytest -v --maxfail=1 tests -n auto
-
-  pip-test-v3-10:
-    name: test with pip and dev version of datatable
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: pip install and test
-      run: |
-        pip install pip --upgrade
-        pip install git+https://github.com/h2oai/datatable.git
         pip install .
         pip install pytest pytest-cov pytest-xdist
         pytest -v --maxfail=1 tests -n auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         pip install pip --upgrade
         pip install .
-        pip install pytest pytest-cov pytest-xdist
+        pip install pytest pytest-xdist
         pytest -v --maxfail=1 tests -n auto
 
   anaconda_pip:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,8 @@ on:
       - ".github/workflows/**"
       - "./covsirphy"
       - "./pyproject.toml"
+    branches:
+      - master
   pull_request:
     types: [edited, synchronize, opened, reopened]
 
@@ -66,7 +68,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10"]
+        python-version: ["3.8", "3.9"]
 
     steps:
     - name: Checkout
@@ -80,6 +82,30 @@ jobs:
     - name: pip install and test
       run: |
         pip install pip --upgrade
+        pip install .
+        pip install pytest pytest-cov pytest-xdist
+        pytest -v --maxfail=1 tests -n auto
+
+  pip-test-v3-10:
+    name: test with pip and dev version of datatable
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.10"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: pip install and test
+      run: |
+        pip install pip --upgrade
+        pip install git+https://github.com/h2oai/datatable.git
         pip install .
         pip install pytest pytest-cov pytest-xdist
         pytest -v --maxfail=1 tests -n auto

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         pip install pip --upgrade
         pip install .
-        pip install pytest pytest-xdist
+        pip install pytest pytest-cov pytest-xdist
         pytest -v --maxfail=1 tests -n auto
 
   anaconda_pip:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9"]
+        python-version: ["3.8", "3.9", "3.10"]
 
     steps:
     - name: Checkout
@@ -80,30 +80,6 @@ jobs:
     - name: pip install and test
       run: |
         pip install pip --upgrade
-        pip install .
-        pip install pytest pytest-cov pytest-xdist
-        pytest -v --maxfail=1 tests -n auto
-
-  pip-test-v3-10:
-    name: test with pip and dev version of datatable
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ["3.10"]
-
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v3
-
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: pip install and test
-      run: |
-        pip install pip --upgrade
-        pip install git+https://github.com/h2oai/datatable.git
         pip install .
         pip install pytest pytest-cov pytest-xdist
         pytest -v --maxfail=1 tests -n auto


### PR DESCRIPTION
## Related issues
#1159

## What was changed
- test: refactor test workflow because datatable installation is un-necessary with Python 3.10