### PR TITLE
use type hints in APIs users will call: downloading

### DIFF
--- a/covsirphy/downloading/downloader.py
+++ b/covsirphy/downloading/downloader.py
@@ -1,3 +1,6 @@
+from __future__ import annotations
+from pathlib import Path
+import pandas as pd
 from covsirphy.util.error import NotRegisteredError, SubsetNotFoundError
 from covsirphy.util.validator import Validator
 from covsirphy.util.term import Term
@@ -12,33 +15,33 @@ class DataDownloader(Term):
     """Class to download datasets from the recommended data servers.
 
     Args:
-        directory (str or pathlib.Path): directory to save downloaded datasets
-        update_interval (int): update interval of downloading dataset
+        directory: directory to save downloaded datasets
+        update_interval: update interval of downloading dataset
 
     Note:
         Location layers are fixed to ["ISO3", "Province", "City"]
     """
     LAYERS = [Term.ISO3, Term.PROVINCE, Term.CITY]
 
-    def __init__(self, directory="input", update_interval=12, **kwargs):
+    def __init__(self, directory: str or Path = "input", update_interval: int = 12, **kwargs) -> None:
         self._directory = directory
         self._update_interval = Validator(update_interval, "update_interval").int(value_range=(0, None))
         self._gis = GIS(layers=self.LAYERS, country=self.ISO3, date=self.DATE)
 
-    def layer(self, country=None, province=None, databases=None):
+    def layer(self, country: str | None = None, province: str | None = None, databases: list[str] | None = None) -> pd.DataFrame:
         """Return the data at the selected layer.
 
         Args:
-            country (str or None): country name or None
-            province (str or None): province/state/prefecture name or None
-            databases (list[str] or None): databases to use or None (japan, covid19dh, google, owid).
+            country: country name or None
+            province: province/state/prefecture name or None
+            databases: databases to use or None (japan, covid19dh, owid).
                 "japan": COVID-19 Dataset in Japan,
                 "covid19dh": COVID-19 Data Hub,
                 "owid": Our World In Data,
                 "wpp": World Population Prospects by United nations.
 
         Returns:
-            pandas.DataFrame:
+            dataframe:
                 Index
                     reset index
                 Columns
@@ -103,14 +106,14 @@ class DataDownloader(Term):
         except NotRegisteredError:
             raise SubsetNotFoundError(geo=(country, province)) from None
 
-    def citations(self, variables=None):
+    def citations(self, variables: list[str] | None = None) -> list[str]:
         """
         Return citation list of the data sources.
 
         Args:
-            variables (list[str] or None): list of variables to collect or None (all available variables)
+            variables: list of variables to collect or None (all available variables)
 
         Returns:
-            list[str]: citation list
+            citations
         """
         return self._gis.citations(variables=variables)

--- a/covsirphy/downloading/downloader.py
+++ b/covsirphy/downloading/downloader.py
@@ -19,7 +19,7 @@ class DataDownloader(Term):
         update_interval: update interval of downloading dataset
 
     Note:
-        Location layers are fixed to ["ISO3", "Province", "City"]
+        Location layers are fixed to ['ISO3', 'Province', 'City'].
     """
     LAYERS = [Term.ISO3, Term.PROVINCE, Term.CITY]
 
@@ -35,54 +35,50 @@ class DataDownloader(Term):
             country: country name or None
             province: province/state/prefecture name or None
             databases: databases to use or None (japan, covid19dh, owid).
-                "japan": COVID-19 Dataset in Japan,
-                "covid19dh": COVID-19 Data Hub,
-                "owid": Our World In Data,
-                "wpp": World Population Prospects by United nations.
+                Candidates are as follows.
+
+                - "japan": COVID-19 Dataset in Japan,
+                - "covid19dh": COVID-19 Data Hub,
+                - "owid": Our World In Data,
+                - "wpp": World Population Prospects by United nations.
 
         Returns:
