### PR TITLE
Issue1242

### DIFF
--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -11,6 +11,7 @@ except ImportError:
 from covsirphy.__version__ import __version__
 from covsirphy.__citation__ import __citation__
 # util
+from covsirphy.util.config import config
 from covsirphy.util.stopwatch import StopWatch
 from covsirphy.util.error import deprecate, experimental
 from covsirphy.util.error import ExperimentalWarning
@@ -132,7 +133,7 @@ __all__ = [
     "EmptyError", "UnExpectedValueRangeError", "UnExpectedValueError", "NotSubclassError", "UnExpectedLengthError",
     "Validator", "UnExpectedNoneError", "NotNoneError", "NotEnoughDataError",
     # util
-    "StopWatch", "deprecate", "Term", "Filer", "Evaluator", "Alias",
+    "config", "StopWatch", "deprecate", "Term", "Filer", "Evaluator", "Alias",
     # visualization
     "VisualizeBase", "LinePlot", "line_plot", "BarPlot", "bar_plot",
     "ComparePlot", "compare_plot", "ScatterPlot", "scatter_plot",

--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -1,6 +1,13 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import sys
+try:
+    import better_exceptions
+    better_exceptions_installed = True
+except ImportError:
+    better_exceptions_installed = False
+# version
 from covsirphy.__version__ import __version__
 from covsirphy.__citation__ import __citation__
 # util
@@ -152,3 +159,8 @@ __all__ = [
     "JHUData", "OxCGRTData", "VaccineData", "PCRData", "JHUDataComplementHandler", "MobilityData",
     "DataLoader", "AutoMLHandler", "JapanData", "CleaningBase", "PopulationPyramidData",
 ]
+
+# Show exceptions in better format if used from command line
+if not hasattr(sys, "ps1") or not better_exceptions_installed:
+    better_exceptions.MAX_LENGTH = None
+    better_exceptions.hook()

--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -1,13 +1,6 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import sys
-try:
-    import better_exceptions
-    better_exceptions_installed = True
-except ImportError:
-    better_exceptions_installed = False
-# version
 from covsirphy.__version__ import __version__
 from covsirphy.__citation__ import __citation__
 # util
@@ -159,8 +152,3 @@ __all__ = [
     "JHUData", "OxCGRTData", "VaccineData", "PCRData", "JHUDataComplementHandler", "MobilityData",
     "DataLoader", "AutoMLHandler", "JapanData", "CleaningBase", "PopulationPyramidData",
 ]
-
-# Show exceptions in better format if used from command line
-if not hasattr(sys, "ps1") or not better_exceptions_installed:
-    better_exceptions.MAX_LENGTH = None
-    better_exceptions.hook()

--- a/covsirphy/util/config.py
+++ b/covsirphy/util/config.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+import sys
+from loguru import logger as loguru_logger
+
+
+def _catch_exception(cls):
+    """Catch exceptions raised by the all methods of the class in logger.
+
+    Args:
+        cls (object): class object
+    """
+    for attr in cls.__dict__:
+        if callable(getattr(cls, attr)):
+            setattr(cls, attr, loguru_logger.catch(getattr(cls, attr)))
+    return cls
+
+
+class _Config(object):
+    """Class for configuration of logger.
+    """
+    _LEVEL_DICT = {0: "ERROR", 1: "WARNING", 2: "INFO", 3: "DEBUG"}
+
+    def __init__(self):
+        self._logger = loguru_logger
+
+    def logger(self, level):
+        """Update configuration of logger.
+
+        Args:
+            level (int): log level (0: ERROR, 1: WARNING, 2: INFO, 3: DEBUG)
+        """
+        self._logger.remove()
+        self._logger.add(
+            sys.__stdout__,
+            level=self._LEVEL_DICT[level],
+            format="{time:YYYY-MM-DD at HH:mm:ss} | <level>{level}</level> | <level>{message}</level>",
+        )
+
+    def warning(self, message):
+        """Show warning.
+
+        Args:
+            message (str): message to show
+        """
+        self._logger.warning(message)
+
+    def info(self, message):
+        """Show information.
+
+        Args:
+            message (str): message to show
+        """
+        self._logger.info(message)
+
+    def debug(self, message):
+        """Show debug message.
+
+        Args:
+            message (str): message to show
+        """
+        self._logger.debug(message)
+
+    def exception(self, **kwargs):
+        """Show message for trace.
+
+        Args:
+            **kwarg: keyword arguments of the exception object
+
+        Examples:
+            >>> import covsirphy as cs
+            >>> try:
+                    a = "value"
+                    cs.Validator(a).int()
+                except cs.UnExpectedTypeError:
+                    cs.config.exception(name="a", target=a, expected=int)
+
+        """
+        _exception, *_ = sys.exc_info()
+        self._logger.opt(exception=True).debug(f"{_exception} was raised")
+        self._logger.exception(_exception(**kwargs))
+
+
+config = _Config()
+config.logger(level=2)

--- a/covsirphy/util/config.py
+++ b/covsirphy/util/config.py
@@ -62,25 +62,6 @@ class _Config(object):
         """
         self._logger.debug(message)
 
-    def exception(self, **kwargs):
-        """Show message for trace.
-
-        Args:
-            **kwarg: keyword arguments of the exception object
-
-        Examples:
-            >>> import covsirphy as cs
-            >>> try:
-                    a = "value"
-                    cs.Validator(a).int()
-                except cs.UnExpectedTypeError:
-                    cs.config.exception(name="a", target=a, expected=int)
-
-        """
-        _exception, *_ = sys.exc_info()
-        self._logger.opt(exception=True).debug(f"{_exception} was raised")
-        self._logger.exception(_exception(**kwargs))
-
 
 config = _Config()
 config.logger(level=2)

--- a/covsirphy/util/config.py
+++ b/covsirphy/util/config.py
@@ -1,7 +1,9 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
+import inspect
 import sys
+from types import FunctionType
 from loguru import logger as loguru_logger
 
 
@@ -10,10 +12,13 @@ def _catch_exception(cls):
 
     Args:
         cls (object): class object
+
+    Note:
+        Codes are from https://github.com/Delgan/loguru/issues/129#issuecomment-522339975
     """
-    for attr in cls.__dict__:
-        if callable(getattr(cls, attr)):
-            setattr(cls, attr, loguru_logger.catch(getattr(cls, attr)))
+    for name, fn in inspect.getmembers(cls):
+        if isinstance(fn, FunctionType):
+            setattr(cls, name, loguru_logger.catch(fn))
     return cls
 
 

--- a/covsirphy/util/config.py
+++ b/covsirphy/util/config.py
@@ -1,25 +1,8 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 
-import inspect
 import sys
-from types import FunctionType
 from loguru import logger as loguru_logger
-
-
-def _catch_exception(cls):
-    """Catch exceptions raised by the all methods of the class in logger.
-
-    Args:
-        cls (object): class object
-
-    Note:
-        Codes are from https://github.com/Delgan/loguru/issues/129#issuecomment-522339975
-    """
-    for name, fn in inspect.getmembers(cls):
-        if isinstance(fn, FunctionType):
-            setattr(cls, name, loguru_logger.catch(fn))
-    return cls
 
 
 class _Config(object):

--- a/covsirphy/util/term.py
+++ b/covsirphy/util/term.py
@@ -9,10 +9,12 @@ import warnings
 import country_converter as coco
 import numpy as np
 import pandas as pd
+from covsirphy.util.config import _catch_exception
 from covsirphy.util.error import deprecate
 from covsirphy.util.validator import Validator
 
 
+@_catch_exception
 class Term(object):
     """
     Term definition.

--- a/covsirphy/util/term.py
+++ b/covsirphy/util/term.py
@@ -9,12 +9,10 @@ import warnings
 import country_converter as coco
 import numpy as np
 import pandas as pd
-from covsirphy.util.config import _catch_exception
 from covsirphy.util.error import deprecate
 from covsirphy.util.validator import Validator
 
 
-@_catch_exception
 class Term(object):
     """
     Term definition.

--- a/covsirphy/util/validator.py
+++ b/covsirphy/util/validator.py
@@ -6,10 +6,8 @@ import math
 import pandas as pd
 from covsirphy.util.error import NAFoundError, NotIncludedError, NotSubclassError, UnExpectedTypeError, EmptyError
 from covsirphy.util.error import UnExpectedValueRangeError, UnExpectedValueError, UnExpectedLengthError, UnExpectedNoneError
-from covsirphy.util.config import _catch_exception
 
 
-@_catch_exception
 class Validator(object):
     """Validate objects and arguments.
 

--- a/covsirphy/util/validator.py
+++ b/covsirphy/util/validator.py
@@ -6,8 +6,10 @@ import math
 import pandas as pd
 from covsirphy.util.error import NAFoundError, NotIncludedError, NotSubclassError, UnExpectedTypeError, EmptyError
 from covsirphy.util.error import UnExpectedValueRangeError, UnExpectedValueError, UnExpectedLengthError, UnExpectedNoneError
+from covsirphy.util.config import _catch_exception
 
 
+@_catch_exception
 class Validator(object):
     """Validate objects and arguments.
 
@@ -170,7 +172,7 @@ class Validator(object):
         divisors = [str(i) for i in range(1, 1441) if 1440 % i == 0]
         raise UnExpectedValueError(
             self._name, value, divisors,
-            details="Tau value [min], a divisor of 1440 [min] is a parameter used to convert actual time to time steps (without units)")
+            details="Tau value [min], a divisor of 1440 [min], is a parameter used to convert actual time to time steps (without units)")
 
     def date(self, value_range=(None, None), default=None):
         """Convert a value to a date object.

--- a/poetry.lock
+++ b/poetry.lock
@@ -170,6 +170,17 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
+name = "better-exceptions"
+version = "0.3.3"
+description = "Pretty and helpful exceptions, automatically"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+
+[[package]]
 name = "bleach"
 version = "5.0.1"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -2534,7 +2545,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "f3f70b5c51a6a904bf5e31410662b6b2ac69604bfcd6d0e4b5bbe01b3376102a"
+content-hash = "a7e007186a96a891577004cd0ee357e8fd19d91af60dc346dd1c7f37d64b7f62"
 
 [metadata.files]
 alabaster = [
@@ -2611,6 +2622,11 @@ backcall = [
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
     {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
+]
+better-exceptions = [
+    {file = "better_exceptions-0.3.3-py3-none-any.whl", hash = "sha256:9c70b1c61d5a179b84cd2c9d62c3324b667d74286207343645ed4306fdaad976"},
+    {file = "better_exceptions-0.3.3-py3.8.egg", hash = "sha256:bf111d0c9994ac1123f29c24907362bed2320a86809c85f0d858396000667ce2"},
+    {file = "better_exceptions-0.3.3.tar.gz", hash = "sha256:e4e6bc18444d5f04e6e894b10381e5e921d3d544240418162c7db57e9eb3453b"},
 ]
 bleach = [
     {file = "bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -170,17 +170,6 @@ html5lib = ["html5lib"]
 lxml = ["lxml"]
 
 [[package]]
-name = "better-exceptions"
-version = "0.3.3"
-description = "Pretty and helpful exceptions, automatically"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-
-[[package]]
 name = "bleach"
 version = "5.0.1"
 description = "An easy safelist-based HTML-sanitizing tool."
@@ -501,11 +490,14 @@ testing = ["pre-commit"]
 
 [[package]]
 name = "executing"
-version = "1.0.0"
+version = "1.1.0"
 description = "Get the currently executing AST node of a frame, and other information"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[package.extras]
+tests = ["asttokens", "littleutils", "pytest", "rich"]
 
 [[package]]
 name = "fastjsonschema"
@@ -676,7 +668,7 @@ python-versions = "*"
 
 [[package]]
 name = "ipykernel"
-version = "6.15.3"
+version = "6.16.0"
 description = "IPython Kernel for Jupyter"
 category = "dev"
 optional = false
@@ -1067,19 +1059,19 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "mdit-py-plugins"
-version = "0.3.0"
+version = "0.3.1"
 description = "Collection of plugins for markdown-it-py"
 category = "dev"
 optional = false
-python-versions = "~=3.6"
+python-versions = ">=3.7"
 
 [package.dependencies]
 markdown-it-py = ">=1.0.0,<3.0.0"
 
 [package.extras]
-code_style = ["pre-commit (==2.6)"]
-rtd = ["myst-parser (>=0.14.0,<0.15.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
-testing = ["coverage", "pytest (>=3.6,<4)", "pytest-cov", "pytest-regressions"]
+code_style = ["pre-commit"]
+rtd = ["attrs", "myst-parser (>=0.16.1,<0.17.0)", "sphinx-book-theme (>=0.1.0,<0.2.0)"]
+testing = ["coverage", "pytest", "pytest-cov", "pytest-regressions"]
 
 [[package]]
 name = "mdurl"
@@ -1137,17 +1129,17 @@ yaml = ["PyYAML (>=5.1.0)"]
 
 [[package]]
 name = "myst-parser"
-version = "0.18.0"
+version = "0.18.1"
 description = "An extended commonmark compliant parser, with bridges to docutils & sphinx."
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 
 [package.dependencies]
-docutils = ">=0.15,<0.19"
+docutils = ">=0.15,<0.20"
 jinja2 = "*"
 markdown-it-py = ">=1.0.0,<3.0.0"
-mdit-py-plugins = ">=0.3.0,<0.4.0"
+mdit-py-plugins = ">=0.3.1,<0.4.0"
 pyyaml = "*"
 sphinx = ">=4,<6"
 typing-extensions = "*"
@@ -1156,7 +1148,7 @@ typing-extensions = "*"
 code_style = ["pre-commit (>=2.12,<3.0)"]
 linkify = ["linkify-it-py (>=1.0,<2.0)"]
 rtd = ["ipython", "sphinx-book-theme", "sphinx-design", "sphinxcontrib.mermaid (>=0.7.1,<0.8.0)", "sphinxext-opengraph (>=0.6.3,<0.7.0)", "sphinxext-rediraffe (>=0.2.7,<0.3.0)"]
-testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx-pytest"]
+testing = ["beautifulsoup4", "coverage[toml]", "pytest (>=6,<7)", "pytest-cov", "pytest-param-files (>=0.3.4,<0.4.0)", "pytest-regressions", "sphinx (<5.2)", "sphinx-pytest"]
 
 [[package]]
 name = "nbclient"
@@ -1214,7 +1206,7 @@ webpdf = ["pyppeteer (>=1,<1.1)"]
 
 [[package]]
 name = "nbformat"
-version = "5.6.0"
+version = "5.6.1"
 description = "The Jupyter Notebook format"
 category = "dev"
 optional = false
@@ -2260,7 +2252,7 @@ sqlcipher = ["sqlcipher3_binary"]
 
 [[package]]
 name = "stack-data"
-version = "0.5.0"
+version = "0.5.1"
 description = "Extract data from python stack frames and tracebacks for informative displays"
 category = "dev"
 optional = false
@@ -2542,7 +2534,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "a7e007186a96a891577004cd0ee357e8fd19d91af60dc346dd1c7f37d64b7f62"
+content-hash = "f3f70b5c51a6a904bf5e31410662b6b2ac69604bfcd6d0e4b5bbe01b3376102a"
 
 [metadata.files]
 alabaster = [
@@ -2619,11 +2611,6 @@ backcall = [
 beautifulsoup4 = [
     {file = "beautifulsoup4-4.11.1-py3-none-any.whl", hash = "sha256:58d5c3d29f5a36ffeb94f02f0d786cd53014cf9b3b3951d42e0080d8a9498d30"},
     {file = "beautifulsoup4-4.11.1.tar.gz", hash = "sha256:ad9aa55b65ef2808eb405f46cf74df7fcb7044d5cbc26487f96eb2ef2e436693"},
-]
-better-exceptions = [
-    {file = "better_exceptions-0.3.3-py3-none-any.whl", hash = "sha256:9c70b1c61d5a179b84cd2c9d62c3324b667d74286207343645ed4306fdaad976"},
-    {file = "better_exceptions-0.3.3-py3.8.egg", hash = "sha256:bf111d0c9994ac1123f29c24907362bed2320a86809c85f0d858396000667ce2"},
-    {file = "better_exceptions-0.3.3.tar.gz", hash = "sha256:e4e6bc18444d5f04e6e894b10381e5e921d3d544240418162c7db57e9eb3453b"},
 ]
 bleach = [
     {file = "bleach-5.0.1-py3-none-any.whl", hash = "sha256:085f7f33c15bd408dd9b17a4ad77c577db66d76203e5984b1bd59baeee948b2a"},
@@ -2926,8 +2913,8 @@ execnet = [
     {file = "execnet-1.9.0.tar.gz", hash = "sha256:8f694f3ba9cc92cab508b152dcfe322153975c29bda272e2fd7f3f00f36e47c5"},
 ]
 executing = [
-    {file = "executing-1.0.0-py2.py3-none-any.whl", hash = "sha256:550d581b497228b572235e633599133eeee67073c65914ca346100ad56775349"},
-    {file = "executing-1.0.0.tar.gz", hash = "sha256:98daefa9d1916a4f0d944880d5aeaf079e05585689bebd9ff9b32e31dd5e1017"},
+    {file = "executing-1.1.0-py2.py3-none-any.whl", hash = "sha256:4a6d96ba89eb3dcc11483471061b42b9006d8c9f81c584dd04246944cd022530"},
+    {file = "executing-1.1.0.tar.gz", hash = "sha256:2c2c07d1ec4b2d8f9676b25170f1d8445c0ee2eb78901afb075a4b8d83608c6a"},
 ]
 fastjsonschema = [
     {file = "fastjsonschema-2.16.2-py3-none-any.whl", hash = "sha256:21f918e8d9a1a4ba9c22e09574ba72267a6762d47822db9add95f6454e51cc1c"},
@@ -3043,8 +3030,8 @@ iniconfig = [
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
 ]
 ipykernel = [
-    {file = "ipykernel-6.15.3-py3-none-any.whl", hash = "sha256:befe3736944b21afec8e832725e9a45f254c8bd9afc40b61d6661c97e45aff5a"},
-    {file = "ipykernel-6.15.3.tar.gz", hash = "sha256:b81d57b0e171670844bf29cdc11562b1010d3da87115c4513e0ee660a8368765"},
+    {file = "ipykernel-6.16.0-py3-none-any.whl", hash = "sha256:d3d95241cd4dd302fea9d5747b00509b58997356d1f6333c9a074c3eccb78cb3"},
+    {file = "ipykernel-6.16.0.tar.gz", hash = "sha256:7fe42c0d58435e971dc15fd42189f20d66bf35f3056bda4f6554271bc1fa3d0d"},
 ]
 ipython = [
     {file = "ipython-8.5.0-py3-none-any.whl", hash = "sha256:6f090e29ab8ef8643e521763a4f1f39dc3914db643122b1e9d3328ff2e43ada2"},
@@ -3361,8 +3348,8 @@ mccabe = [
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
 mdit-py-plugins = [
-    {file = "mdit-py-plugins-0.3.0.tar.gz", hash = "sha256:ecc24f51eeec6ab7eecc2f9724e8272c2fb191c2e93cf98109120c2cace69750"},
-    {file = "mdit_py_plugins-0.3.0-py3-none-any.whl", hash = "sha256:b1279701cee2dbf50e188d3da5f51fee8d78d038cdf99be57c6b9d1aa93b4073"},
+    {file = "mdit-py-plugins-0.3.1.tar.gz", hash = "sha256:3fc13298497d6e04fe96efdd41281bfe7622152f9caa1815ea99b5c893de9441"},
+    {file = "mdit_py_plugins-0.3.1-py3-none-any.whl", hash = "sha256:606a7f29cf56dbdfaf914acb21709b8f8ee29d857e8f29dcc33d8cb84c57bfa1"},
 ]
 mdurl = [
     {file = "mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8"},
@@ -3404,8 +3391,8 @@ munch = [
     {file = "munch-2.5.0.tar.gz", hash = "sha256:2d735f6f24d4dba3417fa448cae40c6e896ec1fdab6cdb5e6510999758a4dbd2"},
 ]
 myst-parser = [
-    {file = "myst-parser-0.18.0.tar.gz", hash = "sha256:739a4d96773a8e55a2cacd3941ce46a446ee23dcd6b37e06f73f551ad7821d86"},
-    {file = "myst_parser-0.18.0-py3-none-any.whl", hash = "sha256:4965e51918837c13bf1c6f6fe2c6bddddf193148360fbdaefe743a4981358f6a"},
+    {file = "myst-parser-0.18.1.tar.gz", hash = "sha256:79317f4bb2c13053dd6e64f9da1ba1da6cd9c40c8a430c447a7b146a594c246d"},
+    {file = "myst_parser-0.18.1-py3-none-any.whl", hash = "sha256:61b275b85d9f58aa327f370913ae1bec26ebad372cc99f3ab85c8ec3ee8d9fb8"},
 ]
 nbclient = [
     {file = "nbclient-0.6.8-py3-none-any.whl", hash = "sha256:7cce8b415888539180535953f80ea2385cdbb444944cdeb73ffac1556fdbc228"},
@@ -3416,8 +3403,8 @@ nbconvert = [
     {file = "nbconvert-7.0.0.tar.gz", hash = "sha256:fd1e361da30e30e4c5a5ae89f7cae95ca2a4d4407389672473312249a7ba0060"},
 ]
 nbformat = [
-    {file = "nbformat-5.6.0-py3-none-any.whl", hash = "sha256:349db50afcf5f44cac6ddcf747fcb9330eafb751044c83994066c48e2f140b35"},
-    {file = "nbformat-5.6.0.tar.gz", hash = "sha256:6f9edb3b70119d82ba89b74b0ecfdbb83f35af8661e491e49ac0893657042674"},
+    {file = "nbformat-5.6.1-py3-none-any.whl", hash = "sha256:9c071f0f615c1b0f4f9bf6745ecfd3294fc02daf279a05c76004c901e9dc5893"},
+    {file = "nbformat-5.6.1.tar.gz", hash = "sha256:146b5b9969391387c2089256359f5da7c718b1d8a88ba814320273ea410e646e"},
 ]
 nbsphinx = [
     {file = "nbsphinx-0.8.9-py3-none-any.whl", hash = "sha256:a7d743762249ee6bac3350a91eb3717a6e1c75f239f2c2a85491f9aca5a63be1"},
@@ -4196,8 +4183,8 @@ SQLAlchemy = [
     {file = "SQLAlchemy-1.4.41.tar.gz", hash = "sha256:0292f70d1797e3c54e862e6f30ae474014648bc9c723e14a2fda730adb0a9791"},
 ]
 stack-data = [
-    {file = "stack_data-0.5.0-py3-none-any.whl", hash = "sha256:66d2ebd3d7f29047612ead465b6cae5371006a71f45037c7e2507d01367bce3b"},
-    {file = "stack_data-0.5.0.tar.gz", hash = "sha256:715c8855fbf5c43587b141e46cc9d9339cc0d1f8d6e0f98ed0d01c6cb974e29f"},
+    {file = "stack_data-0.5.1-py3-none-any.whl", hash = "sha256:5120731a18ba4c82cefcf84a945f6f3e62319ef413bfc210e32aca3a69310ba2"},
+    {file = "stack_data-0.5.1.tar.gz", hash = "sha256:95eb784942e861a3d80efd549ff9af6cf847d88343a12eb681d7157cfcb6e32b"},
 ]
 statsmodels = [
     {file = "statsmodels-0.13.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3e7ca5b7e678c0bb7a24f5c735d58ac104a50eb61b17c484cce0e221a095560f"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -953,6 +953,21 @@ wheel = "*"
 dask = ["dask[array] (>=2.0.0)", "dask[dataframe] (>=2.0.0)", "dask[distributed] (>=2.0.0)", "pandas"]
 
 [[package]]
+name = "loguru"
+version = "0.6.0"
+description = "Python logging made (stupidly) simple"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (>=4.1.1)", "black (>=19.10b0)", "colorama (>=0.3.4)", "docutils (==0.16)", "flake8 (>=3.7.7)", "isort (>=5.1.1)", "pytest (>=4.6.2)", "pytest-cov (>=2.7.1)", "sphinx-autobuild (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)", "tox (>=3.9.0)"]
+
+[[package]]
 name = "lxml"
 version = "4.9.1"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
@@ -2502,6 +2517,17 @@ optional = false
 python-versions = ">=3.7"
 
 [[package]]
+name = "win32-setctime"
+version = "1.1.0"
+description = "A small Python utility to set file creation time on Windows"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
+
+[[package]]
 name = "zipp"
 version = "3.8.1"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -2516,7 +2542,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "18fc7847cbae7198ad9cb846515205425ac83e9600dedae32e4b9dea6108d6d9"
+content-hash = "a7e007186a96a891577004cd0ee357e8fd19d91af60dc346dd1c7f37d64b7f62"
 
 [metadata.files]
 alabaster = [
@@ -3156,6 +3182,10 @@ lightgbm = [
     {file = "lightgbm-3.3.2-py3-none-manylinux2014_aarch64.whl", hash = "sha256:8e788c56853316fc5d35db726d81bd002c721038c856853952287f68082e0158"},
     {file = "lightgbm-3.3.2-py3-none-win_amd64.whl", hash = "sha256:e4f1529cad416066964f9af0efad208787861e9f2181b7f9ee7fc9bacc082d4f"},
     {file = "lightgbm-3.3.2.tar.gz", hash = "sha256:5d25d16e77c844c297ece2044df57651139bc3c8ad8c4108916374267ac68b64"},
+]
+loguru = [
+    {file = "loguru-0.6.0-py3-none-any.whl", hash = "sha256:4e2414d534a2ab57573365b3e6d0234dfb1d84b68b7f3b948e6fb743860a77c3"},
+    {file = "loguru-0.6.0.tar.gz", hash = "sha256:066bd06758d0a513e9836fd9c6b5a75bfb3fd36841f4b996bc60b547a309d41c"},
 ]
 lxml = [
     {file = "lxml-4.9.1-cp27-cp27m-macosx_10_15_x86_64.whl", hash = "sha256:98cafc618614d72b02185ac583c6f7796202062c41d2eeecdf07820bad3295ed"},
@@ -4286,6 +4316,10 @@ wheel = [
 widgetsnbextension = [
     {file = "widgetsnbextension-4.0.3-py3-none-any.whl", hash = "sha256:7f3b0de8fda692d31ef03743b598620e31c2668b835edbd3962d080ccecf31eb"},
     {file = "widgetsnbextension-4.0.3.tar.gz", hash = "sha256:34824864c062b0b3030ad78210db5ae6a3960dfb61d5b27562d6631774de0286"},
+]
+win32-setctime = [
+    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
+    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
 ]
 zipp = [
     {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ lightgbm = "^3.3.2"
 AutoTS = "^0.5.0"
 p-tqdm = "^1.4.0"
 pca = "^1.8.3"
+better-exceptions = "^0.3.3"
 loguru = "^0.6.0"
 
 [tool.poetry.group.test]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ AutoTS = "^0.5.0"
 p-tqdm = "^1.4.0"
 pca = "^1.8.3"
 better-exceptions = "^0.3.3"
+loguru = "^0.6.0"
 
 [tool.poetry.group.test]
 # poetry install --with test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ lightgbm = "^3.3.2"
 AutoTS = "^0.5.0"
 p-tqdm = "^1.4.0"
 pca = "^1.8.3"
-better-exceptions = "^0.3.3"
 loguru = "^0.6.0"
 
 [tool.poetry.group.test]


### PR DESCRIPTION
## Related issues
#1242 (and #1197)

## What was changed
- use `loguru` as a dependency
- ~~remove `better-exceptions` from the direct dependencies because `loguru` will be used directly (#1197)~~
- new: `cs.config.logger(level)`

Not included:
- use `cs.config,warning()` etc. instead of `print'
- documentation of `cs.config.logger(level)`