### PR TITLE
Use type hint in APIs of dynamics and add `pyright` check to quality check workflow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,6 +96,7 @@ check:
 	@# Check codes with deptry and pflake8
 	@poetry run deptry .
 	@poetry run pflake8 covsirphy
+	@poetry run pyright
 
 .PHONY: test
 test:

--- a/covsirphy/downloading/downloader.py
+++ b/covsirphy/downloading/downloader.py
@@ -21,7 +21,7 @@ class DataDownloader(Term):
     Note:
         Location layers are fixed to ['ISO3', 'Province', 'City'].
     """
-    LAYERS = [Term.ISO3, Term.PROVINCE, Term.CITY]
+    LAYERS: list[str] = [Term.ISO3, Term.PROVINCE, Term.CITY]
 
     def __init__(self, directory: str or Path = "input", update_interval: int = 12, **kwargs) -> None:
         self._directory = directory

--- a/covsirphy/dynamics/sir.py
+++ b/covsirphy/dynamics/sir.py
@@ -1,4 +1,6 @@
+from __future__ import annotations
 import numpy as np
+import pandas as pd
 from covsirphy.util.validator import Validator
 from covsirphy.dynamics.ode import ODEModel
 
@@ -7,13 +9,15 @@ class SIRModel(ODEModel):
     """Class of SIR model.
 
     Args:
-        date_range (tuple of (str, str)): start date and end date of simulation
-        tau (int): tau value [min]
-        initial_dict (dict of {str: int}): initial values
+        date_range: start date and end date of simulation
+        tau: tau value [min]
+        initial_dict: initial values
+
             - Susceptible (int): the number of susceptible cases
             - Infected (int): the number of infected cases
             - Fatal or Recovered (int): the number of fatal or recovered cases
-        param_dict (dict of {str: float}): non-dimensional parameter values
+        param_dict: non-dimensional parameter values
+
             - rho: non-dimensional effective contact rate
             - sigma: non-dimensional recovery plus mortality rate
     """
@@ -33,17 +37,17 @@ class SIRModel(ODEModel):
         "param_dict": {"rho": 0.2, "sigma": 0.075}
     }
 
-    def __init__(self, date_range, tau, initial_dict, param_dict):
+    def __init__(self, date_range: tuple[str, str], tau: int, initial_dict: dict[str, int], param_dict: dict[str, float]) -> None:
         super().__init__(date_range, tau, initial_dict, param_dict)
         self._rho = Validator(self._param_dict["rho"], "rho", accept_none=False).float(value_range=(0, 1))
         self._sigma = Validator(self._param_dict["sigma"], "sigma", accept_none=False).float(value_range=(0, 1))
 
-    def _discretize(self, t, X):
+    def _discretize(self, t: int, X: np.ndarray) -> np.ndarray:
         """Discretize the ODE.
 
         Args:
-            t (int): discrete time-steps
-            X (numpy.array): the current values of the model
+            t: discrete time-steps
+            X: the current values of the model
 
         Returns:
             numpy.array: the next values of the model
@@ -56,11 +60,11 @@ class SIRModel(ODEModel):
         return np.array([dsdt, didt, drdt])
 
     @classmethod
-    def transform(cls, data, tau=None):
+    def transform(cls, data: pd.DataFrame, tau: int | None = None) -> pd.DataFrame:
         """Transform a dataframe, converting Susceptible/Infected/Fatal/Recovered to model-specific variables.
 
         Args:
-            data (pandas.DataFrame):
+            data:
                 Index
                     reset index or pandas.DatetimeIndex (when tau is not None)
                 Columns
@@ -68,16 +72,15 @@ class SIRModel(ODEModel):
                     - Infected (int): the number of currently infected cases
                     - Recovered (int): the number of recovered cases
                     - Fatal (int): the number of fatal cases
-            tau (int or None): tau value [min]
+            tau: tau value [min]
 
         Returns:
-            pandas.DataFrame:
-                Index
-                    as the same as index if @data when @tau is None else converted to time(x) = (TIME(x) - TIME(0)) / tau
-                Columns
-                    - Susceptible (int): the number of susceptible cases
-                    - Infected (int): the number of infected cases
-                    - Fatal or Recovered (int): the number of fatal or recovered cases
+            Index
+                as the same as index if @data when @tau is None else converted to time(x) = (TIME(x) - TIME(0)) / tau
+            Columns
+                - Susceptible (int): the number of susceptible cases
+                - Infected (int): the number of infected cases
+                - Fatal or Recovered (int): the number of fatal or recovered cases
         """
         df = Validator(data, "data").dataframe(columns=cls._SIRF)
         df.index = cls._date_to_non_dim(df.index, tau=tau)
@@ -85,29 +88,28 @@ class SIRModel(ODEModel):
         return df.loc[:, cls._VARIABLES].convert_dtypes()
 
     @classmethod
-    def inverse_transform(cls, data, tau=None, start_date=None):
+    def inverse_transform(cls, data: pd.DataFrame, tau: int | None = None, start_date: str | pd.Timestamp | None = None) -> pd.DataFrame:
         """Transform a dataframe, converting model-specific variables to Susceptible/Infected/Fatal/Recovered.
 
         Args:
-            data (pandas.DataFrame):
+            data:
                 Index
                     any index
                 Columns
                     - Susceptible (int): the number of susceptible cases
                     - Infected (int): the number of infected cases
                     - Fatal or Recovered (int): the number of fatal or recovered cases
-            tau (int or None): tau value [min]
-            start_date (str or pandas.Timestamp or None): start date of records ie. TIME(0)
+            tau: tau value [min]
+            start_date: start date of records ie. TIME(0)
 
         Returns:
-            pandas.DataFrame:
-                Index
-                    Date (pandas.DatetimeIndex) or as-is @data (when either @tau or @start_date are None the index @data is date)
-                Columns
-                    - Susceptible (int): the number of susceptible cases
-                    - Infected (int): the number of currently infected cases
-                    - Recovered (int): the number of recovered cases
-                    - Fatal (int): the number of fatal cases
+            Index
+                Date (pandas.DatetimeIndex) or as-is @data (when either @tau or @start_date are None the index @data is date)
+            Columns
+                - Susceptible (int): the number of susceptible cases
+                - Infected (int): the number of currently infected cases
+                - Recovered (int): the number of recovered cases
+                - Fatal (int): the number of fatal cases
         """
         df = Validator(data, "data").dataframe(columns=cls._VARIABLES)
         df = cls._non_dim_to_date(data=df, tau=tau, start_date=start_date)