-            dataframe:
-                Index
-                    reset index
-                Columns
-                    Date (pandas.Timestamp): observation date
-                    ISO3 (str): country names
-                    Province (str): province/state/prefecture names
-                    City (str): city names
-                    Country (str): country names (top level administration)
-                    Province (str): province names (2nd level administration)
-                    ISO3 (str): ISO3 codes
-                    Confirmed (pandas.Int64): the number of confirmed cases
-                    Fatal (pandas.Int64): the number of fatal cases
-                    Recovered (pandas.Int64): the number of recovered cases
-                    Population (pandas.Int64): population values
-                    Tests (pandas.Int64): the number of tests
-                    Product (pandas.Int64): vaccine product names
-                    Vaccinations (pandas.Int64): cumulative number of vaccinations
-                    Vaccinations_boosters (pandas.Int64): cumulative number of booster vaccinations
-                    Vaccinated_once (pandas.Int64): cumulative number of people who received at least one vaccine dose
-                    Vaccinated_full (pandas.Int64): cumulative number of people who received all doses prescribed by the protocol
-                    School_closing
-                    Workplace_closing
-                    Cancel_events
-                    Gatherings_restrictions
-                    Transport_closing
-                    Stay_home_restrictions
-                    Internal_movement_restrictions
-                    International_movement_restrictions
-                    Information_campaigns
-                    Testing_policy
-                    Contact_tracing
-                    Stringency_index
+            A dataframe with reset index and the following columns.
+
+                - Date (pandas.Timestamp): observation date
+                - ISO3 (str): country names
+                - Province (str): province/state/prefecture names
+                - City (str): city names
+                - Country (str): country names (the top level administration)
+                - Province (str): province names (the 2nd level administration)
+                - ISO3 (str): ISO3 codes
+                - Confirmed (pandas.Int64): the number of confirmed cases
+                - Fatal (pandas.Int64): the number of fatal cases
+                - Recovered (pandas.Int64): the number of recovered cases
+                - Population (pandas.Int64): population values
+                - Tests (pandas.Int64): the number of tests
+                - Product (pandas.Int64): vaccine product names
+                - Vaccinations (pandas.Int64): cumulative number of vaccinations
+                - Vaccinations_boosters (pandas.Int64): cumulative number of booster vaccinations
+                - Vaccinated_once (pandas.Int64): cumulative number of people who received at least one vaccine dose
+                - Vaccinated_full (pandas.Int64): cumulative number of people who received all doses prescribed by the protocol
+                - School_closing
+                - Workplace_closing
+                - Cancel_events
+                - Gatherings_restrictions
+                - Transport_closing
+                - Stay_home_restrictions
+                - Internal_movement_restrictions
+                - International_movement_restrictions
+                - Information_campaigns
+                - Testing_policy
+                - Contact_tracing
+                - Stringency_index
 
         Note:
