### PR TITLE
Refactoring Python files and tests, suppressing warning raised by a dependency

### DIFF
--- a/covsirphy/__citation__.py
+++ b/covsirphy/__citation__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy.__version__ import __version__
 
 __citation__ = "Hirokazu Takaya and CovsirPhy Development Team (2020-2022), " \

--- a/covsirphy/__init__.py
+++ b/covsirphy/__init__.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 # flake8: noqa
 
 # version

--- a/covsirphy/__version__.py
+++ b/covsirphy/__version__.py
@@ -1,4 +1,1 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 __version__ = "3.0.0.dev0"

--- a/covsirphy/downloading/_db.py
+++ b/covsirphy/downloading/_db.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 
 from covsirphy.util.filer import Filer
 from covsirphy.util.term import Term

--- a/covsirphy/downloading/_db_covid19dh.py
+++ b/covsirphy/downloading/_db_covid19dh.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy.util.term import Term
 from covsirphy.downloading._db import _DataBase
 

--- a/covsirphy/downloading/_db_cs_japan.py
+++ b/covsirphy/downloading/_db_cs_japan.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 from covsirphy.util.term import Term
 from covsirphy.downloading._db import _DataBase

--- a/covsirphy/downloading/_db_owid.py
+++ b/covsirphy/downloading/_db_owid.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 from covsirphy.util.term import Term
 from covsirphy.downloading._db import _DataBase

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 from covsirphy.util.term import Term
 from covsirphy.downloading._db import _DataBase

--- a/covsirphy/downloading/_provider.py
+++ b/covsirphy/downloading/_provider.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import contextlib
 from datetime import datetime, timezone, timedelta
 from pathlib import Path

--- a/covsirphy/downloading/downloader.py
+++ b/covsirphy/downloading/downloader.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy.util.error import NotRegisteredError, SubsetNotFoundError
 from covsirphy.util.validator import Validator
 from covsirphy.util.term import Term

--- a/covsirphy/dynamics/_simulator.py
+++ b/covsirphy/dynamics/_simulator.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 
 from datetime import timedelta
 import pandas as pd

--- a/covsirphy/dynamics/_trend.py
+++ b/covsirphy/dynamics/_trend.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import warnings
 from datetime import timedelta
 import matplotlib

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from datetime import timedelta
 from functools import partial
 from multiprocessing import cpu_count, Pool

--- a/covsirphy/dynamics/ode.py
+++ b/covsirphy/dynamics/ode.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from datetime import datetime, timedelta
 from functools import partial
 import math

--- a/covsirphy/dynamics/sewirf.py
+++ b/covsirphy/dynamics/sewirf.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 from covsirphy.util.validator import Validator
 from covsirphy.dynamics.ode import ODEModel

--- a/covsirphy/dynamics/sir.py
+++ b/covsirphy/dynamics/sir.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 from covsirphy.util.validator import Validator
 from covsirphy.dynamics.ode import ODEModel

--- a/covsirphy/dynamics/sird.py
+++ b/covsirphy/dynamics/sird.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 from covsirphy.util.validator import Validator
 from covsirphy.dynamics.ode import ODEModel

--- a/covsirphy/dynamics/sirf.py
+++ b/covsirphy/dynamics/sirf.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import pandas as pd
 from covsirphy.util.validator import Validator

--- a/covsirphy/engineering/_cleaner.py
+++ b/covsirphy/engineering/_cleaner.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import contextlib
 import pandas as pd
 from covsirphy.util.validator import Validator

--- a/covsirphy/engineering/_complement.py
+++ b/covsirphy/engineering/_complement.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import functools
 import warnings
 import numpy as np

--- a/covsirphy/engineering/_transformer.py
+++ b/covsirphy/engineering/_transformer.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy.util.validator import Validator
 from covsirphy.util.term import Term
 

--- a/covsirphy/engineering/engineer.py
+++ b/covsirphy/engineering/engineer.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import pandas as pd
 from covsirphy.util.error import NotIncludedError

--- a/covsirphy/gis/_choropleth.py
+++ b/covsirphy/gis/_choropleth.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from pathlib import Path
 import warnings
 import geopandas as gpd

--- a/covsirphy/gis/_choropleth.py
+++ b/covsirphy/gis/_choropleth.py
@@ -56,10 +56,10 @@ class _ChoroplethMap(VisualizeBase):
                 "color": "lightgrey",
                 "edgecolor": "white",
                 "hatch": "///",
-            }
+            },
+            "legend_kwds": {"orientation": "horizontal"},
+            **kwargs
         }
-        plot_kwargs.update(kwargs)
-        plot_kwargs["legend_kwds"] = {"orientation": "horizontal"}
         # Convert to log10 scale
         if logscale:
             gdf["Variable"] = np.log10(gdf["Variable"] + 1)

--- a/covsirphy/gis/_geometry.py
+++ b/covsirphy/gis/_geometry.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from pathlib import Path
 import warnings
 import geopandas as gpd

--- a/covsirphy/gis/_layer.py
+++ b/covsirphy/gis/_layer.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import contextlib
 import pandas as pd
 from covsirphy.util.config import config

--- a/covsirphy/gis/_subset.py
+++ b/covsirphy/gis/_subset.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import contextlib
 from copy import deepcopy
 from covsirphy.util.validator import Validator

--- a/covsirphy/gis/gis.py
+++ b/covsirphy/gis/gis.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import contextlib
 from pathlib import Path
 import geopandas as gpd

--- a/covsirphy/science/_autots.py
+++ b/covsirphy/science/_autots.py
@@ -39,8 +39,8 @@ class _AutoTSHandler(Term):
             "random_seed": Validator(seed, name="seed").int(),
             "n_jobs": "auto",
             "verbose": config.logger_level,
+            **kwargs,
         }
-        autots_kwargs.update(kwargs)
         self._autots = AutoTS(**autots_kwargs)
         self._regressor_forecast = None
 

--- a/covsirphy/science/_autots.py
+++ b/covsirphy/science/_autots.py
@@ -1,3 +1,4 @@
+import warnings
 from autots import AutoTS
 from autots.evaluator.auto_ts import fake_regressor
 from covsirphy.util.config import config
@@ -65,6 +66,7 @@ class _AutoTSHandler(Term):
                 aggfunc=self._autots.aggfunc,
                 verbose=self._autots.verbose,
             )
+        warnings.filterwarnings("ignore", category=FutureWarning)
         self._autots.fit(self._Y, future_regressor=None if X is None else regressor_train)
         return self
 

--- a/covsirphy/science/_autots.py
+++ b/covsirphy/science/_autots.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from autots import AutoTS
 from autots.evaluator.auto_ts import fake_regressor
 from covsirphy.util.config import config

--- a/covsirphy/science/ml.py
+++ b/covsirphy/science/ml.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from pca import pca
 from covsirphy.util.config import config
 from covsirphy.util.validator import Validator

--- a/covsirphy/science/ode_scenario.py
+++ b/covsirphy/science/ode_scenario.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import contextlib
 from copy import deepcopy
 from datetime import timedelta

--- a/covsirphy/util/alias.py
+++ b/covsirphy/util/alias.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy.util.validator import Validator
 from covsirphy.util.term import Term
 

--- a/covsirphy/util/config.py
+++ b/covsirphy/util/config.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import sys
 import warnings
 from loguru import logger as loguru_logger

--- a/covsirphy/util/error.py
+++ b/covsirphy/util/error.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from copy import deepcopy
 from covsirphy.util.config import config
 

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import pandas as pd
 import sklearn.metrics

--- a/covsirphy/util/filer.py
+++ b/covsirphy/util/filer.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from pathlib import Path
 
 

--- a/covsirphy/util/stopwatch.py
+++ b/covsirphy/util/stopwatch.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from datetime import datetime
 
 

--- a/covsirphy/util/term.py
+++ b/covsirphy/util/term.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from collections import defaultdict
 import logging
 import warnings

--- a/covsirphy/util/term.py
+++ b/covsirphy/util/term.py
@@ -162,8 +162,11 @@ class Term(object):
         logging.basicConfig(level=logging.CRITICAL)
         warnings.simplefilter("ignore", FutureWarning)
         names = [name] if (isinstance(name, str) or name is None) else name
-        code_dict = {"UK": "GBR", None: cls.NA * 3, }
-        code_dict.update({elem: coco.convert(elem, to="ISO3", not_found=elem) for elem in set(names) - set(code_dict)})
+        excepted_dict = {"UK": "GBR", None: cls.NA * 3}
+        code_dict = {
+            elem: excepted_dict[elem] if elem in excepted_dict else coco.convert(elem, to="ISO3", not_found=elem)
+            for elem in set(names)
+        }
         return [code_dict[elem] for elem in names]
 
     def _country_information(self):

--- a/covsirphy/util/validator.py
+++ b/covsirphy/util/validator.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from inspect import signature
 import math
 import pandas as pd

--- a/covsirphy/visualization/bar_plot.py
+++ b/covsirphy/visualization/bar_plot.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from matplotlib import pyplot as plt
 from matplotlib.ticker import ScalarFormatter
 import pandas as pd

--- a/covsirphy/visualization/compare_plot.py
+++ b/covsirphy/visualization/compare_plot.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from matplotlib import pyplot as plt
 from matplotlib.ticker import ScalarFormatter
 from covsirphy.util.validator import Validator

--- a/covsirphy/visualization/line_plot.py
+++ b/covsirphy/visualization/line_plot.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from matplotlib import pyplot as plt
 from matplotlib.ticker import ScalarFormatter
 import pandas as pd

--- a/covsirphy/visualization/scatter_plot.py
+++ b/covsirphy/visualization/scatter_plot.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from matplotlib import pyplot as plt
 import pandas as pd
 from covsirphy.util.error import UnExecutedError

--- a/covsirphy/visualization/vbase.py
+++ b/covsirphy/visualization/vbase.py
@@ -32,7 +32,7 @@ def find_args(func_list, **kwargs):
     enabled_nest = [
         list(signature(func).parameters.keys()) for func in func_list
     ]
-    enabled_set = set(sum(enabled_nest, list()))
+    enabled_set = set(sum(enabled_nest, []))
     enabled_set = enabled_set - {"self", "cls"}
     return {k: v for (k, v) in kwargs.items() if k in enabled_set}
 

--- a/covsirphy/visualization/vbase.py
+++ b/covsirphy/visualization/vbase.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from inspect import signature
 import sys
 import matplotlib