@@ -115,14 +117,14 @@ class SIRModel(ODEModel):
         df[cls.R] = df.loc[:, cls.FR]
         return df.loc[:, cls._SIRF].convert_dtypes()
 
-    def r0(self):
+    def r0(self) -> float:
         """Calculate basic reproduction number.
 
         Raises:
             ZeroDivisionError: Sigma value was over 0
 
         Returns:
-            float: reproduction number of the ODE model and parameters
+            reproduction number of the ODE model and parameters
         """
         try:
             return round(self._rho / self._sigma, 2)
@@ -130,14 +132,14 @@ class SIRModel(ODEModel):
             raise ZeroDivisionError(
                 f"Sigma must be over 0 to calculate reproduction number with {self._NAME}.") from None
 
-    def dimensional_parameters(self):
+    def dimensional_parameters(self) -> dict[str, int]:
         """Calculate dimensional parameter values.
 
         Raises:
             ZeroDivisionError: either rho or sigma value was over 0
 
         Returns:
-            dict of {str: int}: dictionary of dimensional parameter values
+            dictionary of dimensional parameter values
                 - "1/beta [day]" (int): infection period
                 - "1/gamma [day]" (int): recovery period
         """
@@ -151,18 +153,19 @@ class SIRModel(ODEModel):
                 f"Rho and sigma must be over 0 to calculate dimensional parameters with {self._NAME}.") from None
 
     @classmethod
-    def _param_quantile(cls, data, q=0.5):
+    def _param_quantile(cls, data: pd.DataFrame, q: float | pd.Series = 0.5) -> dict[str, float | pd.Series]:
         """With combinations (X, dX/dt) for X=S, I, R, calculate quantile values of ODE parameters.
 
         Args:
-            data (pandas.DataFrame): transformed data with covsirphy.SIRModel.transform(data=data, tau=tau)
-            q (float or array-like): the quantile(s) to compute, value(s) between (0, 1)
+            data: transformed data with covsirphy.SIRModel.transform(data=data, tau=tau)
+            q: the quantile(s) to compute, value(s) between (0, 1)
 
         Returns:
-            dict of {str: float or pandas.Series}: parameter values at the quantile(s)
+            parameter values at the quantile(s)
 
         Note:
             We can get approximate parameter values with difference equations as follows.
+
             - rho = - n * (dS/dt) / S / I
             - sigma = (dR/dt) / I
         """
@@ -181,11 +184,11 @@ class SIRModel(ODEModel):
         }
 
     @classmethod
-    def sr(cls, data):
+    def sr(cls, data: pd.DataFrame) -> pd.DataFrame:
         """Return log10(S) and R of model-specific variables for S-R trend analysis.
 
         Args:
-            data (pandas.DataFrame):
+            data:
                 Index
                     Date (pd.Timestamp): Observation date
                 Columns
@@ -195,12 +198,11 @@ class SIRModel(ODEModel):
                     Fatal (int): the number of fatal cases
 
         Returns:
-            pandas.DataFrame:
-                Index
-                    Date (pandas.Timestamp): date
-                Columns
-                    log10(S) (np.float64): common logarithm of Susceptible
-                    R (np.int64): Fatal or Recovered
+            Index
+                Date (pandas.Timestamp): date
+            Columns
+                log10(S) (np.float64): common logarithm of Susceptible
+                R (np.int64): Fatal or Recovered
         """
         Validator(data, "data", accept_none=False).dataframe(time_index=True, columns=cls._SIRF)
         df = data.copy()

--- a/covsirphy/engineering/_complement.py
+++ b/covsirphy/engineering/_complement.py
@@ -1,3 +1,4 @@
+from __future__ import annotations
 import functools
 import warnings
 import numpy as np
@@ -46,15 +47,16 @@ class _ComplementHandler(Term):
     def __init__(self, recovery_period, interval, max_ignored, max_ending_unupdated,
                  upper_limit_days, lower_limit_days, upper_percentage, lower_percentage):
         # Arguments for complement
-        self.recovery_period = Validator(recovery_period, "recovery_period").int(value_range=(1, None))
-        self.interval = Validator(interval, "interval").int(value_range=(0, None))
-        self.max_ignored = Validator(max_ignored, "max_ignored").int(value_range=(1, None))
-        self.max_ending_unupdated = Validator(max_ending_unupdated, "max_ending_unupdated").int(value_range=(0, None))
-        self.upper_limit_days = Validator(upper_limit_days, "upper_limit_days").int(value_range=(0, None))
-        self.lower_limit_days = Validator(lower_limit_days, "lower_limit_days").int(value_range=(0, None))
-        self.upper_percentage = Validator(upper_percentage, "upper_percentage").float(value_range=(0, 100))
-        self.lower_percentage = Validator(lower_percentage, "lower_percentage").float(value_range=(0, 100))
-        self.complement_dict = None
+        self.recovery_period: int = Validator(recovery_period, "recovery_period").int(value_range=(1, None))
+        self.interval: int = Validator(interval, "interval").int(value_range=(0, None))
+        self.max_ignored: int = Validator(max_ignored, "max_ignored").int(value_range=(1, None))
+        self.max_ending_unupdated: int = Validator(
+            max_ending_unupdated, "max_ending_unupdated").int(value_range=(0, None))
+        self.upper_limit_days: int = Validator(upper_limit_days, "upper_limit_days").int(value_range=(0, None))
+        self.lower_limit_days: int = Validator(lower_limit_days, "lower_limit_days").int(value_range=(0, None))
+        self.upper_percentage: float = Validator(upper_percentage, "upper_percentage").float(value_range=(0, 100))
+        self.lower_percentage: float = Validator(lower_percentage, "lower_percentage").float(value_range=(0, 100))
+        self.complement_dict: dict[str, bool] = {}
 
     def _protocol(self):
         """

--- a/covsirphy/util/alias.py
+++ b/covsirphy/util/alias.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+from typing_extensions import Any, Self
 from covsirphy.util.validator import Validator
 from covsirphy.util.term import Term
 
@@ -6,15 +8,15 @@ class Alias(Term):
     """Remember and parse aliases, just like defaultdict.
 
     Args:
-        target_class (object): class of targets or None (all objects)
+        target_class: class of targets or None (all objects)
     """
 
-    def __init__(self, target_class=None):
+    def __init__(self, target_class: Any = None) -> None:
         self._dict = {}
         self._target_class = target_class or object
 
     @classmethod
-    def for_variables(cls):
+    def for_variables(cls) -> Self:
         """Initialize covsirphy.Alias with preset of variable aliases.
         """
         class_obj = cls(target_class=list)
@@ -28,54 +30,54 @@ class Alias(Term):
         [class_obj.update(name, target) for name, target in _dict.items()]
         return class_obj
 
-    def update(self, name, target):
+    def update(self, name: str, target: Any) -> Self:
         """Update target of the alias.
 
         Args:
-            name (str): alias name
-            targets (object): target to link with the name
+            name: alias name
+            targets: target to link with the name
 
         Return:
-            covsirphy.Alias: self
+            updated Alias instance
         """
         Validator(name, "name", accept_none=False).instance(str)
         self._dict[name] = Validator(target, "target").instance(expected=self._target_class)
         return self
 
-    def find(self, name, default=None):
+    def find(self, name: str, default: Any = None) -> Any:
         """Find the target of the alias.
 
         Args:
-            name (str): alias name
-            default (object): default value when not found
+            name: alias name
+            default: default value when not found
 
         Returns:
-            object: target or default value
+            the target or default value
         """
         try:
             return self._dict.get(name, default)
         except TypeError:
             return default
 
-    def all(self):
+    def all(self) -> dict[str, Any]:
         """List up all targets of aliases.
 
         Returns:
-            dict of {str: object}
+            all aliases
         """
         return self._dict
 
-    def delete(self, name):
+    def delete(self, name: str) -> Self:
         """Delete alias.
 
         Args:
-            name (str): alias name
+            name: alias name
 
         Raises:
             KeyError: the alias has not been registered as an alias
 
         Return:
-            covsirphy.Alias: self
+            updated Alias instance
         """
         try:
             del self._dict[name]

--- a/covsirphy/util/validator.py
+++ b/covsirphy/util/validator.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 from inspect import signature
 import math
 import pandas as pd
-from typing_extensions import Any, Callable, Iterable
+from typing import Callable
+from typing_extensions import Any, Iterable
 from covsirphy.util.error import NAFoundError, NotIncludedError, NotSubclassError, UnExpectedTypeError, EmptyError
 from covsirphy.util.error import UnExpectedValueRangeError, UnExpectedValueError, UnExpectedLengthError, UnExpectedNoneError
 

--- a/covsirphy/util/validator.py
+++ b/covsirphy/util/validator.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 from inspect import signature
 import math
 import pandas as pd
-from typing import Callable
-from typing_extensions import Any, Iterable
+from typing import Callable, Iterable
+from typing_extensions import Any
 from covsirphy.util.error import NAFoundError, NotIncludedError, NotSubclassError, UnExpectedTypeError, EmptyError
 from covsirphy.util.error import UnExpectedValueRangeError, UnExpectedValueError, UnExpectedLengthError, UnExpectedNoneError
 

--- a/covsirphy/util/validator.py
+++ b/covsirphy/util/validator.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 from inspect import signature
 import math
 import pandas as pd
+from typing_extensions import Any, Callable, Iterable
 from covsirphy.util.error import NAFoundError, NotIncludedError, NotSubclassError, UnExpectedTypeError, EmptyError
 from covsirphy.util.error import UnExpectedValueRangeError, UnExpectedValueError, UnExpectedLengthError, UnExpectedNoneError
 
@@ -20,45 +22,45 @@ class Validator(object):
         When @accept_none is True and @target is None, default values will be returned with instance methods.
     """
 
-    def __init__(self, target, name="target", accept_none=True):
+    def __init__(self, target: Any, name: str = "target", accept_none: bool = True) -> None:
         self._target = target
-        self._name = str(name)
+        self._name = name
         if target is None and not accept_none:
             raise UnExpectedNoneError(self._name)
 
-    def subclass(self, parent):
+    def subclass(self, parent: Any) -> Any:
         """Ensure the target is a subclass of the parent class.
 
         Args:
-            parent (object): parent class or sequence of parent classes
+            parent: parent class or sequence of parent classes
 
         Raises:
             NotSubclassError: the target is not the subclass
 
         Returns:
-            object: the target itself
+            the target itself
         """
         if issubclass(self._target, parent):
             return self._target
         raise NotSubclassError(self._name, self._target, parent)
 
-    def instance(self, expected):
+    def instance(self, expected: Any) -> Any:
         """Ensure that the target is an instance of a specified class.
 
         Args:
-            expected (object): expected class or sequence of expected classes
+            expected: expected class or sequence of expected classes
 
         Raises:
             UnExpectedTypeError: the target is not an instance of the class
 
         Returns:
-            object: the target itself
+            the target itself
         """
         if isinstance(self._target, expected):
             return self._target
         raise UnExpectedTypeError(self._name, self._target, expected)
 
-    def dataframe(self, time_index=False, columns=None, empty_ok=True):
+    def dataframe(self, time_index: bool = False, columns: list[str] | None = None, empty_ok: bool = True) -> pd.DataFrame:
         """Ensure the target is a dataframe.
 
         Args:
@@ -91,23 +93,24 @@ class Validator(object):
                     details=f"The dataframe has {', '.join(df.columns.tolist())} as columns")
         return df
 
-    def float(self, value_range=(0, None), default=None, digits=None):
+    def float(self, value_range: tuple[int | None, int | None] = (0, None), default: float | None = None, digits: int | None = None) -> float:
         """Convert a value to a float value.
 
         Args:
-            value_range (tuple(int or None, int or None)): value range, None means un-specified
-            default (float or None): default value when the target is None
-            digits (int or None): effective digits or None (skip rounding)
+            value_range: value range, None means un-specified
+            default: default value when the target is None
+            digits: effective digits or None (skip rounding)
 
         Raises:
+            UnExpectedNoneError: the default value is None when the target is None
             UnExpectedTypeError: the target cannot be converted to a float value
             UnExpectedValueRangeError: the value is out of value range
 
         Returns:
-            float or None: converted float value or None (when both of the target and @default are None)
+            converted float value
         """
         if self._target is None:
-            return None if default is None else Validator(default, "default").float(value_range=value_range, digits=digits)
+            return Validator(default, "default", accept_none=False).float(value_range=value_range, digits=digits)
         try:
             value = float(self._target)
         except ValueError:
@@ -118,23 +121,24 @@ class Validator(object):
             return value
         return round(value, digits - 1 - math.floor(math.log10(abs(value))))
 
-    def int(self, value_range=(0, None), default=None, round_ok=False):
+    def int(self, value_range: tuple[int | None, int | None] = (0, None), default: int | None = None, round_ok: bool = False) -> int:
         """Convert a value to an integer.
 
         Args:
-            value_range (tuple(int or None, int or None)): value range, None means un-specified
-            default (int or None): default value when the target is None
-            round_ok (bool): whether ignore round-off error
+            value_range: value range, None means un-specified
+            default: default value when the target is None
+            round_ok: whether ignore round-off error
 
         Raises:
+            UnExpectedNoneError: the default value is None when the target is None
             UnExpectedTypeError: the target cannot be converted to an integer or round-off error exists when @round_ok is False
             UnExpectedValueRangeError: the value is out of value range
 
         Returns:
-            int or None: converted float value or None (when both of the target and @default are None)
+            converted float value
         """
         if self._target is None:
-            return None if default is None else Validator(default, name="default").int(value_range=value_range, round_ok=round_ok)
+            return Validator(default, name="default", accept_none=False).int(value_range=value_range, round_ok=round_ok)
         try:
             value = int(self._target)
         except (ValueError, TypeError):
@@ -146,18 +150,18 @@ class Validator(object):
             raise UnExpectedValueRangeError(self._name, value, value_range)
         return value
 
-    def tau(self, default=None):
+    def tau(self, default: int | None = None) -> int | None:
         """Validate the value can be used as tau value [min].
 
         Args:
-            default (int or None): default value when the target is None
+            default: default value when the target is None
 
         Raises:
             UnExpectedTypeError: the target cannot be converted to an integer
             UnExpectedValueRangeError: the value is out of value range
 
         Returns:
-            int or None: converted float value or None (when both of the target and @default are None)
+            converted float value or None (when both of the target and @default are None)
         """
         if self._target is None:
             return None if default is None else Validator(default, name="default").tau()
@@ -169,22 +173,23 @@ class Validator(object):
             self._name, value, divisors,
             details="Tau value [min], a divisor of 1440 [min], is a parameter used to convert actual time to time steps (without units)")
 
-    def date(self, value_range=(None, None), default=None):
+    def date(self, value_range: tuple[pd.Timestamp | None, pd.Timestamp | None] = (None, None), default: pd.Timestamp | None = None) -> pd.Timestamp:
         """Convert a value to a date object.
 
         Args:
-            value_range (tuple(int or None, int or None)): value range, None means un-specified
-            default (pandas.Timestamp or None): default value when the target is None
+            value_range: value range, None means un-specified
+            default: default value when the target is None
 
         Raises:
+            UnExpectedNoneError: the default value is None when the target is None
             UnExpectedTypeError: the target cannot be converted to a date object
             UnExpectedValueRangeError: the value is out of value range
 
         Returns:
-            pandas.Timestamp or None: converted date or None (when both of the target and @default are None)
+            converted date
         """
         if self._target is None:
-            return None if default is None else Validator(default, name="default").date(value_range=value_range)
+            return Validator(default, name="default", accept_none=False).date(value_range=value_range)
         if isinstance(self._target, pd.Timestamp):
             value = self._target.replace(hour=0, minute=0, second=0, microsecond=0)
         else:
@@ -197,15 +202,15 @@ class Validator(object):
                 self._name, value.strftime("%Y-%m-%d"), [None if value is None else value.strftime("%Y-%m-%d") for value in value_range])
         return value
 
-    def sequence(self, default=None, flatten=False, unique=False, candidates=None, length=None):
+    def sequence(self, default: Iterable[Any] | None = None, flatten: bool = False, unique: bool = False, candidates: Iterable[Any] | None = None, length: int | None = None) -> list[Any]:
         """Convert a sequence (list, tuple) to a list.
 
         Args:
-            default (list[object] or None): default value when the target is None
-            flatten (bool): whether flatten the sequence or not
-            unique (bool): whether remove duplicated values or not, the first value will remain
-            candidates (list[object] or tuple(object) or iter or None): list of candidates or None (no limitations)
-            length (int or None): length of the sequence or None (no limitations)
+            default: default value when the target is None
+            flatten: whether flatten the sequence or not
+            unique: whether remove duplicated values or not, the first value will remain
+            candidates: list of candidates or None (no limitations)
+            length: length of the sequence or None (no limitations)
 
         Raises:
             UnExpectedTypeError: the target cannot be converted to a list or failed in flattening
@@ -213,10 +218,10 @@ class Validator(object):
             UnExpectedLengthError: the number of elements is not the same as @length
 
         Returns:
-            list[object] or None: converted list or None (when both of the target and @default are None)
+            converted list or empty list (when both of the target and @default are None)
         """
         if self._target is None:
-            return None if default is None else Validator(default, name="default").sequence(flatten=flatten, unique=unique, candidates=candidates)
+            return [] if default is None else Validator(default, name="default", accept_none=False).sequence(flatten=flatten, unique=unique, candidates=candidates)
         if not isinstance(self._target, (list, tuple)):
             raise UnExpectedTypeError(
                 self._name, self._target, list, details="A tuple can be used, but it will be converted to a list")
@@ -238,20 +243,20 @@ class Validator(object):
         for value in (set(targets) - set(candidates)):
             raise UnExpectedValueError(self._name, value, [str(c) for c in candidates])
 
-    def dict(self, default=None, required_keys=None, errors="coerce"):
+    def dict(self, default: dict[str, Any] | None = None, required_keys: list[Any] | None = None, errors: str = "coerce") -> dict[str, Any]:
         """Ensure the target is a dictionary.
 
         Args:
-            default (dict[str, object] or None): default values, when the target is None or key is not included in the target
-            required_keys (list): keys which must be included
-            errors (str): "coerce" or "raise"
+            default: default values, when the target is None or key is not included in the target
+            required_keys: keys which must be included
+            errors: "coerce" or "raise"
 
         Raises:
             UnExpectedTypeError: the target is not a dictionary
             NAFoundError: values of the required keys are not specified when @errors="raise"
 
         Returns:
-            dict[str, object]: the target is self with default values and required keys
+            the target is self with default values and required keys
 
         Note:
             All keys of @default will be included and the target will overwrite it.
@@ -269,18 +274,18 @@ class Validator(object):
                 raise NAFoundError(f"The value of key {key} in dictionary {self._name}")
         return _dict
 