-            When @country is None, country-level data will be returned.
-
-        Note:
-            When @country is a string and @province is None, province-level data in the country will be returned.
-
-        Note:
-            When @country and @province are strings, city-level data in the province will be returned.
+            - When @country is None, country-level data will be returned.
+            - When @country is a string and @province is None, province-level data in the country will be returned.
+            - When @country and @province are strings, city-level data in the province will be returned.
         """
         db_dict = {
             "japan": _CSJapan,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -31,6 +31,7 @@ version = cs.__version__
 extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autodoc',
+    'sphinx_autodoc_typehints',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
     'sphinx_rtd_theme',

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,7 +9,6 @@
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
-#
 import os
 import sys
 sys.path.insert(0, os.path.abspath('../'))
@@ -31,6 +30,7 @@ version = cs.__version__
 extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.autodoc',
+    'sphinx.ext.intersphinx',
     'sphinx_autodoc_typehints',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
@@ -86,6 +86,15 @@ html_static_path = ['_static']
 
 
 # -- Extension configuration -------------------------------------------------
+
+napoleon_use_param = True
+napoleon_use_rtype = False
+napoleon_use_ivar = True
+
+intersphinx_mapping = {
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    "python": ("https://docs.python.org/3/", None),
+}
 
 # -- Options for todo extension ----------------------------------------------
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -2051,7 +2051,7 @@ python-versions = ">=3.6"
 
 [[package]]
 name = "sphinx"
-version = "5.1.1"
+version = "5.2.3"
 description = "Python documentation generator"
 category = "dev"
 optional = false
@@ -2059,16 +2059,16 @@ python-versions = ">=3.6"
 
 [package.dependencies]
 alabaster = ">=0.7,<0.8"
-babel = ">=1.3"
-colorama = {version = ">=0.3.5", markers = "sys_platform == \"win32\""}
+babel = ">=2.9"
+colorama = {version = ">=0.4.5", markers = "sys_platform == \"win32\""}
 docutils = ">=0.14,<0.20"
-imagesize = "*"
-importlib-metadata = {version = ">=4.4", markers = "python_version < \"3.10\""}
-Jinja2 = ">=2.3"
-packaging = "*"
-Pygments = ">=2.0"
+imagesize = ">=1.3"
+importlib-metadata = {version = ">=4.8", markers = "python_version < \"3.10\""}
+Jinja2 = ">=3.0"
+packaging = ">=21.0"
+Pygments = ">=2.12"
 requests = ">=2.5.0"
-snowballstemmer = ">=1.1"
+snowballstemmer = ">=2.0"
 sphinxcontrib-applehelp = "*"
 sphinxcontrib-devhelp = "*"
 sphinxcontrib-htmlhelp = ">=2.0.0"
@@ -2078,8 +2078,24 @@ sphinxcontrib-serializinghtml = ">=1.1.5"
 
 [package.extras]
 docs = ["sphinxcontrib-websupport"]
-lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-bugbear", "flake8-comprehensions", "isort", "mypy (>=0.971)", "sphinx-lint", "types-requests", "types-typed-ast"]
-test = ["cython", "html5lib", "pytest (>=4.6)", "typed-ast"]
+lint = ["docutils-stubs", "flake8 (>=3.5.0)", "flake8-bugbear", "flake8-comprehensions", "flake8-simplify", "isort", "mypy (>=0.981)", "sphinx-lint", "types-requests", "types-typed-ast"]
+test = ["cython", "html5lib", "pytest (>=4.6)", "typed_ast"]
+
+[[package]]
+name = "sphinx-autodoc-typehints"
+version = "1.19.4"
+description = "Type hints (PEP 484) support for the Sphinx autodoc extension"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+sphinx = ">=5.2.1"
+
+[package.extras]
+docs = ["furo (>=2022.9.15)", "sphinx (>=5.2.1)", "sphinx-autodoc-typehints (>=1.19.3)"]
+testing = ["covdefaults (>=2.2)", "coverage (>=6.4.4)", "diff-cover (>=7.0.1)", "nptyping (>=2.3.1)", "pytest (>=7.1.3)", "pytest-cov (>=3)", "sphobjinv (>=2.2.2)", "typing-extensions (>=4.3)"]
+type-comment = ["typed-ast (>=1.5.4)"]
 
 [[package]]
 name = "sphinx-copybutton"
@@ -2495,7 +2511,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "72b8db1c056ceda2b3fa943d3bc008c48b189a235c23fa57d6307e8a77308699"
+content-hash = "f6cadd818000b17dcc607b9a8530af038d8b22de770f96eeda64c12e187b0d86"
 
 [metadata.files]
 alabaster = [
@@ -3982,8 +3998,12 @@ soupsieve = [
     {file = "soupsieve-2.3.2.post1.tar.gz", hash = "sha256:fc53893b3da2c33de295667a0e19f078c14bf86544af307354de5fcf12a3f30d"},
 ]
 sphinx = [
-    {file = "Sphinx-5.1.1-py3-none-any.whl", hash = "sha256:309a8da80cb6da9f4713438e5b55861877d5d7976b69d87e336733637ea12693"},
-    {file = "Sphinx-5.1.1.tar.gz", hash = "sha256:ba3224a4e206e1fbdecf98a4fae4992ef9b24b85ebf7b584bb340156eaf08d89"},
+    {file = "Sphinx-5.2.3.tar.gz", hash = "sha256:5b10cb1022dac8c035f75767799c39217a05fc0fe2d6fe5597560d38e44f0363"},
+    {file = "sphinx-5.2.3-py3-none-any.whl", hash = "sha256:7abf6fabd7b58d0727b7317d5e2650ef68765bbe0ccb63c8795fa8683477eaa2"},
+]
+sphinx-autodoc-typehints = [
+    {file = "sphinx_autodoc_typehints-1.19.4-py3-none-any.whl", hash = "sha256:e190d8ee8204c3de05a64f41cf10e592e987e4063c8ec0de7e4b11f6e036b2e2"},
+    {file = "sphinx_autodoc_typehints-1.19.4.tar.gz", hash = "sha256:ffd8e710f6757471b5c831c7ece88f52a9ff15f27836f4ef1c8695a64f8dcca8"},
 ]
 sphinx-copybutton = [
     {file = "sphinx-copybutton-0.5.0.tar.gz", hash = "sha256:a0c059daadd03c27ba750da534a92a63e7a36a7736dcf684f26ee346199787f6"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ jupyter = "^1.0.0"
 ipykernel = "^6.15.3"
 ipywidgets = "^8.0.2"
 docutils = "0.16"
-Sphinx = "5.1.1"
+Sphinx = "^5.2.3"
 sphinx-rtd-theme = "^1.0.0"
 sphinxcontrib-seqdiag = "^3.0.0"
 sphinx-copybutton = "^0.5.0"
@@ -67,6 +67,8 @@ nbsphinx = "^0.8.9"
 Pillow = "^9.2.0"
 myst-parser = "^0.18.0"
 sympy = "^1.11.1"
+sphinx = "^5.2.3"
+sphinx-autodoc-typehints = "^1.19.4"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]
@@ -85,9 +87,5 @@ filterwarnings = ["error"]
 addopts = "--cov=covsirphy --cov-report=xml --cov-report=term-missing -vv --no-cov-on-fail -p no:cacheprovider --durations=1 --maxfail=1"
 
 [tool.deptry]
-ignore_obsolete = [
-    'pyarrow', 'tabulate', 'requests',
-]
-exclude = [
-    'tests', '.venv', 'example', 'docs',
-]
+ignore_obsolete = ['pyarrow', 'tabulate', 'requests']
+exclude = ['tests', '.venv', 'example', 'docs']


### PR DESCRIPTION
## Related issues
#1258

## What was changed
- use type hints in APIs users will call: downloading
- show type hints in documentation using `sphinx_autodoc_typehints` and `sphinx.ext.intersphinx`