--- a/example/demo.py
+++ b/example/demo.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 
 """
 When you use this file from the top directory of the repository with poetry, please run

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from pathlib import Path
 import pandas as pd
 import pytest

--- a/tests/test_downloading/test_downloading.py
+++ b/tests/test_downloading/test_downloading.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pytest
 from covsirphy import DataDownloader, SubsetNotFoundError, Term
 

--- a/tests/test_downloading/test_downloading.py
+++ b/tests/test_downloading/test_downloading.py
@@ -2,38 +2,39 @@ import pytest
 from covsirphy import DataDownloader, SubsetNotFoundError, Term
 
 
-class TestDataDownloader(object):
-    @pytest.mark.parametrize(
-        "country, province",
-        [
-            ("Japan", None),
-            ("USA", None),
-            ("USA", "Alabama"),
-            ("UK", None),
-            (None, None),
-        ]
-    )
-    def test_download(self, country, province):
-        dl = DataDownloader()
-        dl.layer(country=country, province=province, databases=["japan", "covid19dh", "owid"])
-        assert dl.citations()
+@pytest.mark.parametrize(
+    "country, province",
+    [
+        ("Japan", None),
+        ("USA", None),
+        ("USA", "Alabama"),
+        ("UK", None),
+        (None, None),
+    ]
+)
+def test_download(country, province):
+    dl = DataDownloader()
+    dl.layer(country=country, province=province, databases=["japan", "covid19dh", "owid"])
+    assert dl.citations()
 
-    @pytest.mark.parametrize(
-        "country, province",
-        [
-            ("UK", "London Region"),
-        ]
-    )
-    def test_download_error(self, country, province):
-        dl = DataDownloader()
-        with pytest.raises(SubsetNotFoundError):
-            dl.layer(country=country, province=province, databases=["covid19dh"])
 
-    def test_download_wpp(self):
-        dl = DataDownloader()
-        c_df = dl.layer(databases=["wpp"])
-        assert Term.N in c_df
-        with pytest.raises(SubsetNotFoundError):
-            dl.layer(databases=["wpp"], country="Japan")
-        with pytest.raises(SubsetNotFoundError):
-            dl.layer(databases=["wpp"], country="Japan", province="Tokyo")
+@pytest.mark.parametrize(
+    "country, province",
+    [
+        ("UK", "London Region"),
+    ]
+)
+def test_download_error(country, province):
+    dl = DataDownloader()
+    with pytest.raises(SubsetNotFoundError):
+        dl.layer(country=country, province=province, databases=["covid19dh"])
+
+
+def test_download_wpp():
+    dl = DataDownloader()
+    c_df = dl.layer(databases=["wpp"])
+    assert Term.N in c_df
+    with pytest.raises(SubsetNotFoundError):
+        dl.layer(databases=["wpp"], country="Japan")
+    with pytest.raises(SubsetNotFoundError):
+        dl.layer(databases=["wpp"], country="Japan", province="Tokyo")

--- a/tests/test_dynamics/test_dynamics.py
+++ b/tests/test_dynamics/test_dynamics.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/test_dynamics/test_dynamics.py
+++ b/tests/test_dynamics/test_dynamics.py
@@ -5,89 +5,98 @@ from covsirphy import Dynamics, SIRFModel, Term, Validator
 from covsirphy import EmptyError, NotEnoughDataError, NAFoundError, UnExpectedNoneError
 
 
-@pytest.mark.parametrize("model", [SIRFModel])
-class TestDynamics(object):
-    def test_one_phase(self, model):
-        dyn = Dynamics.from_sample(model)
-        del dyn.name
-        dyn.name = "Dynamics"
-        assert dyn.name == "Dynamics"
-        registered_df = dyn.register()
-        Validator(registered_df).dataframe(columns=[*SIRFModel._VARIABLES, *SIRFModel._PARAMETERS])
-        summary_df = dyn.summary()
-        assert len(summary_df) == 1
-        Validator(dyn.simulate()).dataframe(columns=[Term.S, Term.CI, Term.F, Term.R])
-        Validator(dyn.simulate(model_specific=True)).dataframe(columns=SIRFModel._VARIABLES)
-        assert dyn.model == model
-        assert dyn.model_name == model._NAME
+@pytest.fixture(scope="module", params=[SIRFModel])
+def model_class(request):
+    return request.param
 
-    def test_two_phase(self, model):
-        dyn = Dynamics.from_sample(model)
-        registered_df = dyn.register()
-        with pytest.raises(EmptyError):
-            failed_df = registered_df.copy()
-            failed_df[Term.CI] = np.nan
-            dyn.register(failed_df)
-        registered_df.loc[registered_df.index[90], "rho"] = registered_df.loc[registered_df.index[0], "rho"] * 2
-        dyn.register(data=registered_df)
-        summary_df = dyn.summary()
-        assert len(summary_df) == 2
-        Validator(dyn.simulate()).dataframe(columns=[Term.S, Term.CI, Term.F, Term.R])
 
-    def test_from_data(self, model):
-        sample_dyn = Dynamics.from_sample(model)
-        dyn = Dynamics.from_data(model=model, data=sample_dyn.simulate())
-        df = dyn.register()
-        assert df.loc[df.index[0], model._PARAMETERS[0]] is pd.NA
+def test_one_phase(model_class):
+    dyn = Dynamics.from_sample(model_class)
+    del dyn.name
+    dyn.name = "Dynamics"
+    assert dyn.name == "Dynamics"
+    registered_df = dyn.register()
+    Validator(registered_df).dataframe(columns=[*SIRFModel._VARIABLES, *SIRFModel._PARAMETERS])
+    summary_df = dyn.summary()
+    assert len(summary_df) == 1
+    Validator(dyn.simulate()).dataframe(columns=[Term.S, Term.CI, Term.F, Term.R])
+    Validator(dyn.simulate(model_specific=True)).dataframe(columns=SIRFModel._VARIABLES)
+    assert dyn.model == model_class
+    assert dyn.model_name == model_class._NAME
 
-    def test_simulate_failed(self, model):
-        dyn = Dynamics.from_sample(model)
-        df = dyn.register()
-        df[model._PARAMETERS[0]] = np.nan
-        dyn.register(data=df)
-        with pytest.raises(NAFoundError):
-            dyn.simulate()
 
-    def test_trend(self, model, imgfile):
-        with pytest.raises(NotEnoughDataError):
-            dyn_failed = Dynamics.from_sample(model=model)
-            dyn_failed.detect()
-        dyn = Dynamics.from_sample(model)
-        dyn.register(dyn.simulate())
-        points, df = dyn.detect(filename=imgfile)
-        assert isinstance(points, list)
-        assert {"Actual", "0th"}.issubset(df.columns)
-        dyn.segment(filename=imgfile)
-        assert len(dyn) > 1
+def test_two_phase(model_class):
+    dyn = Dynamics.from_sample(model_class)
+    registered_df = dyn.register()
+    with pytest.raises(EmptyError):
+        failed_df = registered_df.copy()
+        failed_df[Term.CI] = np.nan
+        dyn.register(failed_df)
+    registered_df.loc[registered_df.index[90], "rho"] = registered_df.loc[registered_df.index[0], "rho"] * 2
+    dyn.register(data=registered_df)
+    summary_df = dyn.summary()
+    assert len(summary_df) == 2
+    Validator(dyn.simulate()).dataframe(columns=[Term.S, Term.CI, Term.F, Term.R])
 
-    def test_estimate(self, model, imgfile):
-        dyn = Dynamics.from_sample(model)
-        dyn.register(dyn.simulate())
-        dyn.tau = 1440
-        del dyn.tau
-        assert dyn.tau is None
-        with pytest.raises(UnExpectedNoneError):
-            dyn.simulate()
-        with pytest.raises(UnExpectedNoneError):
-            dyn.estimate_params()
-        dyn.estimate().summary()
-        dyn.track()
-        assert dyn.tau is not None
+
+def test_from_data(model_class):
+    sample_dyn = Dynamics.from_sample(model_class)
+    dyn = Dynamics.from_data(model=model_class, data=sample_dyn.simulate())
+    df = dyn.register()
+    assert df.loc[df.index[0], model_class._PARAMETERS[0]] is pd.NA
+
+
+def test_simulate_failed(model_class):
+    dyn = Dynamics.from_sample(model_class)
+    df = dyn.register()
+    df[model_class._PARAMETERS[0]] = np.nan
+    dyn.register(data=df)
+    with pytest.raises(NAFoundError):
         dyn.simulate()
-        dyn.evaluate(display=True, filename=imgfile)
-        with pytest.raises(NotEnoughDataError):
-            dyn_failed = Dynamics.from_sample(model)
-            dyn_failed.estimate_tau()
-        with pytest.raises(NotEnoughDataError):
-            dyn_failed = Dynamics.from_sample(model)
-            dyn_failed.estimate_params()
 
-    def test_parse(self, model):
-        dyn = Dynamics.from_sample(model=model, date_range=("01Jan2022", "31Mar2022"))
-        dyn.segment(points=["01Feb2022", "01Mar2022"])
-        assert len(dyn) == 3
-        assert dyn.parse_phases(phases=None) == tuple(pd.to_datetime(["01Jan2022", "31Mar2022"]))
-        assert dyn.parse_phases(phases=["1st", "last"]) == tuple(pd.to_datetime(["01Feb2022", "31Mar2022"]))
-        assert dyn.parse_days(days=-10, ref="last") == tuple(pd.to_datetime(["21Mar2022", "31Mar2022"]))
-        assert dyn.parse_days(days=10, ref="first") == tuple(pd.to_datetime(["01Jan2022", "11Jan2022"]))
-        assert dyn.parse_days(days=10, ref="01Feb2022") == tuple(pd.to_datetime(["01Feb2022", "11Feb2022"]))
+
+def test_trend(model_class, imgfile):
+    with pytest.raises(NotEnoughDataError):
+        dyn_failed = Dynamics.from_sample(model=model_class)
+        dyn_failed.detect()
+    dyn = Dynamics.from_sample(model_class)
+    dyn.register(dyn.simulate())
+    points, df = dyn.detect(filename=imgfile)
+    assert isinstance(points, list)
+    assert {"Actual", "0th"}.issubset(df.columns)
+    dyn.segment(filename=imgfile)
+    assert len(dyn) > 1
+
+
+def test_estimate(model_class, imgfile):
+    dyn = Dynamics.from_sample(model_class)
+    dyn.register(dyn.simulate())
+    dyn.tau = 1440
+    del dyn.tau
+    assert dyn.tau is None
+    with pytest.raises(UnExpectedNoneError):
+        dyn.simulate()
+    with pytest.raises(UnExpectedNoneError):
+        dyn.estimate_params()
+    dyn.estimate().summary()
+    dyn.track()
+    assert dyn.tau is not None
+    dyn.simulate()
+    dyn.evaluate(display=True, filename=imgfile)
+    with pytest.raises(NotEnoughDataError):
+        dyn_failed = Dynamics.from_sample(model_class)
+        dyn_failed.estimate_tau()
+    with pytest.raises(NotEnoughDataError):
+        dyn_failed = Dynamics.from_sample(model_class)
+        dyn_failed.estimate_params()
+
+
+def test_parse(model_class):
+    dyn = Dynamics.from_sample(model=model_class, date_range=("01Jan2022", "31Mar2022"))
+    dyn.segment(points=["01Feb2022", "01Mar2022"])
+    assert len(dyn) == 3
+    assert dyn.parse_phases(phases=None) == tuple(pd.to_datetime(["01Jan2022", "31Mar2022"]))
+    assert dyn.parse_phases(phases=["1st", "last"]) == tuple(pd.to_datetime(["01Feb2022", "31Mar2022"]))
+    assert dyn.parse_days(days=-10, ref="last") == tuple(pd.to_datetime(["21Mar2022", "31Mar2022"]))
+    assert dyn.parse_days(days=10, ref="first") == tuple(pd.to_datetime(["01Jan2022", "11Jan2022"]))
+    assert dyn.parse_days(days=10, ref="01Feb2022") == tuple(pd.to_datetime(["01Feb2022", "11Feb2022"]))

--- a/tests/test_dynamics/test_model.py
+++ b/tests/test_dynamics/test_model.py
@@ -5,6 +5,11 @@ from covsirphy import ODEModel, SIRModel, SIRDModel, SIRFModel, SEWIRFModel
 from covsirphy import Term, Validator, NotNoneError, UnExpectedNoneError
 
 
+@pytest.fixture(scope="module", params=[SIRModel, SIRDModel, SIRFModel, SEWIRFModel])
+def model_class(request):
+    return request.param
+
+
 def test_not_implemented():
     model = ODEModel.from_sample()
     with pytest.raises(NotImplementedError):
@@ -23,117 +28,124 @@ def test_not_implemented():
         model.sr(data=pd.DataFrame())
 
 
-@pytest.mark.parametrize("model_class", [SIRModel, SIRDModel, SIRFModel, SEWIRFModel])
-class TestODEModel(object):
-    def test_special(self, model_class):
-        model = model_class.from_sample()
-        assert str(model) == model._NAME == model_class.name()
-        assert model == model_class(**model.settings())
-        assert model == eval(repr(model))
-        assert model.definitions() == model_class.definitions()
+def test_special(model_class):
+    model = model_class.from_sample()
+    assert str(model) == model._NAME == model_class.name()
+    assert model == model_class(**model.settings())
+    assert model == eval(repr(model))
+    assert model.definitions() == model_class.definitions()
 
-    @pytest.mark.parametrize("tau", [720, 1440])
-    def test_solve(self, model_class, tau):
-        model = model_class.from_sample(tau=tau)
-        df = model.solve()
-        assert df.iloc[0].to_dict() == model.settings()["initial_dict"]
-        Validator(df, name="analytical solution").dataframe(time_index=True, columns=model_class._VARIABLES)
-        assert df.index.name == Term.DATE
 
-    @pytest.mark.parametrize("tau", [720, 1440, None])
-    def test_transform(self, model_class, tau):
-        model = model_class.from_sample(tau=tau or 360)
-        start_date = model.settings()["date_range"][0]
-        solved_df = model.solve()
-        with pytest.raises(NotNoneError):
-            model_class.inverse_transform(solved_df.reset_index(drop=True), tau=None, start_date=start_date)
-        with pytest.raises(UnExpectedNoneError):
-            model_class.inverse_transform(solved_df.reset_index(drop=True), tau=tau or 360, start_date=None)
-        actual_df = model_class.inverse_transform(solved_df, tau=tau, start_date=None if tau is None else start_date)
-        trans_df = model_class.transform(actual_df, tau=tau)
-        if issubclass(model_class, SEWIRFModel):
-            return
-        assert_frame_equal(model_class.transform(actual_df), solved_df)
-        assert_frame_equal(trans_df.reset_index(drop=True), solved_df.reset_index(drop=True))
+@pytest.mark.parametrize("tau", [720, 1440])
+def test_solve(model_class, tau):
+    model = model_class.from_sample(tau=tau)
+    df = model.solve()
+    assert df.iloc[0].to_dict() == model.settings()["initial_dict"]
+    Validator(df, name="analytical solution").dataframe(time_index=True, columns=model_class._VARIABLES)
+    assert df.index.name == Term.DATE
 
-    def test_r0(self, model_class):
-        model = model_class.from_sample()
-        assert model.r0() > 0
-        with pytest.raises(ZeroDivisionError):
-            _dict = model.settings()
-            _dict.update(param_dict={param: 0 for param in _dict["param_dict"].keys()})
-            model_class(**_dict).r0()
 
-    def test_dimensional_parameters(self, model_class):
-        model = model_class.from_sample()
-        assert model.dimensional_parameters()
-        with pytest.raises(ZeroDivisionError):
-            _dict = model.settings()
-            _dict.update(param_dict={param: 0 for param in _dict["param_dict"].keys()})
-            model_class(**_dict).dimensional_parameters()
+@pytest.mark.parametrize("tau", [720, 1440, None])
+def test_transform(model_class, tau):
+    model = model_class.from_sample(tau=tau or 360)
+    start_date = model.settings()["date_range"][0]
+    solved_df = model.solve()
+    with pytest.raises(NotNoneError):
+        model_class.inverse_transform(solved_df.reset_index(drop=True), tau=None, start_date=start_date)
+    with pytest.raises(UnExpectedNoneError):
+        model_class.inverse_transform(solved_df.reset_index(drop=True), tau=tau or 360, start_date=None)
+    actual_df = model_class.inverse_transform(solved_df, tau=tau, start_date=None if tau is None else start_date)
+    trans_df = model_class.transform(actual_df, tau=tau)
+    if issubclass(model_class, SEWIRFModel):
+        return
+    assert_frame_equal(model_class.transform(actual_df), solved_df)
+    assert_frame_equal(trans_df.reset_index(drop=True), solved_df.reset_index(drop=True))
 
-    @pytest.mark.parametrize("tau", [720, 1440])
-    def test_from_data(self, model_class, tau):
-        sample_model = model_class.from_sample(tau=tau)
-        sample_df = sample_model.solve()
-        sample_dict = sample_model.settings()
-        trans_df = model_class.inverse_transform(sample_df).reset_index()
-        model = model_class.from_data(data=trans_df, param_dict=sample_dict["param_dict"], tau=tau, digits=None)
-        assert model.settings(with_estimation=True)["estimation_dict"]["method"] == "not_performed"
-        solved_df = model.solve()
-        if issubclass(model_class, SEWIRFModel):
-            return
-        assert_index_equal(solved_df.index, sample_df.index)
-        assert_series_equal(solved_df.iloc[0], sample_df.iloc[0])
 
-    @pytest.mark.parametrize("tau", [720, 1440])
-    @pytest.mark.parametrize("q", [0.5])
-    def test_from_data_with_quantile(self, model_class, tau, q):
-        if issubclass(model_class, SEWIRFModel):
-            with pytest.raises(NotImplementedError):
-                model_class.from_data_with_quantile()
-            return
-        sample_model = model_class.from_sample(tau=tau)
-        sample_df = sample_model.solve()
-        trans_df = model_class.inverse_transform(sample_df).reset_index()
-        model = model_class.from_data_with_quantile(data=trans_df, tau=tau, q=q, digits=2)
-        assert model.settings(with_estimation=True)["estimation_dict"]["method"] == "with_quantile"
-        solved_df = model.solve()
-        assert_index_equal(solved_df.index, sample_df.index)
-        assert_series_equal(solved_df.iloc[0], sample_df.iloc[0])
+def test_r0(model_class):
+    model = model_class.from_sample()
+    assert model.r0() > 0
+    with pytest.raises(ZeroDivisionError):
+        _dict = model.settings()
+        _dict.update(param_dict={param: 0 for param in _dict["param_dict"].keys()})
+        model_class(**_dict).r0()
 
-    @pytest.mark.parametrize("tau", [720, 1440])
-    @pytest.mark.parametrize("metric", ["RMSLE"])
-    def test_from_data_with_optimization(self, model_class, tau, metric):
-        if issubclass(model_class, SEWIRFModel):
-            with pytest.raises(NotImplementedError):
-                model_class.from_data_with_optimization()
-            return
-        sample_model = model_class.from_sample(tau=tau)
-        sample_df = sample_model.solve()
-        trans_df = model_class.inverse_transform(sample_df).reset_index()
-        model = model_class.from_data_with_optimization(data=trans_df, tau=tau, metric=metric, digits=4)
-        assert model.settings(with_estimation=True)["estimation_dict"]["method"] == "with_optimization"
-        solved_df = model.solve()
-        assert_index_equal(solved_df.index, sample_df.index)
-        assert_series_equal(solved_df.iloc[0], sample_df.iloc[0])
 
-    @pytest.mark.parametrize("tau", [720])
-    @pytest.mark.parametrize("metric", ["RMSLE"])
-    def test_from_data_with_optimization_with_infinity(self, model_class, tau, metric):
-        if issubclass(model_class, SEWIRFModel):
-            return
-        sample_model = model_class.from_sample(tau=tau)
-        sample_df = sample_model.solve()
-        trans_df = model_class.inverse_transform(sample_df).reset_index()
-        trans_df[Term.R] = 0
-        model_class.from_data_with_optimization(data=trans_df, tau=tau, metric=metric, digits=4)
+def test_dimensional_parameters(model_class):
+    model = model_class.from_sample()
+    assert model.dimensional_parameters()
+    with pytest.raises(ZeroDivisionError):
+        _dict = model.settings()
+        _dict.update(param_dict={param: 0 for param in _dict["param_dict"].keys()})
+        model_class(**_dict).dimensional_parameters()
 
-    def test_sr(self, model_class):
-        if issubclass(model_class, SEWIRFModel):
-            return
-        sample_model = model_class.from_sample()
-        record_df = model_class.inverse_transform(sample_model.solve())
-        sr_df = sample_model.sr(record_df)
-        sr_df.corr()
-        assert set(sr_df.reset_index().columns) == {model_class.DATE, model_class._logS, model_class._r}
+
+@pytest.mark.parametrize("tau", [720, 1440])
+def test_from_data(model_class, tau):
+    sample_model = model_class.from_sample(tau=tau)
+    sample_df = sample_model.solve()
+    sample_dict = sample_model.settings()
+    trans_df = model_class.inverse_transform(sample_df).reset_index()
+    model = model_class.from_data(data=trans_df, param_dict=sample_dict["param_dict"], tau=tau, digits=None)
+    assert model.settings(with_estimation=True)["estimation_dict"]["method"] == "not_performed"
+    solved_df = model.solve()
+    if issubclass(model_class, SEWIRFModel):
+        return
+    assert_index_equal(solved_df.index, sample_df.index)
+    assert_series_equal(solved_df.iloc[0], sample_df.iloc[0])
+
+
+@pytest.mark.parametrize("tau", [720, 1440])
+@pytest.mark.parametrize("q", [0.5])
+def test_from_data_with_quantile(model_class, tau, q):
+    if issubclass(model_class, SEWIRFModel):
+        with pytest.raises(NotImplementedError):
+            model_class.from_data_with_quantile()
+        return
+    sample_model = model_class.from_sample(tau=tau)
+    sample_df = sample_model.solve()
+    trans_df = model_class.inverse_transform(sample_df).reset_index()
+    model = model_class.from_data_with_quantile(data=trans_df, tau=tau, q=q, digits=2)
+    assert model.settings(with_estimation=True)["estimation_dict"]["method"] == "with_quantile"
+    solved_df = model.solve()
+    assert_index_equal(solved_df.index, sample_df.index)
+    assert_series_equal(solved_df.iloc[0], sample_df.iloc[0])
+
+
+@pytest.mark.parametrize("tau", [720, 1440])
+@pytest.mark.parametrize("metric", ["RMSLE"])
+def test_from_data_with_optimization(model_class, tau, metric):
+    if issubclass(model_class, SEWIRFModel):
+        with pytest.raises(NotImplementedError):
+            model_class.from_data_with_optimization()
+        return
+    sample_model = model_class.from_sample(tau=tau)
+    sample_df = sample_model.solve()
+    trans_df = model_class.inverse_transform(sample_df).reset_index()
+    model = model_class.from_data_with_optimization(data=trans_df, tau=tau, metric=metric, digits=4)
+    assert model.settings(with_estimation=True)["estimation_dict"]["method"] == "with_optimization"
+    solved_df = model.solve()
+    assert_index_equal(solved_df.index, sample_df.index)
+    assert_series_equal(solved_df.iloc[0], sample_df.iloc[0])
+
+
+@pytest.mark.parametrize("tau", [720])
+@pytest.mark.parametrize("metric", ["RMSLE"])
+def test_from_data_with_optimization_with_infinity(model_class, tau, metric):
+    if issubclass(model_class, SEWIRFModel):
+        return
+    sample_model = model_class.from_sample(tau=tau)
+    sample_df = sample_model.solve()
+    trans_df = model_class.inverse_transform(sample_df).reset_index()
+    trans_df[Term.R] = 0
+    model_class.from_data_with_optimization(data=trans_df, tau=tau, metric=metric, digits=4)
+
+
+def test_sr(model_class):
+    if issubclass(model_class, SEWIRFModel):
+        return
+    sample_model = model_class.from_sample()
+    record_df = model_class.inverse_transform(sample_model.solve())
+    sr_df = sample_model.sr(record_df)
+    sr_df.corr()
+    assert set(sr_df.reset_index().columns) == {model_class.DATE, model_class._logS, model_class._r}

--- a/tests/test_dynamics/test_model.py
+++ b/tests/test_dynamics/test_model.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 from pandas.testing import assert_frame_equal, assert_index_equal, assert_series_equal
 import pytest

--- a/tests/test_engineering/test_engineer.py
+++ b/tests/test_engineering/test_engineer.py
@@ -5,71 +5,74 @@ from covsirphy import DataEngineer, Term, Dynamics, SIRFModel
 from covsirphy.util.error import NotIncludedError
 
 
-class TestDataEngineer(object):
-    def test_from_sample_data(self):
-        dynamics = Dynamics.from_sample(model=SIRFModel)
-        data = dynamics.simulate().reset_index()
-        data.insert(0, "Model", SIRFModel.name())
-        engineer = DataEngineer(layers=["Model"], country=None)
-        engineer.register(data, citations="Simulated data")
-        assert set(engineer.all().columns) == {"Model", Term.DATE, Term.S, Term.CI, Term.F, Term.R}
-        assert engineer.citations() == ["Simulated data"]
-        engineer.inverse_transform()
-        assert set(engineer.all().columns) == {"Model", Term.DATE, Term.S, Term.CI, Term.F, Term.R, Term.N, Term.C}
-        assert len(engineer.subset(geo=SIRFModel.name())[0]) == len(data)
+def test_from_sample_data():
+    dynamics = Dynamics.from_sample(model=SIRFModel)
+    data = dynamics.simulate().reset_index()
+    data.insert(0, "Model", SIRFModel.name())
+    engineer = DataEngineer(layers=["Model"], country=None)
+    engineer.register(data, citations="Simulated data")
+    assert set(engineer.all().columns) == {"Model", Term.DATE, Term.S, Term.CI, Term.F, Term.R}
+    assert engineer.citations() == ["Simulated data"]
+    engineer.inverse_transform()
+    assert set(engineer.all().columns) == {"Model", Term.DATE, Term.S, Term.CI, Term.F, Term.R, Term.N, Term.C}
+    assert len(engineer.subset(geo=SIRFModel.name())[0]) == len(data)
 
-    def test_operations(self):
-        dynamics = Dynamics.from_sample(model=SIRFModel)
-        data = dynamics.simulate().reset_index()
-        data.insert(0, "Model", SIRFModel.name())
-        engineer = DataEngineer(layers=["Model"], country=None)
-        engineer.register(data, citations="Simulated data")
-        engineer.inverse_transform()
-        # Diff
-        engineer.diff(column=Term.C, suffix="_diff", freq="D")
-        assert f"{Term.C}_diff" in engineer.all()
-        # Addition
-        engineer.add(columns=[Term.F, Term.R])
-        assert f"{Term.F}+{Term.R}" in engineer.all()
-        # Multiplication
-        engineer.mul(columns=[Term.C, Term.R])
-        assert f"{Term.C}*{Term.R}" in engineer.all()
-        # Subtraction
-        engineer.sub(minuend=Term.C, subtrahend=Term.R)
-        assert f"{Term.C}-{Term.R}" in engineer.all()
-        # Division and assign
-        engineer.assign(Tests=lambda x: x[Term.C] * 10)
-        engineer.div(numerator=Term.C, denominator="Tests", new="Positive_rate")
-        engineer.assign(**{"Positive_rate_%": lambda x: x["Positive_rate"] * 100})
-        assert engineer.all()["Positive_rate_%"].unique() == 10
 
-    def test_with_actual_data(self, imgfile):
-        engineer = DataEngineer()
-        engineer.download(databases=["japan", "covid19dh", "owid"])
-        all_df = engineer.all()
-        layer_df = engineer.layer()
-        assert_frame_equal(all_df, layer_df, check_dtype=False, check_categorical=False)
-        engineer.choropleth(geo=None, variable=Term.C, filename=imgfile)
-        engineer.clean()
-        engineer.transform()
-        assert len(engineer.subset(geo="Japan", complement=False)) == len(engineer.subset(geo="Japan"))
-        df, *_ = engineer.subset_alias(alias="UK", geo="UK")
-        assert_frame_equal(engineer.subset_alias(alias="UK")[0], df)
-        assert engineer.subset_alias(alias=None)
-        assert isinstance(DataEngineer.recovery_period(data=df), int)
+def test_operations():
+    dynamics = Dynamics.from_sample(model=SIRFModel)
+    data = dynamics.simulate().reset_index()
+    data.insert(0, "Model", SIRFModel.name())
+    engineer = DataEngineer(layers=["Model"], country=None)
+    engineer.register(data, citations="Simulated data")
+    engineer.inverse_transform()
+    # Diff
+    engineer.diff(column=Term.C, suffix="_diff", freq="D")
+    assert f"{Term.C}_diff" in engineer.all()
+    # Addition
+    engineer.add(columns=[Term.F, Term.R])
+    assert f"{Term.F}+{Term.R}" in engineer.all()
+    # Multiplication
+    engineer.mul(columns=[Term.C, Term.R])
+    assert f"{Term.C}*{Term.R}" in engineer.all()
+    # Subtraction
+    engineer.sub(minuend=Term.C, subtrahend=Term.R)
+    assert f"{Term.C}-{Term.R}" in engineer.all()
+    # Division and assign
+    engineer.assign(Tests=lambda x: x[Term.C] * 10)
+    engineer.div(numerator=Term.C, denominator="Tests", new="Positive_rate")
+    engineer.assign(**{"Positive_rate_%": lambda x: x["Positive_rate"] * 100})
+    assert engineer.all()["Positive_rate_%"].unique() == 10
 
-    def test_variables_alias(self):
-        engineer = DataEngineer()
-        assert engineer.variables_alias(alias=None)
-        engineer.variables_alias(alias="nc", variables=[Term.N, Term.C])
-        assert engineer.variables_alias(alias="nc") == [Term.N, Term.C]
-        with pytest.raises(NotIncludedError):
-            engineer.variables_alias(alias="unknown")
 
-    def test_resample_with_date_range(self):
-        eng = DataEngineer(layers=["Country"], country=["Country"])
-        eng.download(databases=["wpp"])
-        eng.clean(kinds=["resample"], date_range=("01Jan2022", "19Sep2022"))
-        df = eng.all()
-        assert df["Date"].min() >= pd.to_datetime("01Jan2022")
-        assert df["Date"].max() <= pd.to_datetime("19Sep2022")
+def test_with_actual_data(imgfile):
+    engineer = DataEngineer()
+    engineer.download(databases=["japan", "covid19dh", "owid"])
+    all_df = engineer.all()
+    layer_df = engineer.layer()
+    assert_frame_equal(all_df, layer_df, check_dtype=False, check_categorical=False)
+    engineer.choropleth(geo=None, variable=Term.C, filename=imgfile)
+    engineer.clean()
+    engineer.transform()
+    assert len(engineer.subset(geo="Japan", complement=False)) == len(engineer.subset(geo="Japan"))
+    df, *_ = engineer.subset_alias(alias="UK", geo="UK")
+    assert_frame_equal(engineer.subset_alias(alias="UK")[0], df)
+    assert engineer.subset_alias(alias=None)
+    assert isinstance(DataEngineer.recovery_period(data=df), int)
+
+
+def test_variables_alias():
+    engineer = DataEngineer()
+    assert engineer.variables_alias(alias=None)
+    engineer.variables_alias(alias="nc", variables=[Term.N, Term.C])
+    assert engineer.variables_alias(alias="nc") == [Term.N, Term.C]
+    with pytest.raises(NotIncludedError):
+        engineer.variables_alias(alias="unknown")
+
+
+def test_resample_with_date_range():
+    eng = DataEngineer(layers=["Country"], country=["Country"])
+    eng.download(databases=["wpp"])
+    eng.clean(kinds=["resample"], date_range=("01Jan2022", "19Sep2022"))
+    df = eng.all()
+    assert df["Date"].min() >= pd.to_datetime("01Jan2022")
+    assert df["Date"].max() <= pd.to_datetime("19Sep2022")

--- a/tests/test_engineering/test_engineer.py
+++ b/tests/test_engineering/test_engineer.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 from pandas.testing import assert_frame_equal
 import pytest

--- a/tests/test_gis/test_gis.py
+++ b/tests/test_gis/test_gis.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 import pytest
 from covsirphy import GIS, NotRegisteredError, SubsetNotFoundError

--- a/tests/test_gis/test_gis.py
+++ b/tests/test_gis/test_gis.py
@@ -3,102 +3,105 @@ import pytest
 from covsirphy import GIS, NotRegisteredError, SubsetNotFoundError
 
 
-class TestGIS(object):
-    def test_all(self, c_df, p_df):
-        system = GIS(layers=["Country", "Province"], country="Country", date="Date")
-        with pytest.raises(NotRegisteredError):
-            system.all(variables=["Positive"])
-        system.register(data=c_df, layers=["Country"], date="date", citations="Country-level")
-        system.register(data=p_df, layers=["Country", "Prefecture"], date="date", citations="Prefecture-level")
-        all_df = system.all(variables=["Positive"])
-        assert all_df.columns.tolist() == ["Country", "Province", "Date", "Positive"]
-        assert set(system.citations()) == {"Country-level", "Prefecture-level"}
+def test_all(c_df, p_df):
+    system = GIS(layers=["Country", "Province"], country="Country", date="Date")
+    with pytest.raises(NotRegisteredError):
+        system.all(variables=["Positive"])
+    system.register(data=c_df, layers=["Country"], date="date", citations="Country-level")
+    system.register(data=p_df, layers=["Country", "Prefecture"], date="date", citations="Prefecture-level")
+    all_df = system.all(variables=["Positive"])
+    assert all_df.columns.tolist() == ["Country", "Province", "Date", "Positive"]
+    assert set(system.citations()) == {"Country-level", "Prefecture-level"}
 
-    @pytest.mark.parametrize(
-        "geo, end_date, length",
-        [
-            (None, "31Dec2021", 365),
-            ((None,), "31Dec2021", 365),
-            ("Japan", "31Dec2020", 0),
-            ("Japan", "31Dec2021", 365 * 47),
-            (("Japan",), "31Dec2021", 365 * 47),
-            ((["Japan", "UK"],), "31Dec2021", 365 * 47),
-            ("UK", "31Dec2021", 0),
-        ]
-    )
-    def test_layer(self, c_df, p_df, geo, end_date, length):
-        system = GIS(layers=["Country", "Province"], country="Country", date="Date")
+
+@pytest.mark.parametrize(
+    "geo, end_date, length",
+    [
+        (None, "31Dec2021", 365),
+        ((None,), "31Dec2021", 365),
+        ("Japan", "31Dec2020", 0),
+        ("Japan", "31Dec2021", 365 * 47),
+        (("Japan",), "31Dec2021", 365 * 47),
+        ((["Japan", "UK"],), "31Dec2021", 365 * 47),
+        ("UK", "31Dec2021", 0),
+    ]
+)
+def test_layer(c_df, p_df, geo, end_date, length):
+    system = GIS(layers=["Country", "Province"], country="Country", date="Date")
+    with pytest.raises(NotRegisteredError):
+        system.layer(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
+    system.register(data=c_df, layers=["Country"], date="date", citations="Country-level")
+    system.register(data=p_df, layers=["Country", "Prefecture"], date="date", citations="Prefecture-level")
+    if length == 0:
         with pytest.raises(NotRegisteredError):
             system.layer(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
-        system.register(data=c_df, layers=["Country"], date="date", citations="Country-level")
-        system.register(data=p_df, layers=["Country", "Prefecture"], date="date", citations="Prefecture-level")
-        if length == 0:
-            with pytest.raises(NotRegisteredError):
-                system.layer(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
-        else:
-            df = system.layer(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
-            assert set(df.columns) == {"Country", "Province", "Date", "Positive", "Tested", "Discharged", "Fatal"}
-            assert len(df) == length
+    else:
+        df = system.layer(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
+        assert set(df.columns) == {"Country", "Province", "Date", "Positive", "Tested", "Discharged", "Fatal"}
+        assert len(df) == length
 
-    @pytest.mark.parametrize("geo, on", [(None, "01Jan2022"), ("Japan", None), ("Japan", "01Feb2022")])
-    def test_to_geo_pandas_choropleth(self, c_df, p_df, geo, on, imgfile):
-        with pytest.raises(ValueError):
-            GIS(layers=["Province"], country="Country").to_geopandas()
-        with pytest.raises(ValueError):
-            GIS(layers=["Country", "Province"], country=None).to_geopandas()
-        system = GIS(layers=["Country", "Province"], country="Country", date="Date")
-        system.register(data=c_df, layers=["Country"], date="date", citations="Country-level")
-        system.register(data=p_df, layers=["Country", "Prefecture"], date="date", citations="Prefecture-level")
-        gdf = system.to_geopandas(geo=geo, on=on)
-        if geo is None:
-            assert "Province" not in gdf.columns
-            assert gdf["Country"].unique() == ["JPN"]
-        else:
-            assert "Country" not in gdf.columns
-            assert gdf["Province"].nunique() == 47
-        if on is None:
-            assert gdf["Date"].max() == system.layer(geo=geo)["Date"].max()
-        else:
-            assert pd.to_datetime(gdf["Date"].unique()) == [pd.to_datetime(on)]
-        # Choropleth map
-        system.choropleth(geo=geo, on=on, variable="Positive", filename=imgfile)
 
-    @pytest.mark.parametrize(
-        "geo, end_date, length",
-        [
-            (None, "31Dec2021", 365),
-            ((None,), "31Dec2021", 365),
-            ("Japan", "31Dec2020", 0),
-            ("Japan", "31Dec2021", 365),
-            (("Japan",), "31Dec2021", 365),
-            ((["Japan", "UK"],), "31Dec2021", 365),
-            ("UK", "31Dec2021", 0),
-        ]
-    )
-    def test_subset(self, c_df, p_df, geo, end_date, length):
-        system = GIS(layers=["Country", "Province"], country="Country", date="Date")
-        with pytest.raises(NotRegisteredError):
+@pytest.mark.parametrize("geo, on", [(None, "01Jan2022"), ("Japan", None), ("Japan", "01Feb2022")])
+def test_to_geo_pandas_choropleth(c_df, p_df, geo, on, imgfile):
+    with pytest.raises(ValueError):
+        GIS(layers=["Province"], country="Country").to_geopandas()
+    with pytest.raises(ValueError):
+        GIS(layers=["Country", "Province"], country=None).to_geopandas()
+    system = GIS(layers=["Country", "Province"], country="Country", date="Date")
+    system.register(data=c_df, layers=["Country"], date="date", citations="Country-level")
+    system.register(data=p_df, layers=["Country", "Prefecture"], date="date", citations="Prefecture-level")
+    gdf = system.to_geopandas(geo=geo, on=on)
+    if geo is None:
+        assert "Province" not in gdf.columns
+        assert gdf["Country"].unique() == ["JPN"]
+    else:
+        assert "Country" not in gdf.columns
+        assert gdf["Province"].nunique() == 47
+    if on is None:
+        assert gdf["Date"].max() == system.layer(geo=geo)["Date"].max()
+    else:
+        assert pd.to_datetime(gdf["Date"].unique()) == [pd.to_datetime(on)]
+    # Choropleth map
+    system.choropleth(geo=geo, on=on, variable="Positive", filename=imgfile)
+
+
+@pytest.mark.parametrize(
+    "geo, end_date, length",
+    [
+        (None, "31Dec2021", 365),
+        ((None,), "31Dec2021", 365),
+        ("Japan", "31Dec2020", 0),
+        ("Japan", "31Dec2021", 365),
+        (("Japan",), "31Dec2021", 365),
+        ((["Japan", "UK"],), "31Dec2021", 365),
+        ("UK", "31Dec2021", 0),
+    ]
+)
+def test_subset(c_df, p_df, geo, end_date, length):
+    system = GIS(layers=["Country", "Province"], country="Country", date="Date")
+    with pytest.raises(NotRegisteredError):
+        system.subset(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
+    system.register(data=c_df, layers=["Country"], date="date", citations="Country-level")
+    system.register(data=p_df, layers=["Country", "Prefecture"], date="date", citations="Prefecture-level")
+    if length == 0:
+        with pytest.raises(SubsetNotFoundError):
             system.subset(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
-        system.register(data=c_df, layers=["Country"], date="date", citations="Country-level")
-        system.register(data=p_df, layers=["Country", "Prefecture"], date="date", citations="Prefecture-level")
-        if length == 0:
-            with pytest.raises(SubsetNotFoundError):
-                system.subset(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
-        else:
-            df = system.subset(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
-            assert set(df.columns) == {"Date", "Positive", "Tested", "Discharged", "Fatal"}
-            assert len(df) == length
+    else:
+        df = system.subset(geo=geo, start_date="01Jan2021", end_date=end_date, variables=None)
+        assert set(df.columns) == {"Date", "Positive", "Tested", "Discharged", "Fatal"}
+        assert len(df) == length
 
-    @pytest.mark.parametrize(
-        "geo, answer",
-        [
-            (None, "the world"),
-            ((None,), "the world"),
-            ("Japan", "Japan"),
-            (("Japan",), "Japan"),
-            ((["Japan", "UK"],), "Japan_UK"),
-            (("Japan", "Tokyo"), "Tokyo/Japan"),
-        ]
-    )
-    def test_area_name(self, geo, answer):
-        assert GIS.area_name(geo) == answer
+
+@pytest.mark.parametrize(
+    "geo, answer",
+    [
+        (None, "the world"),
+        ((None,), "the world"),
+        ("Japan", "Japan"),
+        (("Japan",), "Japan"),
+        ((["Japan", "UK"],), "Japan_UK"),
+        (("Japan", "Tokyo"), "Tokyo/Japan"),
+    ]
+)
+def test_area_name(geo, answer):
+    assert GIS.area_name(geo) == answer

--- a/tests/test_gis/test_layer.py
+++ b/tests/test_gis/test_layer.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import pandas as pd
 from pandas.testing import assert_frame_equal

--- a/tests/test_gis/test_layer.py
+++ b/tests/test_gis/test_layer.py
@@ -6,86 +6,86 @@ from covsirphy import Term
 from covsirphy.gis._layer import _LayerAdjuster as LayerAdjuster
 
 
-class TestLayerAdjuster(object):
-    def test_empty(self):
-        with pytest.raises(ValueError):
-            collector = LayerAdjuster(layers=["ISO3", "Province", "Province"])
-        collector = LayerAdjuster(layers=["ISO3", "Province"])
-        all_df = collector.all()
-        assert all_df.empty
-        assert set(all_df.columns) == {"Date", "ISO3", "Province"}
-        assert not collector.citations()
+def test_empty():
+    with pytest.raises(ValueError):
+        collector = LayerAdjuster(layers=["ISO3", "Province", "Province"])
+    collector = LayerAdjuster(layers=["ISO3", "Province"])
+    all_df = collector.all()
+    assert all_df.empty
+    assert set(all_df.columns) == {"Date", "ISO3", "Province"}
+    assert not collector.citations()
 
-    @pytest.mark.parametrize(
-        "country, layers, data_dict, all_dict",
+
+@pytest.mark.parametrize(
+    "country, layers, data_dict, all_dict",
+    (
         (
-            (
-                "ISO3",
-                ["ISO3", "Province", "City"],
-                {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]},
-                {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]}
-            ),
-            (
-                "ISO3",
-                ["ISO3", "Province", "City"],
-                {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"]},
-                {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"], "City": ["-", "-"]}
-            ),
-            (
-                "ISO3",
-                ["ISO3", "Province"],
-                {"ISO3": ["JPN", "JPN"], "Prefecture": ["-", "Tokyo"]},
-                {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"]}
-            ),
-            (
-                "ISO3",
-                ["ISO3", "Province", "City"],
-                {"ISO3": ["JPN", "JPN"], "City": ["-", "Chiyoda"]},
-                {"ISO3": ["JPN", "JPN"], "Province": ["-", "-"], "City": ["-", "Chiyoda"]}
-            ),
-            (
-                "ISO3",
-                ["ISO3", "Province"],
-                {"ISO3": ["JPN", "JPN", "JPN"], "Province": ["-", "Tokyo", "Tokyo"], "City": ["-", "-", "Chiyoda"]},
-                {"ISO3": ["JPN", "JPN", "-"], "Province": ["-", "Tokyo", "-"]}
-            ),
-            (
-                "ISO3",
-                ["ISO3", "Province", "City"],
-                {"Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]},
-                {"ISO3": ["-", "-"], "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]}
-            ),
-            (
-                "Country",
-                ["Country", "Province", "City"],
-                {"Country": ["Japan", "Japan"], "Region": ["-", "Kanto"], "City": ["-", "Chiyoda"]},
-                {"Country": ["JPN", "JPN"], "Province": ["-", "Kanto"], "City": ["-", "Chiyoda"]}
-            ),
-            (
-                "Country",
-                ["Country", "Province", "City"],
-                {"Country": ["Japan", "Japan"], "Region": ["-", "Kanto"],
-                    "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]},
-                {"Country": ["JPN", "JPN"], "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]}
-            ),
-        )
+            "ISO3",
+            ["ISO3", "Province", "City"],
+            {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]},
+            {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]}
+        ),
+        (
+            "ISO3",
+            ["ISO3", "Province", "City"],
+            {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"]},
+            {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"], "City": ["-", "-"]}
+        ),
+        (
+            "ISO3",
+            ["ISO3", "Province"],
+            {"ISO3": ["JPN", "JPN"], "Prefecture": ["-", "Tokyo"]},
+            {"ISO3": ["JPN", "JPN"], "Province": ["-", "Tokyo"]}
+        ),
+        (
+            "ISO3",
+            ["ISO3", "Province", "City"],
+            {"ISO3": ["JPN", "JPN"], "City": ["-", "Chiyoda"]},
+            {"ISO3": ["JPN", "JPN"], "Province": ["-", "-"], "City": ["-", "Chiyoda"]}
+        ),
+        (
+            "ISO3",
+            ["ISO3", "Province"],
+            {"ISO3": ["JPN", "JPN", "JPN"], "Province": ["-", "Tokyo", "Tokyo"], "City": ["-", "-", "Chiyoda"]},
+            {"ISO3": ["JPN", "JPN", "-"], "Province": ["-", "Tokyo", "-"]}
+        ),
+        (
+            "ISO3",
+            ["ISO3", "Province", "City"],
+            {"Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]},
+            {"ISO3": ["-", "-"], "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]}
+        ),
+        (
+            "Country",
+            ["Country", "Province", "City"],
+            {"Country": ["Japan", "Japan"], "Region": ["-", "Kanto"], "City": ["-", "Chiyoda"]},
+            {"Country": ["JPN", "JPN"], "Province": ["-", "Kanto"], "City": ["-", "Chiyoda"]}
+        ),
+        (
+            "Country",
+            ["Country", "Province", "City"],
+            {"Country": ["Japan", "Japan"], "Region": ["-", "Kanto"],
+                "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]},
+            {"Country": ["JPN", "JPN"], "Province": ["-", "Tokyo"], "City": ["-", "Chiyoda"]}
+        ),
     )
-    def test_register(self, country, layers, data_dict, all_dict):
-        day0, day1 = pd.to_datetime("2022-01-01"), pd.to_datetime("2022-01-02")
-        raw = pd.concat([pd.DataFrame(data_dict), pd.DataFrame(data_dict)], axis=0, ignore_index=True)
-        raw["date"] = [day0 for _ in range(len(raw) // 2)] + [day1 for _ in range(len(raw) // 2)]
-        raw["Confirmed"] = np.arange(len(raw))
-        raw["Recovered"] = 0
-        collector = LayerAdjuster(layers=layers, country=country)
-        with pytest.raises(ValueError):
-            collector.register(
-                data=raw, layers=["Country", "Country"], date="date", variables=["Confirmed", "Recovered"], citations="Manual")
+)
+def test_register(country, layers, data_dict, all_dict):
+    day0, day1 = pd.to_datetime("2022-01-01"), pd.to_datetime("2022-01-02")
+    raw = pd.concat([pd.DataFrame(data_dict), pd.DataFrame(data_dict)], axis=0, ignore_index=True)
+    raw["date"] = [day0 for _ in range(len(raw) // 2)] + [day1 for _ in range(len(raw) // 2)]
+    raw["Confirmed"] = np.arange(len(raw))
+    raw["Recovered"] = 0
+    collector = LayerAdjuster(layers=layers, country=country)
+    with pytest.raises(ValueError):
         collector.register(
-            data=raw, layers=list(data_dict.keys()), date="date", variables=["Confirmed"], citations="Manual")
-        # Expected all data
-        all_df = pd.concat([pd.DataFrame(all_dict), pd.DataFrame(all_dict)], axis=0, ignore_index=True)
-        all_df[Term.DATE] = [day0 for _ in range(len(all_df) // 2)] + [day1 for _ in range(len(all_df) // 2)]
-        all_df["Confirmed"] = np.arange(len(all_df))
-        all_df = all_df.sort_values([*layers, Term.DATE], ignore_index=True)
-        assert_frame_equal(collector.all(variables=["Confirmed"]), all_df, check_dtype=False)
-        assert collector.citations() == ["Manual"]
+            data=raw, layers=["Country", "Country"], date="date", variables=["Confirmed", "Recovered"], citations="Manual")
+    collector.register(
+        data=raw, layers=list(data_dict.keys()), date="date", variables=["Confirmed"], citations="Manual")
+    # Expected all data
+    all_df = pd.concat([pd.DataFrame(all_dict), pd.DataFrame(all_dict)], axis=0, ignore_index=True)
+    all_df[Term.DATE] = [day0 for _ in range(len(all_df) // 2)] + [day1 for _ in range(len(all_df) // 2)]
+    all_df["Confirmed"] = np.arange(len(all_df))
+    all_df = all_df.sort_values([*layers, Term.DATE], ignore_index=True)
+    assert_frame_equal(collector.all(variables=["Confirmed"]), all_df, check_dtype=False)
+    assert collector.citations() == ["Manual"]

--- a/tests/test_gis/test_subset.py
+++ b/tests/test_gis/test_subset.py
@@ -4,186 +4,186 @@ from covsirphy import Term
 from covsirphy.gis._subset import _SubsetManager as SubsetManager
 
 
-class TestSubsetManager(object):
-    def test_layer(self):
-        day0, day1 = pd.to_datetime("2022-01-01"), pd.to_datetime("2022-01-02")
-        raw = pd.DataFrame(
-            {
-                Term.COUNTRY: [Term.NA, Term.NA, *["UK" for _ in range(4)], *["Japan" for _ in range(10)]],
-                Term.PROVINCE: [
-                    Term.NA, Term.NA, "England", "England", *[Term.NA for _ in range(4)],
-                    *["Tokyo" for _ in range(4)], *["Kanagawa" for _ in range(4)]],
-                Term.CITY: [
-                    *[Term.NA for _ in range(10)], "Chiyoda", "Chiyoda", "Yokohama", "Yokohama", "Kawasaki", "Kawasaki"],
-                Term.DATE: [day0, day1] * 8,
-                Term.C: range(16),
-            }
-        )
-        geography = SubsetManager(layers=[Term.COUNTRY, Term.PROVINCE, Term.CITY])
-        # When `geo=None` or `geo=(None,)`, returns country-level data.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["UK", "UK", "Japan", "Japan"],
-                Term.PROVINCE: [Term.NA for _ in range(4)],
-                Term.CITY: [Term.NA for _ in range(4)],
-                Term.DATE: [day0, day1] * 2,
-                Term.C: [4, 5, 6, 7],
-            }
-        )
-        assert geography.layer(data=raw, geo=None).equals(df)
-        assert geography.layer(data=raw, geo=(None,)).equals(df)
-        # When `geo=("Japan",)` or `geo="Japan"`, returns province-level data in Japan.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["Japan" for _ in range(2)],
-                Term.PROVINCE: ["Tokyo", "Tokyo"],
-                Term.CITY: [Term.NA for _ in range(2)],
-                Term.DATE: [day0, day1],
-                Term.C: [8, 9],
-            }
-        )
-        assert geography.layer(data=raw, geo=("Japan",)).equals(df)
-        assert geography.layer(data=raw, geo="Japan").equals(df)
-        # When `geo=(["Japan", "UK"],)`, returns province-level data in Japan and UK.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["UK", "UK", "Japan", "Japan"],
-                Term.PROVINCE: ["England", "England", "Tokyo", "Tokyo"],
-                Term.CITY: [Term.NA for _ in range(4)],
-                Term.DATE: [day0, day1] * 2,
-                Term.C: [2, 3, 8, 9],
-            }
-        )
-        assert geography.layer(data=raw, geo=(["Japan", "UK"],)).equals(df)
-        # When `geo=("Japan", "Kanagawa")`, returns city-level data in Kanagawa/Japan.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["Japan" for _ in range(4)],
-                Term.PROVINCE: ["Kanagawa" for _ in range(4)],
-                Term.CITY: ["Yokohama", "Yokohama", "Kawasaki", "Kawasaki"],
-                Term.DATE: [day0, day1] * 2,
-                Term.C: [12, 13, 14, 15],
-            }
-        )
-        assert geography.layer(data=raw, geo=("Japan", "Kanagawa")).equals(df)
-        # When `geo=("Japan", ["Tokyo", "Kanagawa"])`, returns city-level data in Tokyo/Japan and Kanagawa/Japan.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["Japan" for _ in range(6)],
-                Term.PROVINCE: ["Tokyo", "Tokyo", *["Kanagawa" for _ in range(4)]],
-                Term.CITY: ["Chiyoda", "Chiyoda", "Yokohama", "Yokohama", "Kawasaki", "Kawasaki"],
-                Term.DATE: [day0, day1] * 3,
-                Term.C: [10, 11, 12, 13, 14, 15],
-            }
-        )
-        assert geography.layer(data=raw, geo=("Japan", ["Tokyo", "Kanagawa"])).equals(df)
-        # Errors
-        with pytest.raises(TypeError):
-            geography.layer(data=raw, geo=1)
-        with pytest.raises(TypeError):
-            geography.layer(data=raw, geo=(1,))
-        with pytest.raises(ValueError):
-            geography.layer(data=raw, geo=("The Earth", "Japan", "Tokyo", "Chiyoda"))
+def test_layer():
+    day0, day1 = pd.to_datetime("2022-01-01"), pd.to_datetime("2022-01-02")
+    raw = pd.DataFrame(
+        {
+            Term.COUNTRY: [Term.NA, Term.NA, *["UK" for _ in range(4)], *["Japan" for _ in range(10)]],
+            Term.PROVINCE: [
+                Term.NA, Term.NA, "England", "England", *[Term.NA for _ in range(4)],
+                *["Tokyo" for _ in range(4)], *["Kanagawa" for _ in range(4)]],
+            Term.CITY: [
+                *[Term.NA for _ in range(10)], "Chiyoda", "Chiyoda", "Yokohama", "Yokohama", "Kawasaki", "Kawasaki"],
+            Term.DATE: [day0, day1] * 8,
+            Term.C: range(16),
+        }
+    )
+    geography = SubsetManager(layers=[Term.COUNTRY, Term.PROVINCE, Term.CITY])
+    # When `geo=None` or `geo=(None,)`, returns country-level data.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["UK", "UK", "Japan", "Japan"],
+            Term.PROVINCE: [Term.NA for _ in range(4)],
+            Term.CITY: [Term.NA for _ in range(4)],
+            Term.DATE: [day0, day1] * 2,
+            Term.C: [4, 5, 6, 7],
+        }
+    )
+    assert geography.layer(data=raw, geo=None).equals(df)
+    assert geography.layer(data=raw, geo=(None,)).equals(df)
+    # When `geo=("Japan",)` or `geo="Japan"`, returns province-level data in Japan.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["Japan" for _ in range(2)],
+            Term.PROVINCE: ["Tokyo", "Tokyo"],
+            Term.CITY: [Term.NA for _ in range(2)],
+            Term.DATE: [day0, day1],
+            Term.C: [8, 9],
+        }
+    )
+    assert geography.layer(data=raw, geo=("Japan",)).equals(df)
+    assert geography.layer(data=raw, geo="Japan").equals(df)
+    # When `geo=(["Japan", "UK"],)`, returns province-level data in Japan and UK.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["UK", "UK", "Japan", "Japan"],
+            Term.PROVINCE: ["England", "England", "Tokyo", "Tokyo"],
+            Term.CITY: [Term.NA for _ in range(4)],
+            Term.DATE: [day0, day1] * 2,
+            Term.C: [2, 3, 8, 9],
+        }
+    )
+    assert geography.layer(data=raw, geo=(["Japan", "UK"],)).equals(df)
+    # When `geo=("Japan", "Kanagawa")`, returns city-level data in Kanagawa/Japan.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["Japan" for _ in range(4)],
+            Term.PROVINCE: ["Kanagawa" for _ in range(4)],
+            Term.CITY: ["Yokohama", "Yokohama", "Kawasaki", "Kawasaki"],
+            Term.DATE: [day0, day1] * 2,
+            Term.C: [12, 13, 14, 15],
+        }
+    )
+    assert geography.layer(data=raw, geo=("Japan", "Kanagawa")).equals(df)
+    # When `geo=("Japan", ["Tokyo", "Kanagawa"])`, returns city-level data in Tokyo/Japan and Kanagawa/Japan.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["Japan" for _ in range(6)],
+            Term.PROVINCE: ["Tokyo", "Tokyo", *["Kanagawa" for _ in range(4)]],
+            Term.CITY: ["Chiyoda", "Chiyoda", "Yokohama", "Yokohama", "Kawasaki", "Kawasaki"],
+            Term.DATE: [day0, day1] * 3,
+            Term.C: [10, 11, 12, 13, 14, 15],
+        }
+    )
+    assert geography.layer(data=raw, geo=("Japan", ["Tokyo", "Kanagawa"])).equals(df)
+    # Errors
+    with pytest.raises(TypeError):
+        geography.layer(data=raw, geo=1)
+    with pytest.raises(TypeError):
+        geography.layer(data=raw, geo=(1,))
+    with pytest.raises(ValueError):
+        geography.layer(data=raw, geo=("The Earth", "Japan", "Tokyo", "Chiyoda"))
 
-    def test_filter(self):
-        day0, day1 = pd.to_datetime("2022-01-01"), pd.to_datetime("2022-01-02")
-        raw = pd.DataFrame(
-            {
-                Term.COUNTRY: [*["UK" for _ in range(4)], *["Japan" for _ in range(10)], Term.NA, Term.NA],
-                Term.PROVINCE: [
-                    "England", "England", *[Term.NA for _ in range(4)],
-                    *["Tokyo" for _ in range(4)], *["Kanagawa" for _ in range(4)], Term.NA, Term.NA],
-                Term.CITY: [
-                    *[Term.NA for _ in range(8)], "Chiyoda", "Chiyoda", "Yokohama", "Yokohama", "Kawasaki", "Kawasaki", Term.NA, Term.NA],
-                Term.DATE: [day0, day1] * 8,
-                Term.C: range(16),
-            }
-        )
-        geography = SubsetManager(layers=[Term.COUNTRY, Term.PROVINCE, Term.CITY])
-        # When `geo = None` or `geo = (None,)`, returns all country-level data.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["UK", "UK", "Japan", "Japan"],
-                Term.PROVINCE: [Term.NA for _ in range(4)],
-                Term.CITY: [Term.NA for _ in range(4)],
-                Term.DATE: [day0, day1] * 2,
-                Term.C: [2, 3, 4, 5],
-            }
-        )
-        assert geography.filter(data=raw, geo=None).equals(df)
-        assert geography.filter(data=raw, geo=(None,)).equals(df)
-        # When `geo = ("Japan",)` or `geo="Japan"`, returns country-level data in Japan.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["Japan", "Japan"],
-                Term.PROVINCE: [Term.NA for _ in range(2)],
-                Term.CITY: [Term.NA for _ in range(2)],
-                Term.DATE: [day0, day1],
-                Term.C: [4, 5],
-            }
-        )
-        assert geography.filter(data=raw, geo=("Japan",)).equals(df)
-        assert geography.filter(data=raw, geo="Japan").equals(df)
-        # When `geo = (["Japan", "UK"],)`, returns country-level data of Japan and UK.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["UK", "UK", "Japan", "Japan"],
-                Term.PROVINCE: [Term.NA for _ in range(4)],
-                Term.CITY: [Term.NA for _ in range(4)],
-                Term.DATE: [day0, day1] * 2,
-                Term.C: [2, 3, 4, 5],
-            }
-        )
-        assert geography.filter(data=raw, geo=(["Japan", "UK"],)).equals(df)
-        # When `geo = ("Japan", "Tokyo")`, returns province - level data of Tokyo/Japan.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["Japan", "Japan"],
-                Term.PROVINCE: ["Tokyo", "Tokyo"],
-                Term.CITY: [Term.NA for _ in range(2)],
-                Term.DATE: [day0, day1],
-                Term.C: [6, 7],
-            }
-        )
-        assert geography.filter(data=raw, geo=("Japan", "Tokyo")).equals(df)
-        # When `geo = ("Japan", ["Tokyo", "Kanagawa"])`, returns province-level data of Tokyo/Japan and Kanagawa/Japan.
-        # Note that the example raw data does not include province-level data of Kanagawa/Japan.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["Japan", "Japan"],
-                Term.PROVINCE: ["Tokyo", "Tokyo"],
-                Term.CITY: [Term.NA for _ in range(2)],
-                Term.DATE: [day0, day1],
-                Term.C: [6, 7],
-            }
-        )
-        assert geography.filter(data=raw, geo=("Japan", ["Tokyo", "Kanagawa"])).equals(df)
-        # When `geo = ("Japan", "Kanagawa", "Yokohama")`, returns city-level data of Yokohama/Kanagawa/Japan.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["Japan", "Japan"],
-                Term.PROVINCE: ["Kanagawa", "Kanagawa"],
-                Term.CITY: ["Yokohama", "Yokohama"],
-                Term.DATE: [day0, day1],
-                Term.C: [10, 11],
-            }
-        )
-        assert geography.filter(data=raw, geo=("Japan", "Kanagawa", "Yokohama")).equals(df)
-        # When `geo = (("Japan", "Kanagawa", ["Yokohama", "Kawasaki"])`, returns city-level data of Yokohama/Kanagawa/Japan and Kawasaki / Kanagawa / Japan.
-        df = pd.DataFrame(
-            {
-                Term.COUNTRY: ["Japan", "Japan", "Japan", "Japan"],
-                Term.PROVINCE: ["Kanagawa", "Kanagawa", "Kanagawa", "Kanagawa"],
-                Term.CITY: ["Yokohama", "Yokohama", "Kawasaki", "Kawasaki"],
-                Term.DATE: [day0, day1] * 2,
-                Term.C: [10, 11, 12, 13],
-            }
-        )
-        assert geography.filter(data=raw, geo=("Japan", "Kanagawa", ["Yokohama", "Kawasaki"])).equals(df)
-        # Errors
-        with pytest.raises(TypeError):
-            geography.filter(data=raw, geo=1)
-        with pytest.raises(TypeError):
-            geography.filter(data=raw, geo=(1,))
-        with pytest.raises(ValueError):
-            geography.filter(data=raw, geo=("The Earth", "Japan", "Tokyo", "Chiyoda"))
+
+def test_filter():
+    day0, day1 = pd.to_datetime("2022-01-01"), pd.to_datetime("2022-01-02")
+    raw = pd.DataFrame(
+        {
+            Term.COUNTRY: [*["UK" for _ in range(4)], *["Japan" for _ in range(10)], Term.NA, Term.NA],
+            Term.PROVINCE: [
+                "England", "England", *[Term.NA for _ in range(4)],
+                *["Tokyo" for _ in range(4)], *["Kanagawa" for _ in range(4)], Term.NA, Term.NA],
+            Term.CITY: [
+                *[Term.NA for _ in range(8)], "Chiyoda", "Chiyoda", "Yokohama", "Yokohama", "Kawasaki", "Kawasaki", Term.NA, Term.NA],
+            Term.DATE: [day0, day1] * 8,
+            Term.C: range(16),
+        }
+    )
+    geography = SubsetManager(layers=[Term.COUNTRY, Term.PROVINCE, Term.CITY])
+    # When `geo = None` or `geo = (None,)`, returns all country-level data.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["UK", "UK", "Japan", "Japan"],
+            Term.PROVINCE: [Term.NA for _ in range(4)],
+            Term.CITY: [Term.NA for _ in range(4)],
+            Term.DATE: [day0, day1] * 2,
+            Term.C: [2, 3, 4, 5],
+        }
+    )
+    assert geography.filter(data=raw, geo=None).equals(df)
+    assert geography.filter(data=raw, geo=(None,)).equals(df)
+    # When `geo = ("Japan",)` or `geo="Japan"`, returns country-level data in Japan.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["Japan", "Japan"],
+            Term.PROVINCE: [Term.NA for _ in range(2)],
+            Term.CITY: [Term.NA for _ in range(2)],
+            Term.DATE: [day0, day1],
+            Term.C: [4, 5],
+        }
+    )
+    assert geography.filter(data=raw, geo=("Japan",)).equals(df)
+    assert geography.filter(data=raw, geo="Japan").equals(df)
+    # When `geo = (["Japan", "UK"],)`, returns country-level data of Japan and UK.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["UK", "UK", "Japan", "Japan"],
+            Term.PROVINCE: [Term.NA for _ in range(4)],
+            Term.CITY: [Term.NA for _ in range(4)],
+            Term.DATE: [day0, day1] * 2,
+            Term.C: [2, 3, 4, 5],
+        }
+    )
+    assert geography.filter(data=raw, geo=(["Japan", "UK"],)).equals(df)
+    # When `geo = ("Japan", "Tokyo")`, returns province - level data of Tokyo/Japan.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["Japan", "Japan"],
+            Term.PROVINCE: ["Tokyo", "Tokyo"],
+            Term.CITY: [Term.NA for _ in range(2)],
+            Term.DATE: [day0, day1],
+            Term.C: [6, 7],
+        }
+    )
+    assert geography.filter(data=raw, geo=("Japan", "Tokyo")).equals(df)
+    # When `geo = ("Japan", ["Tokyo", "Kanagawa"])`, returns province-level data of Tokyo/Japan and Kanagawa/Japan.
+    # Note that the example raw data does not include province-level data of Kanagawa/Japan.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["Japan", "Japan"],
+            Term.PROVINCE: ["Tokyo", "Tokyo"],
+            Term.CITY: [Term.NA for _ in range(2)],
+            Term.DATE: [day0, day1],
+            Term.C: [6, 7],
+        }
+    )
+    assert geography.filter(data=raw, geo=("Japan", ["Tokyo", "Kanagawa"])).equals(df)
+    # When `geo = ("Japan", "Kanagawa", "Yokohama")`, returns city-level data of Yokohama/Kanagawa/Japan.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["Japan", "Japan"],
+            Term.PROVINCE: ["Kanagawa", "Kanagawa"],
+            Term.CITY: ["Yokohama", "Yokohama"],
+            Term.DATE: [day0, day1],
+            Term.C: [10, 11],
+        }
+    )
+    assert geography.filter(data=raw, geo=("Japan", "Kanagawa", "Yokohama")).equals(df)
+    # When `geo = (("Japan", "Kanagawa", ["Yokohama", "Kawasaki"])`, returns city-level data of Yokohama/Kanagawa/Japan and Kawasaki / Kanagawa / Japan.
+    df = pd.DataFrame(
+        {
+            Term.COUNTRY: ["Japan", "Japan", "Japan", "Japan"],
+            Term.PROVINCE: ["Kanagawa", "Kanagawa", "Kanagawa", "Kanagawa"],
+            Term.CITY: ["Yokohama", "Yokohama", "Kawasaki", "Kawasaki"],
+            Term.DATE: [day0, day1] * 2,
+            Term.C: [10, 11, 12, 13],
+        }
+    )
+    assert geography.filter(data=raw, geo=("Japan", "Kanagawa", ["Yokohama", "Kawasaki"])).equals(df)
+    # Errors
+    with pytest.raises(TypeError):
+        geography.filter(data=raw, geo=1)
+    with pytest.raises(TypeError):
+        geography.filter(data=raw, geo=(1,))
+    with pytest.raises(ValueError):
+        geography.filter(data=raw, geo=("The Earth", "Japan", "Tokyo", "Chiyoda"))

--- a/tests/test_gis/test_subset.py
+++ b/tests/test_gis/test_subset.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 import pytest
 from covsirphy import Term

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import covsirphy as cs
 
 

--- a/tests/test_meta.py
+++ b/tests/test_meta.py
@@ -1,11 +1,11 @@
 import covsirphy as cs
 
 
-class TestMeta(object):
-    def test_version(self):
-        assert isinstance(cs.__version__, str)
-        assert isinstance(cs.get_version(), str)
+def test_version():
+    assert isinstance(cs.__version__, str)
+    assert isinstance(cs.get_version(), str)
 
-    def test_citation(self):
-        assert isinstance(cs.__citation__, str)
-        assert isinstance(cs.get_citation(), str)
+
+def test_citation():
+    assert isinstance(cs.__citation__, str)
+    assert isinstance(cs.get_citation(), str)

--- a/tests/test_science/test_ml.py
+++ b/tests/test_science/test_ml.py
@@ -1,33 +1,34 @@
+import pytest
 from covsirphy import MLEngineer, DataEngineer, Term
 
 
-class TestMLEngineer(object):
-    def _subset(self):
-        data_eng = DataEngineer()
-        data_eng.download(databases=["japan", "covid19dh", "owid"])
-        data_eng.clean()
-        data_eng.transform()
-        return data_eng.subset(geo="Japan")[0]
+@pytest.fixture(scope="module")
+def subset_df():
+    data_eng = DataEngineer()
+    data_eng.download(databases=["japan", "covid19dh", "owid"])
+    data_eng.clean()
+    data_eng.transform()
+    return data_eng.subset(geo="Japan")[0]
 
-    def test_pca(self):
-        subset_df = self._subset()
-        subset_df = subset_df.drop([Term.N, Term.S, Term.C, Term.CI, Term.F, Term.R], axis=1)
-        # PCA
-        eng = MLEngineer()
-        pca_dict = eng.pca(X=subset_df, n_components=0.95)
-        assert isinstance(pca_dict, dict)
-        assert {"loadings", "PC", "explained_var", "topfeat"}.issubset(pca_dict)
 
-    def test_forecast(self):
-        subset_df = self._subset()
-        Y = subset_df.loc[:, [Term.C, Term.F, Term.R]]
-        subset_df = subset_df.drop([Term.N, Term.S, Term.C, Term.CI, Term.F, Term.R], axis=1)
-        # PCA
-        eng = MLEngineer()
-        pca_dict = eng.pca(X=subset_df, n_components=0.95)
-        X = pca_dict["PC"].copy()
-        # Forecasting without other information
-        X_pred = eng.forecast(Y=X, days=30, X=None)
-        # Forecasting with other information
-        Y_pred = eng.forecast(Y=Y, days=30, X=X_pred)
-        assert X_pred.index[-1] == Y_pred.index[-1]
+def test_pca(subset_df):
+    subset_df = subset_df.drop([Term.N, Term.S, Term.C, Term.CI, Term.F, Term.R], axis=1)
+    # PCA
+    eng = MLEngineer()
+    pca_dict = eng.pca(X=subset_df, n_components=0.95)
+    assert isinstance(pca_dict, dict)
+    assert {"loadings", "PC", "explained_var", "topfeat"}.issubset(pca_dict)
+
+
+def test_forecast(subset_df):
+    Y = subset_df.loc[:, [Term.C, Term.F, Term.R]]
+    subset_df = subset_df.drop([Term.N, Term.S, Term.C, Term.CI, Term.F, Term.R], axis=1)
+    # PCA
+    eng = MLEngineer()
+    pca_dict = eng.pca(X=subset_df, n_components=0.95)
+    X = pca_dict["PC"].copy()
+    # Forecasting without other information
+    X_pred = eng.forecast(Y=X, days=30, X=None)
+    # Forecasting with other information
+    Y_pred = eng.forecast(Y=Y, days=30, X=X_pred)
+    assert X_pred.index[-1] == Y_pred.index[-1]

--- a/tests/test_science/test_ml.py
+++ b/tests/test_science/test_ml.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy import MLEngineer, DataEngineer, Term
 
 

--- a/tests/test_science/test_ode_scenario.py
+++ b/tests/test_science/test_ode_scenario.py
@@ -22,23 +22,23 @@ def snr(jsonpath):
     return instance
 
 
-class TestODEScenario(object):
-    def test_scenario_manipulation(self, snr):
-        snr.build_with_template(name="New1", template="Baseline")
-        with pytest.raises(ScenarioNotFoundError):
-            snr.build_with_template(name="New2", template="Unknown")
-        with pytest.raises(ScenarioNotFoundError):
-            snr.to_dynamics(name="New2")
-        snr.build_with_template(name="New2", template="Baseline")
-        snr.build_with_template(name="Old", template="Baseline")
-        snr.build_with_template(name="Wow", template="Baseline")
-        snr.delete(pattern="Old", exact=True)
-        snr.delete(pattern="New", exact=False)
-        snr.rename(old="Wow", new="Excellent")
-        assert set(snr.track()[Term.SERIES].unique()) == {"Baseline", "Excellent"}
-        assert isinstance(snr.summary(), pd.DataFrame)
-        snr.delete(pattern="Excellent", exact=True)
+def test_scenario_manipulation(snr):
+    snr.build_with_template(name="New1", template="Baseline")
+    with pytest.raises(ScenarioNotFoundError):
+        snr.build_with_template(name="New2", template="Unknown")
+    with pytest.raises(ScenarioNotFoundError):
+        snr.to_dynamics(name="New2")
+    snr.build_with_template(name="New2", template="Baseline")
+    snr.build_with_template(name="Old", template="Baseline")
+    snr.build_with_template(name="Wow", template="Baseline")
+    snr.delete(pattern="Old", exact=True)
+    snr.delete(pattern="New", exact=False)
+    snr.rename(old="Wow", new="Excellent")
+    assert set(snr.track()[Term.SERIES].unique()) == {"Baseline", "Excellent"}
+    assert isinstance(snr.summary(), pd.DataFrame)
+    snr.delete(pattern="Excellent", exact=True)
 
-    def test_auto_filed(self, snr):
-        with pytest.raises(SubsetNotFoundError):
-            ODEScenario.auto_build(geo="Moon", model=SIRFModel)
+
+def test_auto_filed(snr):
+    with pytest.raises(SubsetNotFoundError):
+        ODEScenario.auto_build(geo="Moon", model=SIRFModel)

--- a/tests/test_science/test_ode_scenario.py
+++ b/tests/test_science/test_ode_scenario.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 from pathlib import Path
 import pytest

--- a/tests/test_util/test_alias.py
+++ b/tests/test_util/test_alias.py
@@ -1,16 +1,16 @@
 from covsirphy import Alias
 
 
-class TestAlias(object):
-    def test_alias(self):
-        alias = Alias()
-        alias.update(name="alias0", target=0)
-        alias.update(name="alias1", target=1)
-        assert alias.find(name="alias1", default=-1) == 1
-        assert alias.find(name="alias2", default=-1) == -1
-        assert alias.find(name=["alias1"], default=-1) == -1
-        assert alias.all() == {"alias0": 0, "alias1": 1}
+def test_alias():
+    alias = Alias()
+    alias.update(name="alias0", target=0)
+    alias.update(name="alias1", target=1)
+    assert alias.find(name="alias1", default=-1) == 1
+    assert alias.find(name="alias2", default=-1) == -1
+    assert alias.find(name=["alias1"], default=-1) == -1
+    assert alias.all() == {"alias0": 0, "alias1": 1}
 
-    def test_for_variable(self):
-        alias = Alias.for_variables()
-        assert alias.find("C") == [Alias.C]
+
+def test_for_variable():
+    alias = Alias.for_variables()
+    assert alias.find("C") == [Alias.C]

--- a/tests/test_util/test_alias.py
+++ b/tests/test_util/test_alias.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy import Alias
 
 

--- a/tests/test_util/test_evaluator.py
+++ b/tests/test_util/test_evaluator.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import numpy as np
 import pandas as pd
 import pytest

--- a/tests/test_util/test_evaluator.py
+++ b/tests/test_util/test_evaluator.py
@@ -4,54 +4,54 @@ import pytest
 from covsirphy import Evaluator, UnExpectedValueError, NAFoundError
 
 
-class TestEvaluator(object):
+@pytest.mark.parametrize("metric", ["ME", "MAE", "MSE", "MSLE", "MAPE", "RMSE", "RMSLE", "R2"])
+def test_score_series(metric):
+    assert metric in Evaluator.metrics()
+    true = pd.Series([5, 10, 8, 6])
+    pred = pd.Series([8, 12, 6, 5])
+    evaluator = Evaluator(true, pred, on=None)
+    score_metric = evaluator.score(metric=metric)
+    score_metrics = evaluator.score(metrics=metric)
+    assert score_metric == score_metrics
+    assert isinstance(Evaluator.smaller_is_better(metric=metric), bool)
+    best_tuple = Evaluator.best_one({"A": 1.0, "B": 1.5, "C": 2.0}, metric=metric)
+    if metric == "R2":
+        assert best_tuple == ("C", 2.0)
+    else:
+        assert best_tuple == ("A", 1.0)
 
-    @pytest.mark.parametrize("metric", ["ME", "MAE", "MSE", "MSLE", "MAPE", "RMSE", "RMSLE", "R2"])
-    def test_score_series(self, metric):
-        assert metric in Evaluator.metrics()
-        true = pd.Series([5, 10, 8, 6])
-        pred = pd.Series([8, 12, 6, 5])
-        evaluator = Evaluator(true, pred, on=None)
-        score_metric = evaluator.score(metric=metric)
-        score_metrics = evaluator.score(metrics=metric)
-        assert score_metric == score_metrics
-        assert isinstance(Evaluator.smaller_is_better(metric=metric), bool)
-        best_tuple = Evaluator.best_one({"A": 1.0, "B": 1.5, "C": 2.0}, metric=metric)
-        if metric == "R2":
-            assert best_tuple == ("C", 2.0)
-        else:
-            assert best_tuple == ("A", 1.0)
 
-    @pytest.mark.parametrize("metric", ["ME", "MAE", "MSE", "MSLE", "MAPE", "RMSE", "RMSLE", "R2"])
-    @pytest.mark.parametrize("how", ["all", "inner"])
-    @pytest.mark.parametrize("on", [None, "join_on"])
-    def test_score_dataframe(self, metric, how, on):
-        true = pd.DataFrame(
-            {
-                "join_on": [0, 1, 2, 3, 4, 5],
-                "value": [20, 40, 30, 50, 90, 10]
-            }
-        )
-        pred = pd.DataFrame(
-            {
-                "join_on": [0, 2, 3, 4, 6, 7],
-                "value": [20, 40, 30, 50, 110, 55]
-            }
-        )
-        evaluator = Evaluator(true, pred, how=how, on=on)
-        if metric == "ME" and (how == "all" or on is None):
-            with pytest.raises(ValueError):
-                evaluator.score(metric=metric)
-            return
-        assert isinstance(evaluator.score(metric=metric), float)
+@pytest.mark.parametrize("metric", ["ME", "MAE", "MSE", "MSLE", "MAPE", "RMSE", "RMSLE", "R2"])
+@pytest.mark.parametrize("how", ["all", "inner"])
+@pytest.mark.parametrize("on", [None, "join_on"])
+def test_score_dataframe(metric, how, on):
+    true = pd.DataFrame(
+        {
+            "join_on": [0, 1, 2, 3, 4, 5],
+            "value": [20, 40, 30, 50, 90, 10]
+        }
+    )
+    pred = pd.DataFrame(
+        {
+            "join_on": [0, 2, 3, 4, 6, 7],
+            "value": [20, 40, 30, 50, 110, 55]
+        }
+    )
+    evaluator = Evaluator(true, pred, how=how, on=on)
+    if metric == "ME" and (how == "all" or on is None):
+        with pytest.raises(ValueError):
+            evaluator.score(metric=metric)
+        return
+    assert isinstance(evaluator.score(metric=metric), float)
 
-    def test_error(self):
-        with pytest.raises(NAFoundError):
-            Evaluator([1, 2, 3, np.nan], [2, 5, 7, 10])
-        true = pd.Series([5, 10, 8, 6])
-        pred = pd.Series([8, 12, 6, 5])
-        evaluator = Evaluator(true, pred, on=None)
-        with pytest.raises(UnExpectedValueError):
-            evaluator.score(metric="Unknown")
-        with pytest.raises(UnExpectedValueError):
-            evaluator.smaller_is_better(metric="Unknown")
+
+def test_error():
+    with pytest.raises(NAFoundError):
+        Evaluator([1, 2, 3, np.nan], [2, 5, 7, 10])
+    true = pd.Series([5, 10, 8, 6])
+    pred = pd.Series([8, 12, 6, 5])
+    evaluator = Evaluator(true, pred, on=None)
+    with pytest.raises(UnExpectedValueError):
+        evaluator.score(metric="Unknown")
+    with pytest.raises(UnExpectedValueError):
+        evaluator.smaller_is_better(metric="Unknown")

--- a/tests/test_util/test_filer.py
+++ b/tests/test_util/test_filer.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pytest
 from covsirphy import Filer
 

--- a/tests/test_util/test_filer.py
+++ b/tests/test_util/test_filer.py
@@ -2,23 +2,22 @@ import pytest
 from covsirphy import Filer
 
 
-class TestFiler(object):
-    def test_filing(self):
-        with pytest.raises(ValueError):
-            Filer("output", numbering="xxx")
-        filer = Filer(directory=["output", "A"], prefix="jpn", suffix=None, numbering="01")
-        filer = Filer(directory=("output", "A", "B"), prefix="jpn", suffix=None, numbering="01")
-        filer = Filer(directory="output", prefix="jpn", suffix=None, numbering="01")
-        # Create filenames
-        filer.png("records")
-        filer.jpg("records")
-        filer.json("records")
-        filer.geojson("records")
-        filer.csv("records", index=True)
-        # Check files
-        assert len(filer.files(ext=None)) == 5
-        assert len(filer.files(ext="png")) == 1
-        assert len(filer.files(ext="jpg")) == 1
-        assert len(filer.files(ext="json")) == 1
-        assert len(filer.files(ext="geojson")) == 1
-        assert len(filer.files(ext="csv")) == 1
+def test_filing():
+    with pytest.raises(ValueError):
+        Filer("output", numbering="xxx")
+    filer = Filer(directory=["output", "A"], prefix="jpn", suffix=None, numbering="01")
+    filer = Filer(directory=("output", "A", "B"), prefix="jpn", suffix=None, numbering="01")
+    filer = Filer(directory="output", prefix="jpn", suffix=None, numbering="01")
+    # Create filenames
+    filer.png("records")
+    filer.jpg("records")
+    filer.json("records")
+    filer.geojson("records")
+    filer.csv("records", index=True)
+    # Check files
+    assert len(filer.files(ext=None)) == 5
+    assert len(filer.files(ext="png")) == 1
+    assert len(filer.files(ext="jpg")) == 1
+    assert len(filer.files(ext="json")) == 1
+    assert len(filer.files(ext="geojson")) == 1
+    assert len(filer.files(ext="csv")) == 1

--- a/tests/test_util/test_stopwatch.py
+++ b/tests/test_util/test_stopwatch.py
@@ -1,7 +1,6 @@
 from covsirphy import StopWatch
 
 
-class TestStopWatch(object):
-    def test_stopwatch(self):
-        stop_watch = StopWatch()
-        assert isinstance(stop_watch.stop_show(), str)
+def test_stopwatch():
+    stop_watch = StopWatch()
+    assert isinstance(stop_watch.stop_show(), str)

--- a/tests/test_util/test_stopwatch.py
+++ b/tests/test_util/test_stopwatch.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy import StopWatch
 
 

--- a/tests/test_util/test_validator.py
+++ b/tests/test_util/test_validator.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from datetime import datetime
 import pytest
 import pandas as pd

--- a/tests/test_util/test_validator.py
+++ b/tests/test_util/test_validator.py
@@ -7,107 +7,116 @@ from covsirphy import NAFoundError, NotIncludedError, NotSubclassError, UnExpect
 from covsirphy import UnExpectedValueRangeError, UnExpectedValueError, UnExpectedLengthError, UnExpectedNoneError
 
 
-class TestValidator(object):
-    def test_none(self):
-        Validator(1, "target", accept_none=True)
-        with pytest.raises(UnExpectedNoneError):
-            Validator(None, "target", accept_none=False)
+def test_none():
+    Validator(1, "target", accept_none=True)
+    with pytest.raises(UnExpectedNoneError):
+        Validator(None, "target", accept_none=False)
 
-    def test_subclass(self):
-        v = Validator(SIRFModel, name="model")
-        with pytest.raises(NotSubclassError):
-            v.subclass(SIRModel)
-        assert v.subclass(ODEModel) == SIRFModel
 
-    def test_instance(self):
-        v = Validator("covsirphy")
-        with pytest.raises(UnExpectedTypeError):
-            v.instance(int)
-        assert v.instance(str) == "covsirphy"
+def test_subclass():
+    v = Validator(SIRFModel, name="model")
+    with pytest.raises(NotSubclassError):
+        v.subclass(SIRModel)
+    assert v.subclass(ODEModel) == SIRFModel
 
-    def test_dataframe(self):
-        with pytest.raises(UnExpectedTypeError):
-            Validator("string").dataframe()
-        with pytest.raises(EmptyError):
-            Validator(pd.DataFrame()).dataframe(empty_ok=False)
-        df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": pd.date_range("01Jan2022", "02Jan2022", freq="D")})
-        v = Validator(df, "dataframe")
-        with pytest.raises(UnExpectedTypeError):
-            v.dataframe(time_index=True)
-        with pytest.raises(NotIncludedError):
-            v.dataframe(columns=["D"])
-        assert_frame_equal(v.dataframe(), df)
-        assert_frame_equal(v.dataframe(columns=["A"]), df)
 
-    def test_float(self):
-        assert Validator(None).float(default=1.2) == 1.2
-        with pytest.raises(UnExpectedTypeError):
-            Validator("string").float()
-        with pytest.raises(UnExpectedValueRangeError):
-            Validator(1.2).float(value_range=(0, 1.1))
-        with pytest.raises(UnExpectedValueRangeError):
-            Validator(1.2).float(value_range=(1.5, 2))
-        assert Validator(1.2).float() == 1.2
-        assert Validator(1.6564).float(digits=3) == 1.66
-        assert Validator(0).float(digits=3) == 0
+def test_instance():
+    v = Validator("covsirphy")
+    with pytest.raises(UnExpectedTypeError):
+        v.instance(int)
+    assert v.instance(str) == "covsirphy"
 
-    def test_int(self):
-        assert Validator(None).int(default=2) == 2
-        with pytest.raises(UnExpectedTypeError):
-            Validator("string").int()
-        with pytest.raises(UnExpectedTypeError):
-            Validator(1.2).int()
-        with pytest.raises(UnExpectedValueRangeError):
-            Validator(2).int(value_range=(0, 1))
-        with pytest.raises(UnExpectedValueRangeError):
-            Validator(2).int(value_range=(3, 4))
-        assert Validator(2.5).int(round_ok=True) == 2
 
-    def test_tau(self):
-        assert Validator(None).tau(default=720) == 720
-        with pytest.raises(UnExpectedValueError):
-            Validator(11).tau()
-        assert Validator(360).tau() == 360
+def test_dataframe():
+    with pytest.raises(UnExpectedTypeError):
+        Validator("string").dataframe()
+    with pytest.raises(EmptyError):
+        Validator(pd.DataFrame()).dataframe(empty_ok=False)
+    df = pd.DataFrame({"A": [1, 2], "B": [3, 4], "C": pd.date_range("01Jan2022", "02Jan2022", freq="D")})
+    v = Validator(df, "dataframe")
+    with pytest.raises(UnExpectedTypeError):
+        v.dataframe(time_index=True)
+    with pytest.raises(NotIncludedError):
+        v.dataframe(columns=["D"])
+    assert_frame_equal(v.dataframe(), df)
+    assert_frame_equal(v.dataframe(columns=["A"]), df)
 
-    def test_date(self):
-        assert Validator(None).date(default=pd.Timestamp("01Jan2022")) == pd.Timestamp("01Jan2022")
-        assert Validator(pd.Timestamp("01Jan2022")).date() == pd.Timestamp("01Jan2022")
-        assert Validator(datetime(year=2022, month=1, day=1)).date() == pd.Timestamp("01Jan2022")
-        assert Validator("01Jan2022").date() == pd.Timestamp("01Jan2022")
-        with pytest.raises(UnExpectedTypeError):
-            Validator("hello").date()
-        v = Validator("2022-01-01")
-        with pytest.raises(UnExpectedValueRangeError):
-            v.date(value_range=(None, pd.Timestamp("2021-12-31")))
-        with pytest.raises(UnExpectedValueRangeError):
-            v.date(value_range=(pd.Timestamp("2022-02-01"), None))
 
-    def test_sequence(self):
-        assert Validator(None).sequence(default=[1, 2]) == [1, 2]
-        with pytest.raises(UnExpectedTypeError):
-            Validator(1).sequence()
-        with pytest.raises(UnExpectedTypeError):
-            Validator([[1, 2], 2]).sequence(flatten=True)
-        assert Validator([[1, 2], [3, 4]]).sequence(flatten=True) == [1, 2, 3, 4]
-        assert Validator([1, 2, 4, 2, 2]).sequence(unique=True) == [1, 2, 4]
-        v = Validator([1, 2, 3])
-        with pytest.raises(UnExpectedValueError):
-            v.sequence(candidates=[1, 4, 5])
-        assert v.sequence(candidates=[1, 2, 3, 4]) == [1, 2, 3]
-        with pytest.raises(UnExpectedLengthError):
-            v.sequence(length=2)
-        assert v.sequence(length=3) == [1, 2, 3]
+def test_float():
+    assert Validator(None).float(default=1.2) == 1.2
+    with pytest.raises(UnExpectedTypeError):
+        Validator("string").float()
+    with pytest.raises(UnExpectedValueRangeError):
+        Validator(1.2).float(value_range=(0, 1.1))
+    with pytest.raises(UnExpectedValueRangeError):
+        Validator(1.2).float(value_range=(1.5, 2))
+    assert Validator(1.2).float() == 1.2
+    assert Validator(1.6564).float(digits=3) == 1.66
+    assert Validator(0).float(digits=3) == 0
 
-    def test_dict(self):
-        assert Validator(None).dict(default={1: 2}) == {1: 2}
-        with pytest.raises(UnExpectedTypeError):
-            Validator(1).dict()
-        with pytest.raises(NAFoundError):
-            Validator({1: 2}).dict(required_keys=[3, 4], errors="raise")
-        assert Validator({1: 2}).dict(default={3: 5, 6: 8}, required_keys=[3, 4]) == {1: 2, 3: 5, 6: 8, 4: None}
 
-    def test_kwargs(self):
-        kwargs = {"target": SIRModel, "unnecessary_key": True}
-        v = Validator(kwargs)
-        result_dict = v.kwargs(functions=Validator, default={"name": "target name"})
-        assert isinstance(Validator(**result_dict), Validator)
+def test_int():
+    assert Validator(None).int(default=2) == 2
+    with pytest.raises(UnExpectedTypeError):
+        Validator("string").int()
+    with pytest.raises(UnExpectedTypeError):
+        Validator(1.2).int()
+    with pytest.raises(UnExpectedValueRangeError):
+        Validator(2).int(value_range=(0, 1))
+    with pytest.raises(UnExpectedValueRangeError):
+        Validator(2).int(value_range=(3, 4))
+    assert Validator(2.5).int(round_ok=True) == 2
+
+
+def test_tau():
+    assert Validator(None).tau(default=720) == 720
+    with pytest.raises(UnExpectedValueError):
+        Validator(11).tau()
+    assert Validator(360).tau() == 360
+
+
+def test_date():
+    assert Validator(None).date(default=pd.Timestamp("01Jan2022")) == pd.Timestamp("01Jan2022")
+    assert Validator(pd.Timestamp("01Jan2022")).date() == pd.Timestamp("01Jan2022")
+    assert Validator(datetime(year=2022, month=1, day=1)).date() == pd.Timestamp("01Jan2022")
+    assert Validator("01Jan2022").date() == pd.Timestamp("01Jan2022")
+    with pytest.raises(UnExpectedTypeError):
+        Validator("hello").date()
+    v = Validator("2022-01-01")
+    with pytest.raises(UnExpectedValueRangeError):
+        v.date(value_range=(None, pd.Timestamp("2021-12-31")))
+    with pytest.raises(UnExpectedValueRangeError):
+        v.date(value_range=(pd.Timestamp("2022-02-01"), None))
+
+
+def test_sequence():
+    assert Validator(None).sequence(default=[1, 2]) == [1, 2]
+    with pytest.raises(UnExpectedTypeError):
+        Validator(1).sequence()
+    with pytest.raises(UnExpectedTypeError):
+        Validator([[1, 2], 2]).sequence(flatten=True)
+    assert Validator([[1, 2], [3, 4]]).sequence(flatten=True) == [1, 2, 3, 4]
+    assert Validator([1, 2, 4, 2, 2]).sequence(unique=True) == [1, 2, 4]
+    v = Validator([1, 2, 3])
+    with pytest.raises(UnExpectedValueError):
+        v.sequence(candidates=[1, 4, 5])
+    assert v.sequence(candidates=[1, 2, 3, 4]) == [1, 2, 3]
+    with pytest.raises(UnExpectedLengthError):
+        v.sequence(length=2)
+    assert v.sequence(length=3) == [1, 2, 3]
+
+
+def test_dict():
+    assert Validator(None).dict(default={1: 2}) == {1: 2}
+    with pytest.raises(UnExpectedTypeError):
+        Validator(1).dict()
+    with pytest.raises(NAFoundError):
+        Validator({1: 2}).dict(required_keys=[3, 4], errors="raise")
+    assert Validator({1: 2}).dict(default={3: 5, 6: 8}, required_keys=[3, 4]) == {1: 2, 3: 5, 6: 8, 4: None}
+
+
+def test_kwargs():
+    kwargs = {"target": SIRModel, "unnecessary_key": True}
+    v = Validator(kwargs)
+    result_dict = v.kwargs(functions=Validator, default={"name": "target name"})
+    assert isinstance(Validator(**result_dict), Validator)

--- a/tests/test_visualization/test_bar.py
+++ b/tests/test_visualization/test_bar.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pytest
 from covsirphy import BarPlot, bar_plot, Term
 

--- a/tests/test_visualization/test_bar.py
+++ b/tests/test_visualization/test_bar.py
@@ -2,40 +2,41 @@ import pytest
 from covsirphy import BarPlot, bar_plot, Term
 
 
-class TestBarPlot(object):
-    def test_plot(self, japan_df, imgfile):
-        df = japan_df.set_index("date").rename(columns={"Positive": Term.C}).tail()
+def test_plot(japan_df, imgfile):
+    df = japan_df.set_index("date").rename(columns={"Positive": Term.C}).tail()
+    with BarPlot(filename=imgfile) as bp:
+        bp.plot(data=df[Term.C])
+    with BarPlot(filename=imgfile) as bp:
+        bp.plot(data=df, vertical=True)
+    with BarPlot(filename=imgfile) as bp:
+        bp.plot(data=df, vertical=False)
+    with BarPlot(filename=imgfile) as bp:
+        bp.plot(data=df, colormap="rainbow")
+    with BarPlot(filename=imgfile) as bp:
+        bp.plot(data=df, color_dict={Term.C: "blue"})
+    with pytest.raises(KeyError):
         with BarPlot(filename=imgfile) as bp:
-            bp.plot(data=df[Term.C])
-        with BarPlot(filename=imgfile) as bp:
-            bp.plot(data=df, vertical=True)
-        with BarPlot(filename=imgfile) as bp:
-            bp.plot(data=df, vertical=False)
-        with BarPlot(filename=imgfile) as bp:
-            bp.plot(data=df, colormap="rainbow")
-        with BarPlot(filename=imgfile) as bp:
-            bp.plot(data=df, color_dict={Term.C: "blue"})
-        with pytest.raises(KeyError):
-            with BarPlot(filename=imgfile) as bp:
-                bp.plot(data=df, colormap="unknown")
+            bp.plot(data=df, colormap="unknown")
 
-    def test_axis(self, japan_df, imgfile):
-        df = japan_df.set_index("date").rename(columns={"Positive": Term.C}).tail()
-        with BarPlot(filename=imgfile) as bp:
-            pass
-        with BarPlot(filename=imgfile) as bp:
-            bp.plot(data=df)
-            bp.y_axis(y_integer=True)
-        with BarPlot(filename=imgfile) as bp:
-            bp.plot(data=df)
-            bp.x_axis(xlabel=Term.DATE)
-            bp.y_axis(y_logscale=True)
-            bp.line(h=100_000)
-        with BarPlot(filename=imgfile) as bp:
-            bp.plot(data=df, vertical=True)
-            bp.line(v=100_000)
 
-    def test_function(self, japan_df, imgfile):
-        df = japan_df.set_index("date").rename(columns={"Positive": Term.C}).tail()
-        bar_plot(df=df, filename=imgfile)
-        bar_plot(df=df, filename=imgfile, show_legend=False)
+def test_axis(japan_df, imgfile):
+    df = japan_df.set_index("date").rename(columns={"Positive": Term.C}).tail()
+    with BarPlot(filename=imgfile) as bp:
+        pass
+    with BarPlot(filename=imgfile) as bp:
+        bp.plot(data=df)
+        bp.y_axis(y_integer=True)
+    with BarPlot(filename=imgfile) as bp:
+        bp.plot(data=df)
+        bp.x_axis(xlabel=Term.DATE)
+        bp.y_axis(y_logscale=True)
+        bp.line(h=100_000)
+    with BarPlot(filename=imgfile) as bp:
+        bp.plot(data=df, vertical=True)
+        bp.line(v=100_000)
+
+
+def test_function(japan_df, imgfile):
+    df = japan_df.set_index("date").rename(columns={"Positive": Term.C}).tail()
+    bar_plot(df=df, filename=imgfile)
+    bar_plot(df=df, filename=imgfile, show_legend=False)

--- a/tests/test_visualization/test_compare.py
+++ b/tests/test_visualization/test_compare.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 from covsirphy import compare_plot
 
 

--- a/tests/test_visualization/test_compare.py
+++ b/tests/test_visualization/test_compare.py
@@ -1,10 +1,9 @@
 from covsirphy import compare_plot
 
 
-class TestComparePlot(object):
-    def test_plot(self, japan_df, imgfile):
-        df = japan_df.set_index("date")
-        tokyo_df = df.loc[df["Prefecture"] == "Tokyo"].drop("Prefecture", axis=1)
-        osaka_df = df.loc[df["Prefecture"] == "Osaka"].drop("Prefecture", axis=1)
-        df = tokyo_df.merge(osaka_df, on="date", suffixes=("_tokyo", "_osaka"))
-        compare_plot(df, variables=["Positive", "Fatal", "Discharged"], groups=["tokyo", "osaka"], filename=imgfile)
+def test_plot(japan_df, imgfile):
+    df = japan_df.set_index("date")
+    tokyo_df = df.loc[df["Prefecture"] == "Tokyo"].drop("Prefecture", axis=1)
+    osaka_df = df.loc[df["Prefecture"] == "Osaka"].drop("Prefecture", axis=1)
+    df = tokyo_df.merge(osaka_df, on="date", suffixes=("_tokyo", "_osaka"))
+    compare_plot(df, variables=["Positive", "Fatal", "Discharged"], groups=["tokyo", "osaka"], filename=imgfile)

--- a/tests/test_visualization/test_line.py
+++ b/tests/test_visualization/test_line.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pandas as pd
 import pytest
 from covsirphy import LinePlot, line_plot, Term, UnExecutedError

--- a/tests/test_visualization/test_line.py
+++ b/tests/test_visualization/test_line.py
@@ -3,43 +3,45 @@ import pytest
 from covsirphy import LinePlot, line_plot, Term, UnExecutedError
 
 
-class TestLinePlot(object):
-    def test_plot(self, japan_df, imgfile):
-        df = japan_df.set_index("date").rename(columns={"Positive": Term.C})
+def test_plot(japan_df, imgfile):
+    df = japan_df.set_index("date").rename(columns={"Positive": Term.C})
+    with LinePlot(filename=imgfile) as lp:
+        lp.plot(data=df)
+    with LinePlot(filename=imgfile) as lp:
+        lp.plot(data=df[Term.C])
+    with LinePlot(filename=imgfile) as lp:
+        lp.plot(data=df, colormap="rainbow")
+    with LinePlot(filename=imgfile) as lp:
+        lp.plot(data=df, color_dict={Term.C: "blue"})
+    with pytest.raises(KeyError):
         with LinePlot(filename=imgfile) as lp:
-            lp.plot(data=df)
-        with LinePlot(filename=imgfile) as lp:
-            lp.plot(data=df[Term.C])
-        with LinePlot(filename=imgfile) as lp:
-            lp.plot(data=df, colormap="rainbow")
-        with LinePlot(filename=imgfile) as lp:
-            lp.plot(data=df, color_dict={Term.C: "blue"})
-        with pytest.raises(KeyError):
-            with LinePlot(filename=imgfile) as lp:
-                lp.plot(data=df, colormap="unknown")
+            lp.plot(data=df, colormap="unknown")
 
-    def test_axis(self, japan_df, imgfile):
-        df = japan_df.set_index("date").rename(columns={"Positive": Term.C})
-        with LinePlot(filename=imgfile) as lp:
-            lp.plot(data=df)
-            lp.x_axis(x_logscale=True)
-            lp.y_axis(y_logscale=True)
-            lp.line(v=pd.Timestamp("01Jan2021"))
-        with LinePlot(filename=imgfile) as lp:
-            lp.plot(data=df)
-            lp.y_axis(y_integer=True)
-            lp.line(h=100_000)
 
-    def test_legend(self, japan_df, imgfile):
-        df = japan_df.set_index("date")
-        with LinePlot(filename=imgfile) as lp:
-            with pytest.raises(UnExecutedError):
-                lp.legend()
-            lp.plot(data=df)
-            lp.legend_hide()
+def test_axis(japan_df, imgfile):
+    df = japan_df.set_index("date").rename(columns={"Positive": Term.C})
+    with LinePlot(filename=imgfile) as lp:
+        lp.plot(data=df)
+        lp.x_axis(x_logscale=True)
+        lp.y_axis(y_logscale=True)
+        lp.line(v=pd.Timestamp("01Jan2021"))
+    with LinePlot(filename=imgfile) as lp:
+        lp.plot(data=df)
+        lp.y_axis(y_integer=True)
+        lp.line(h=100_000)
+
+
+def test_legend(japan_df, imgfile):
+    df = japan_df.set_index("date")
+    with LinePlot(filename=imgfile) as lp:
+        with pytest.raises(UnExecutedError):
             lp.legend()
+        lp.plot(data=df)
+        lp.legend_hide()
+        lp.legend()
 
-    def test_function(self, japan_df, imgfile):
-        df = japan_df.set_index("date")
-        line_plot(df=df, filename=imgfile, show_legend=True)
-        line_plot(df=df, filename=imgfile, show_legend=False)
+
+def test_function(japan_df, imgfile):
+    df = japan_df.set_index("date")
+    line_plot(df=df, filename=imgfile, show_legend=True)
+    line_plot(df=df, filename=imgfile, show_legend=False)

--- a/tests/test_visualization/test_scatter.py
+++ b/tests/test_visualization/test_scatter.py
@@ -3,29 +3,30 @@ from covsirphy import ScatterPlot, scatter_plot
 from covsirphy import UnExecutedError
 
 
-class TestScatterPlot(object):
-    def test_plot(self, japan_df, imgfile):
-        df = japan_df.rename(columns={"Positive": "x", "Discharged": "y"})
-        # Create a scatter plot
-        scatter_plot(df, filename=imgfile)
+def test_plot(japan_df, imgfile):
+    df = japan_df.rename(columns={"Positive": "x", "Discharged": "y"})
+    # Create a scatter plot
+    scatter_plot(df, filename=imgfile)
 
-    def test_error(self, japan_df, imgfile):
-        df = japan_df.rename(columns={"Positive": "x", "Discharged": "y"})
-        # Plotting not done
-        with ScatterPlot(filename=imgfile) as sp:
-            with pytest.raises(UnExecutedError):
-                sp.line_straight()
-        # Cannot show a legend
-        with ScatterPlot(filename=imgfile) as sp:
-            sp.plot(data=df)
-            with pytest.raises(NotImplementedError):
-                sp.legend()
-            with pytest.raises(NotImplementedError):
-                sp.legend_hide()
 
-    @pytest.mark.skip(reason="Refer to https://github.com/lisphilar/covid19-sir/issues/1225")
-    def test_colormap(self, japan_df, imgfile):
-        df = japan_df.rename(columns={"Positive": "x", "Discharged": "y"})
-        with ScatterPlot(filename=imgfile) as sp:
-            with pytest.raises(KeyError):
-                sp.plot(data=df, colormap="unknown")
+def test_error(japan_df, imgfile):
+    df = japan_df.rename(columns={"Positive": "x", "Discharged": "y"})
+    # Plotting not done
+    with ScatterPlot(filename=imgfile) as sp:
+        with pytest.raises(UnExecutedError):
+            sp.line_straight()
+    # Cannot show a legend
+    with ScatterPlot(filename=imgfile) as sp:
+        sp.plot(data=df)
+        with pytest.raises(NotImplementedError):
+            sp.legend()
+        with pytest.raises(NotImplementedError):
+            sp.legend_hide()
+
+
+@pytest.mark.skip(reason="Refer to https://github.com/lisphilar/covid19-sir/issues/1225")
+def test_colormap(japan_df, imgfile):
+    df = japan_df.rename(columns={"Positive": "x", "Discharged": "y"})
+    with ScatterPlot(filename=imgfile) as sp:
+        with pytest.raises(KeyError):
+            sp.plot(data=df, colormap="unknown")

--- a/tests/test_visualization/test_scatter.py
+++ b/tests/test_visualization/test_scatter.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import pytest
 from covsirphy import ScatterPlot, scatter_plot
 from covsirphy import UnExecutedError

--- a/tests/test_visualization/test_visualize.py
+++ b/tests/test_visualization/test_visualize.py
@@ -1,6 +1,3 @@
-#!/usr/bin/env python
-# -*- coding: utf-8 -*-
-
 import warnings
 import matplotlib
 import pytest

--- a/tests/test_visualization/test_visualize.py
+++ b/tests/test_visualization/test_visualize.py
@@ -4,22 +4,23 @@ import pytest
 from covsirphy import VisualizeBase
 
 
-class TestVisualizeBase(object):
-    def test_base(self):
-        warnings.filterwarnings("ignore", category=UserWarning)
-        with VisualizeBase() as vb:
-            with pytest.raises(NotImplementedError):
-                vb.plot()
+def test_base():
+    warnings.filterwarnings("ignore", category=UserWarning)
+    with VisualizeBase() as vb:
+        with pytest.raises(NotImplementedError):
+            vb.plot()
 
-    def test_file(self, imgfile):
-        with VisualizeBase(filename=imgfile):
-            pass
 
-    def test_setting(self, imgfile):
-        with VisualizeBase(filename=imgfile) as vb:
-            assert not vb.title
-            assert isinstance(vb.ax, matplotlib.axes.Axes)
-            vb.ax = vb.ax
-            vb.title = "title"
-            vb.tick_params(
-                labelbottom=False, labelleft=False, left=False, bottom=False)
+def test_file(imgfile):
+    with VisualizeBase(filename=imgfile):
+        pass
+
+
+def test_setting(imgfile):
+    with VisualizeBase(filename=imgfile) as vb:
+        assert not vb.title
+        assert isinstance(vb.ax, matplotlib.axes.Axes)
+        vb.ax = vb.ax
+        vb.title = "title"
+        vb.tick_params(
+            labelbottom=False, labelleft=False, left=False, bottom=False)


### PR DESCRIPTION
## Related issues
#1266, #1267, #1268

## What was changed
- Close #1266 by removing un-necessary shebang and encoding declaration
- Close #1267 by replacing TestClasses with functions in tests
- Close #1268 by supressing `FutureWarnig` with a dependency when prediction