-    def kwargs(self, functions, default=None):
+    def kwargs(self, functions: list[Callable] | Callable, default: dict[str, Any] | None = None) -> dict[str, Any]:
         """Find keyword arguments of the functions.
 
         Args:
-            functions (list[function] or function): target functions
-            default (dict[str, object] or None): default values, when the target is None or key is not included in the target
+            functions: target functions
+            default: default values, when the target is None or key is not included in the target
 
         Raises:
             UnExpectedTypeError: the target is not a dictionary
 
         Returns:
-            dict[str, object]: keyword arguments of the functions
+            dict: keyword arguments of the functions
         """
         _dict = self.dict(default=default, required_keys=None, errors="coerce")
         keywords_nest = [

--- a/covsirphy/visualization/bar_plot.py
+++ b/covsirphy/visualization/bar_plot.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 from matplotlib import pyplot as plt
 from matplotlib.ticker import ScalarFormatter
 import pandas as pd
+from typing_extensions import Self
 from covsirphy.util.validator import Validator
 from covsirphy.visualization.vbase import VisualizeBase, find_args
 
@@ -22,7 +24,7 @@ class BarPlot(VisualizeBase):
         self._variables = []
         self._ax = None
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return super().__enter__()
 
     def __exit__(self, *exc_info):

--- a/covsirphy/visualization/compare_plot.py
+++ b/covsirphy/visualization/compare_plot.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 from matplotlib import pyplot as plt
 from matplotlib.ticker import ScalarFormatter
+from typing_extensions import Self
 from covsirphy.util.validator import Validator
 from covsirphy.visualization.vbase import VisualizeBase, find_args
 
@@ -21,7 +23,7 @@ class ComparePlot(VisualizeBase):
         self._variables = []
         self._ax = None
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return super().__enter__()
 
     def __exit__(self, *exc_info):

--- a/covsirphy/visualization/line_plot.py
+++ b/covsirphy/visualization/line_plot.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
 from matplotlib import pyplot as plt
 from matplotlib.ticker import ScalarFormatter
 import pandas as pd
+from typing_extensions import Self
 from covsirphy.util.validator import Validator
 from covsirphy.visualization.vbase import VisualizeBase, find_args
 
@@ -22,7 +24,7 @@ class LinePlot(VisualizeBase):
         self._variables = []
         self._ax = None
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return super().__enter__()
 
     def __exit__(self, *exc_info):

--- a/covsirphy/visualization/scatter_plot.py
+++ b/covsirphy/visualization/scatter_plot.py
@@ -1,5 +1,7 @@
+from __future__ import annotations
 from matplotlib import pyplot as plt
 import pandas as pd
+from typing_extensions import Self
 from covsirphy.util.error import UnExecutedError
 from covsirphy.util.validator import Validator
 from covsirphy.visualization.vbase import find_args
@@ -23,7 +25,7 @@ class ScatterPlot(LinePlot):
         self._ax = None
         self._data = pd.DataFrame(columns=["x", "y"])
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return super().__enter__()
 
     def __exit__(self, *exc_info):

--- a/covsirphy/visualization/vbase.py
+++ b/covsirphy/visualization/vbase.py
@@ -1,9 +1,11 @@
+from __future__ import annotations
 from inspect import signature
 import sys
 import matplotlib
 if not hasattr(sys, "ps1"):
     matplotlib.use("Agg")
 from matplotlib import pyplot as plt
+from typing_extensions import Self
 from covsirphy.util.error import UnExecutedError
 from covsirphy.util.validator import Validator
 from covsirphy.util.term import Term
@@ -49,11 +51,12 @@ class VisualizeBase(Term):
     def __init__(self, filename=None, bbox_inches="tight", **kwargs):
         self._filename = filename
         self._savefig_dict = {"bbox_inches": bbox_inches, **kwargs}
+        self._variables = []
         # Properties
         self._title = ""
         _, self._ax = plt.subplots(1, 1)
 
-    def __enter__(self):
+    def __enter__(self) -> Self:
         return self
 
     def __exit__(self, *exc_info):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -92,8 +92,10 @@ napoleon_use_rtype = False
 napoleon_use_ivar = True
 
 intersphinx_mapping = {
-    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
     "python": ("https://docs.python.org/3/", None),
+    "pandas": ("https://pandas.pydata.org/pandas-docs/stable/", None),
+    'numpy': ('http://docs.scipy.org/doc/numpy', None),
+    'matplotlib': ('http://matplotlib.org/stable', None),
 }
 
 # -- Options for todo extension ----------------------------------------------

--- a/poetry.lock
+++ b/poetry.lock
@@ -1245,6 +1245,17 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "nodeenv"
+version = "1.7.0"
+description = "Node.js virtual environment builder"
+category = "dev"
+optional = false
+python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,!=3.5.*,!=3.6.*"
+
+[package.dependencies]
+setuptools = "*"
+
+[[package]]
 name = "notebook"
 version = "6.5.1"
 description = "A web-based notebook environment for interactive computing"
@@ -1534,7 +1545,7 @@ tests = ["pytest", "pytest-cov", "pytest-lazy-fixture"]
 
 [[package]]
 name = "prometheus-client"
-version = "0.14.1"
+version = "0.15.0"
 description = "Python client for the Prometheus monitoring system."
 category = "dev"
 optional = false
@@ -1687,6 +1698,21 @@ description = "A python implementation of GNU readline."
 category = "main"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "pyright"
+version = "1.1.275"
+description = "Command line wrapper for pyright"
+category = "dev"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+nodeenv = ">=1.6.0"
+
+[package.extras]
+all = ["twine (>=3.4.1)"]
+dev = ["twine (>=3.4.1)"]
 
 [[package]]
 name = "pyrsistent"
@@ -1964,7 +1990,7 @@ testing = ["docutils", "flake8", "flake8-coding", "flake8-copyright", "flake8-is
 
 [[package]]
 name = "setuptools"
-version = "65.4.1"
+version = "65.5.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
@@ -1995,7 +2021,7 @@ toml = ["setuptools (>=42)"]
 
 [[package]]
 name = "shapely"
-version = "1.8.5"
+version = "1.8.5.post1"
 description = "Geometric objects, predicates, and operations"
 category = "main"
 optional = false
@@ -2511,7 +2537,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "f6cadd818000b17dcc607b9a8530af038d8b22de770f96eeda64c12e187b0d86"
+content-hash = "04de2aa68626c1ae233a88bf47d6344ba88924eaaa5755c6820803e1a2c9547d"
 
 [metadata.files]
 alabaster = [
@@ -3321,6 +3347,10 @@ nest-asyncio = [
     {file = "nest_asyncio-1.5.6-py3-none-any.whl", hash = "sha256:b9a953fb40dceaa587d109609098db21900182b16440652454a146cffb06e8b8"},
     {file = "nest_asyncio-1.5.6.tar.gz", hash = "sha256:d267cc1ff794403f7df692964d1d2a3fa9418ffea2a3f6859a439ff482fef290"},
 ]
+nodeenv = [
+    {file = "nodeenv-1.7.0-py2.py3-none-any.whl", hash = "sha256:27083a7b96a25f2f5e1d8cb4b6317ee8aeda3bdd121394e5ac54e498028a042e"},
+    {file = "nodeenv-1.7.0.tar.gz", hash = "sha256:e0e7f7dfb85fc5394c6fe1e8fa98131a2473e04311a45afb6508f7cf1836fa2b"},
+]
 notebook = [
     {file = "notebook-6.5.1-py3-none-any.whl", hash = "sha256:660849b12a1e03f98bfc84ec73422f09a4fdd1af6679c1935b1baf426b864fca"},
     {file = "notebook-6.5.1.tar.gz", hash = "sha256:f69fd3b13df092af3a66c8797fa8ce00608db71cade89105ac4178b8d8d154aa"},
@@ -3513,8 +3543,8 @@ prettytable = [
     {file = "prettytable-3.4.1.tar.gz", hash = "sha256:7d7dd84d0b206f2daac4471a72f299d6907f34516064feb2838e333a4e2567bd"},
 ]
 prometheus-client = [
-    {file = "prometheus_client-0.14.1-py3-none-any.whl", hash = "sha256:522fded625282822a89e2773452f42df14b5a8e84a86433e3f8a189c1d54dc01"},
-    {file = "prometheus_client-0.14.1.tar.gz", hash = "sha256:5459c427624961076277fdc6dc50540e2bacb98eebde99886e59ec55ed92093a"},
+    {file = "prometheus_client-0.15.0-py3-none-any.whl", hash = "sha256:db7c05cbd13a0f79975592d112320f2605a325969b270a94b71dcabc47b931d2"},
+    {file = "prometheus_client-0.15.0.tar.gz", hash = "sha256:be26aa452490cfcf6da953f9436e95a9f2b4d578ca80094b4458930e5f584ab1"},
 ]
 prompt-toolkit = [
     {file = "prompt_toolkit-3.0.31-py3-none-any.whl", hash = "sha256:9696f386133df0fc8ca5af4895afe5d78f5fcfe5258111c2a79a1c3e41ffa96d"},
@@ -3653,6 +3683,10 @@ pyproject-flake8 = [
 pyreadline3 = [
     {file = "pyreadline3-3.4.1-py3-none-any.whl", hash = "sha256:b0efb6516fd4fb07b45949053826a62fa4cb353db5be2bbb4a7aa1fdd1e345fb"},
     {file = "pyreadline3-3.4.1.tar.gz", hash = "sha256:6f3d1f7b8a31ba32b73917cefc1f28cc660562f39aea8646d30bd6eff21f7bae"},
+]
+pyright = [
+    {file = "pyright-1.1.275-py3-none-any.whl", hash = "sha256:83072f509e18160f2661a2276ac85f471112dbcfc1dadf0cbb0393a4d56db72a"},
+    {file = "pyright-1.1.275.tar.gz", hash = "sha256:f0061ce47c785b9b64745b7648ff9732a99811ef7c7f3f88642aa2cb7868c81e"},
 ]
 pyrsistent = [
     {file = "pyrsistent-0.18.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:df46c854f490f81210870e509818b729db4488e1f30f2a1ce1698b2295a878d1"},
@@ -3935,48 +3969,53 @@ seqdiag = [
     {file = "seqdiag-3.0.0.tar.gz", hash = "sha256:e15113a28bd075460a62da44e15a88fafa3c81fdf3a35dcd5e3cd64ef15e961a"},
 ]
 setuptools = [
-    {file = "setuptools-65.4.1-py3-none-any.whl", hash = "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012"},
-    {file = "setuptools-65.4.1.tar.gz", hash = "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"},
+    {file = "setuptools-65.5.0-py3-none-any.whl", hash = "sha256:f62ea9da9ed6289bfe868cd6845968a2c854d1427f8548d52cae02a42b4f0356"},
+    {file = "setuptools-65.5.0.tar.gz", hash = "sha256:512e5536220e38146176efb833d4a62aa726b7bbff82cfbc8ba9eaa3996e0b17"},
 ]
 setuptools-scm = [
     {file = "setuptools_scm-7.0.5-py3-none-any.whl", hash = "sha256:7930f720905e03ccd1e1d821db521bff7ec2ac9cf0ceb6552dd73d24a45d3b02"},
     {file = "setuptools_scm-7.0.5.tar.gz", hash = "sha256:031e13af771d6f892b941adb6ea04545bbf91ebc5ce68c78aaf3fff6e1fb4844"},
 ]
 shapely = [
-    {file = "Shapely-1.8.5-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:dbc8b2ed8e7655c0b33abbb5c8c74013699fe29d2ca15f354b6e1abd29f0ed7a"},
-    {file = "Shapely-1.8.5-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1c6198da94fc993049fc2d31bd183f4f4de4f33f70be8437a9807ae8788c069c"},
-    {file = "Shapely-1.8.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:a9a660dae5780fac8bdccaa2c68ca9ddcddb5d55330be47869fa9a8f55cb9580"},
-    {file = "Shapely-1.8.5-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6baf62a648c8745de3fb69e96a5ef93b1854159dd9c85527978e68fc2b062f76"},
-    {file = "Shapely-1.8.5-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:81c1286a1e46d1224bec8c1dba8f174b286710df796b4256198e64d1e987dfc9"},
-    {file = "Shapely-1.8.5-cp310-cp310-win32.whl", hash = "sha256:999952cf8ed7a033debf7d2715d7029e7f1a1144eb1bdefabe0d64aa4c9910cd"},
-    {file = "Shapely-1.8.5-cp310-cp310-win_amd64.whl", hash = "sha256:7a840e7d96a01e6da6725a002dab662a1dbd1f5d53a6433f7fdbaf2a1322576b"},
-    {file = "Shapely-1.8.5-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:27238d6890f409b0744c4d740413698bbb94d8cf5249406c4668ca28ade8df3b"},
-    {file = "Shapely-1.8.5-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:1512eb7222f4a00ec4d9c81762bd15ed622fa5e06dd9fe64721db6a5fc3345fe"},
-    {file = "Shapely-1.8.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:a0a5621d68ac371162768f1a05a91bcf64ac5f00a517458db5b8d8896c8e4743"},
-    {file = "Shapely-1.8.5-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8a1545c3e539516e87f5c4a96d5a76c623e385e5defe7555b7b26232043c9c5c"},
-    {file = "Shapely-1.8.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ba4d98a117ead8b49c2cc8723eb071f04da03d6eb59f340eb51364581bb6c9e0"},
-    {file = "Shapely-1.8.5-cp311-cp311-win32.whl", hash = "sha256:b0b60993adb141b5a1ff7f94fc512f9be69320be6e8757d32c460f25359d51f5"},
-    {file = "Shapely-1.8.5-cp311-cp311-win_amd64.whl", hash = "sha256:0d014b1d072f2f5b166c9cf57a58507089570b1839a83e14a308df56d467b809"},
-    {file = "Shapely-1.8.5-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:bd55b14fa82d54bf9d7eba4d11c6d9d61f96ab0ffe530c6eb7cd3bb9a6590153"},
-    {file = "Shapely-1.8.5-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:bd598f7373e1b5f317a3117d388a68b3c165fa15d5aa7de042848a1acbe4c18d"},
-    {file = "Shapely-1.8.5-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1500f7d9fbe47c02298694e282dbd9cd30f6dbd33f0bd2efd0712bf907d9a2b7"},
-    {file = "Shapely-1.8.5-cp37-cp37m-win32.whl", hash = "sha256:b1216ec40baf505dba006bfa0a7ced6b2334261925841fa23fafcdb26d9b1f54"},
-    {file = "Shapely-1.8.5-cp37-cp37m-win_amd64.whl", hash = "sha256:c1f2f125b785d468c08ee698472716355b54d8cbd69f7f09081893b4e4111e3f"},
-    {file = "Shapely-1.8.5-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:eca890915cbebc879c96cfc1b7ff51a09a2326c9f94b6b3e13d6d3cdfc659ed9"},
-    {file = "Shapely-1.8.5-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:17f1a4f0ba88e8f53975845af312a276e557e7bac8f0572e8b5805705739c892"},
-    {file = "Shapely-1.8.5-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1aa924b11d53fe817c4e5b14ac0c8e980913b9b5f15e01c23a35e3ee53cccf41"},
-    {file = "Shapely-1.8.5-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:045a9a5ba872431c7559020c6761983e4a0c13c9a0eb7fa93e427b4451f2d8cc"},
-    {file = "Shapely-1.8.5-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a43b3ba408f00c6588e174f6fb4dba5739fdee87af2e186ed7e8caece6b91568"},
-    {file = "Shapely-1.8.5-cp38-cp38-win32.whl", hash = "sha256:72ee40adae74ab93b6cf13d71f7183de8f91b077296a8788e791097703aa279d"},
-    {file = "Shapely-1.8.5-cp38-cp38-win_amd64.whl", hash = "sha256:221c9bd94d286b6941b3f86cbebead24c3f54cbac2cb02fb6746fd768be73b80"},
-    {file = "Shapely-1.8.5-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:2c86c9006b266c64bc1b9c0c0ebc20eff8fcce1bc06d4db13bbfbac9e5e2d910"},
-    {file = "Shapely-1.8.5-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:bffeab5498ac32e014845f675d6c4d7a85cba42cbc76ee794da828faf3c12ba6"},
-    {file = "Shapely-1.8.5-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:52f5b61ee2998a75e5bcadb609036bfd626ec472fc456241150bc95a9088c89c"},
-    {file = "Shapely-1.8.5-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:57df87c68e58050546fda07963d2f87a7e16db57029eb67239d27732f65f40d1"},
-    {file = "Shapely-1.8.5-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a8ad6ebec3b39af4890a59a027ad60e7fece5bfd71ecc998da7b03e5f414d32a"},
-    {file = "Shapely-1.8.5-cp39-cp39-win32.whl", hash = "sha256:0e6172d2e9e77aed7b6515bc68eefe623e5be7b865ced4b9892b5205166e2931"},
-    {file = "Shapely-1.8.5-cp39-cp39-win_amd64.whl", hash = "sha256:4c9a777bf999eca65ecf9f90821f6c699f72633f1f2fe4ca3fa829e6114fdb45"},
-    {file = "Shapely-1.8.5.tar.gz", hash = "sha256:e82b6d60ecfb124120c88fe106a478596bbeab142116d7e7f64a364dac902a92"},
+    {file = "Shapely-1.8.5.post1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:d048f93e42ba578b82758c15d8ae037d08e69d91d9872bca5a1895b118f4e2b0"},
+    {file = "Shapely-1.8.5.post1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:99ab0ddc05e44acabdbe657c599fdb9b2d82e86c5493bdae216c0c4018a82dee"},
+    {file = "Shapely-1.8.5.post1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:99a2f0da0109e81e0c101a2b4cd8412f73f5f299e7b5b2deaf64cd2a100ac118"},
+    {file = "Shapely-1.8.5.post1-cp310-cp310-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:6fe855e7d45685926b6ba00aaeb5eba5862611f7465775dacd527e081a8ced6d"},
+    {file = "Shapely-1.8.5.post1-cp310-cp310-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:ec14ceca36f67cb48b34d02d7f65a9acae15cd72b48e303531893ba4a960f3ea"},
+    {file = "Shapely-1.8.5.post1-cp310-cp310-win32.whl", hash = "sha256:21776184516a16bf82a0c3d6d6a312b3cd15a4cabafc61ee01cf2714a82e8396"},
+    {file = "Shapely-1.8.5.post1-cp310-cp310-win_amd64.whl", hash = "sha256:a354199219c8d836f280b88f2c5102c81bb044ccea45bd361dc38a79f3873714"},
+    {file = "Shapely-1.8.5.post1-cp311-cp311-macosx_10_9_universal2.whl", hash = "sha256:783bad5f48e2708a0e2f695a34ed382e4162c795cb2f0368b39528ac1d6db7ed"},
+    {file = "Shapely-1.8.5.post1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:a23ef3882d6aa203dd3623a3d55d698f59bfbd9f8a3bfed52c2da05a7f0f8640"},
+    {file = "Shapely-1.8.5.post1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:ab38f7b5196ace05725e407cb8cab9ff66edb8e6f7bb36a398e8f73f52a7aaa2"},
+    {file = "Shapely-1.8.5.post1-cp311-cp311-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:8d086591f744be483b34628b391d741e46f2645fe37594319e0a673cc2c26bcf"},
+    {file = "Shapely-1.8.5.post1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:4728666fff8cccc65a07448cae72c75a8773fea061c3f4f139c44adc429b18c3"},
+    {file = "Shapely-1.8.5.post1-cp311-cp311-win32.whl", hash = "sha256:84010db15eb364a52b74ea8804ef92a6a930dfc1981d17a369444b6ddec66efd"},
+    {file = "Shapely-1.8.5.post1-cp311-cp311-win_amd64.whl", hash = "sha256:48dcfffb9e225c0481120f4bdf622131c8c95f342b00b158cdbe220edbbe20b6"},
+    {file = "Shapely-1.8.5.post1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:2fd15397638df291c427a53d641d3e6fd60458128029c8c4f487190473a69a91"},
+    {file = "Shapely-1.8.5.post1-cp36-cp36m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:a74631e511153366c6dbe3229fa93f877e3c87ea8369cd00f1d38c76b0ed9ace"},
+    {file = "Shapely-1.8.5.post1-cp36-cp36m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:66bdac74fbd1d3458fa787191a90fa0ae610f09e2a5ec398c36f968cc0ed743f"},
+    {file = "Shapely-1.8.5.post1-cp36-cp36m-win32.whl", hash = "sha256:6d388c0c1bd878ed1af4583695690aa52234b02ed35f93a1c8486ff52a555838"},
+    {file = "Shapely-1.8.5.post1-cp36-cp36m-win_amd64.whl", hash = "sha256:be9423d5a3577ac2e92c7e758bd8a2b205f5e51a012177a590bc46fc51eb4834"},
+    {file = "Shapely-1.8.5.post1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:5d7f85c2d35d39ff53c9216bc76b7641c52326f7e09aaad1789a3611a0f812f2"},
+    {file = "Shapely-1.8.5.post1-cp37-cp37m-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:adcf8a11b98af9375e32bff91de184f33a68dc48b9cb9becad4f132fa25cfa3c"},
+    {file = "Shapely-1.8.5.post1-cp37-cp37m-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:753ed0e21ab108bd4282405b9b659f2e985e8502b1a72b978eaa51d3496dee19"},
+    {file = "Shapely-1.8.5.post1-cp37-cp37m-win32.whl", hash = "sha256:65b21243d8f6bcd421210daf1fabb9de84de2c04353c5b026173b88d17c1a581"},
+    {file = "Shapely-1.8.5.post1-cp37-cp37m-win_amd64.whl", hash = "sha256:370b574c78dc5af3a198a6da5d9b3d7c04654bd2ef7e80e80a3a0992dfb2d9cd"},
+    {file = "Shapely-1.8.5.post1-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:532a55ee2a6c52d23d6f7d1567c8f0473635f3b270262c44e1b0c88096827e22"},
+    {file = "Shapely-1.8.5.post1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:3480657460e939f45a7d359ef0e172a081f249312557fe9aa78c4fd3a362d993"},
+    {file = "Shapely-1.8.5.post1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b65f5d530ba91e49ffc7c589255e878d2506a8b96ffce69d3b7c4500a9a9eaf8"},
+    {file = "Shapely-1.8.5.post1-cp38-cp38-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:147066da0be41b147a61f8eb805dea3b13709dbc873a431ccd7306e24d712bc0"},
+    {file = "Shapely-1.8.5.post1-cp38-cp38-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c2822111ddc5bcfb116e6c663e403579d0fe3f147d2a97426011a191c43a7458"},
+    {file = "Shapely-1.8.5.post1-cp38-cp38-win32.whl", hash = "sha256:2e0a8c2e55f1be1312b51c92b06462ea89e6bb703fab4b114e7a846d941cfc40"},
+    {file = "Shapely-1.8.5.post1-cp38-cp38-win_amd64.whl", hash = "sha256:0d885cb0cf670c1c834df3f371de8726efdf711f18e2a75da5cfa82843a7ab65"},
+    {file = "Shapely-1.8.5.post1-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:0b4ee3132ee90f07d63db3aea316c4c065ed7a26231458dda0874414a09d6ba3"},
+    {file = "Shapely-1.8.5.post1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:02dd5d7dc6e46515d88874134dc8fcdc65826bca93c3eecee59d1910c42c1b17"},
+    {file = "Shapely-1.8.5.post1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c6a9a4a31cd6e86d0fbe8473ceed83d4fe760b19d949fb557ef668defafea0f6"},
+    {file = "Shapely-1.8.5.post1-cp39-cp39-manylinux_2_12_i686.manylinux2010_i686.whl", hash = "sha256:38f0fbbcb8ca20c16451c966c1f527cc43968e121c8a048af19ed3e339a921cd"},
+    {file = "Shapely-1.8.5.post1-cp39-cp39-manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:78fb9d929b8ee15cfd424b6c10879ce1907f24e05fb83310fc47d2cd27088e40"},
+    {file = "Shapely-1.8.5.post1-cp39-cp39-win32.whl", hash = "sha256:8e59817b0fe63d34baedaabba8c393c0090f061917d18fc0bcc2f621937a8f73"},
+    {file = "Shapely-1.8.5.post1-cp39-cp39-win_amd64.whl", hash = "sha256:e9c30b311de2513555ab02464ebb76115d242842b29c412f5a9aa0cac57be9f6"},
+    {file = "Shapely-1.8.5.post1.tar.gz", hash = "sha256:ef3be705c3eac282a28058e6c6e5503419b250f482320df2172abcbea642c831"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ p-tqdm = "^1.4.0"
 pca = "^1.8.3"
 loguru = "^0.6.0"
 requests = "^2.28.1"
+typing-extensions = "^4.4.0"
 
 [tool.poetry.group.test]
 # poetry install --with test

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,11 +46,12 @@ optional = true
 [tool.poetry.group.test.dependencies]
 autopep8 = "^1.7.0"
 flake8 = "^5.0.4"
+pyproject-flake8 = "^5.0.4.post1"
+deptry = "0.5.12"
+pyright = "^1.1.275"
 pytest = "^7.1.3"
 pytest-profiling = "^1.7.0"
 pytest-cov = "^3.0.0"
-pyproject-flake8 = "^5.0.4.post1"
-deptry = "0.5.12"
 
 [tool.poetry.group.docs]
 # poetry install --with docs
@@ -90,3 +91,9 @@ addopts = "--cov=covsirphy --cov-report=xml --cov-report=term-missing -vv --no-c
 [tool.deptry]
 ignore_obsolete = ['pyarrow', 'tabulate', 'requests']
 exclude = ['tests', '.venv', 'example', 'docs']
+
+[tool.pyright]
+include = ["covsirphy"]
+reportOptionalMemberAccess = false
+reportUnboundVariable = false
+reportGeneralTypeIssues = false


### PR DESCRIPTION
## Related issues
#1258

## What was changed
- use type hints in APIs users will call: dynamics
- use `pyright` as type checker
- fix/suppress errors of type hints found by `pyright`
- update intersphinx mapping to link with numpy and matplotlib in docs/conf.py