### PR TITLE
Improve importing time and add make command for evaluation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -146,8 +146,14 @@ clean:
 	@rm -rf dist covsirphy.egg-info
 	@rm -f .coverage*
 	@poetry cache clear . --all
+	@rm importtime.log
 
 .PHONY: shell
 shell:
 	@poetry shell
 	@python -i
+
+.PHONY: importtime
+importtime:
+	@poetry run python -X importtime -c "import covsirphy" 2> importtime.log
+	@poetry run tuna importtime.log

--- a/covsirphy/dynamics/ode.py
+++ b/covsirphy/dynamics/ode.py
@@ -103,7 +103,7 @@ class ODEModel(Term):
             - param_dict (dict of {str: float}): non-dimensional parameter values
             - estimation_dict (dict of {str: str or int}: information regarding ODE parameter estimation, when @with_estimation is True
                 - method (str): method of estimation, "with_quantile" or "with_optimization" or "not_performed"
-                - {metrics} (int): score of hyperparameter optimization, if available
+                - {metric} (int): score of hyperparameter optimization, if available
                 - Trials (int) : the number of trials of hyperparameter optimization, if available
                 - Runtime (str): runtime of hyperparameter optimization, if available
                 - keyword arguments set with covsirphy.ODEModel.with_optimization(), if available
@@ -476,7 +476,7 @@ class ODEModel(Term):
 
         Returns:
             - dict of {str: float}: dictionary of parameter values
-            - float: score with metrics
+            - float: score of the metric
             - str: runtime of hyperparameter optimization
             - int: the number of trials of hyperparameter optimization
         """

--- a/covsirphy/science/_autots.py
+++ b/covsirphy/science/_autots.py
@@ -1,6 +1,4 @@
 import warnings
-from autots import AutoTS
-from autots.evaluator.auto_ts import fake_regressor
 from covsirphy.util.config import config
 from covsirphy.util.validator import Validator
 from covsirphy.util.term import Term
@@ -24,6 +22,7 @@ class _AutoTSHandler(Term):
     """
 
     def __init__(self, Y, days, seed, **kwargs):
+        from autots import AutoTS  # https://github.com/lisphilar/covid19-sir/issues/1265
         self._Y = Validator(Y, "Y").dataframe(time_index=True, empty_ok=False)
         self._days = Validator(days, name="days").int(value_range=(1, None))
         autots_kwargs = {
@@ -57,6 +56,8 @@ class _AutoTSHandler(Term):
         Returns:
             _AutoTSHandler: self
         """
+        # https://github.com/lisphilar/covid19-sir/issues/1265
+        from autots.evaluator.auto_ts import fake_regressor
         if X is not None:
             regressor_train, self._regressor_forecast = fake_regressor(
                 self._Y,

--- a/covsirphy/science/ml.py
+++ b/covsirphy/science/ml.py
@@ -1,4 +1,3 @@
-from pca import pca
 from covsirphy.util.config import config
 from covsirphy.util.validator import Validator
 from covsirphy.util.term import Term
@@ -62,6 +61,7 @@ class MLEngineer(Term):
         Note:
             Regarding pca package, please refer to https://github.com/erdogant/pca
         """
+        from pca import pca  # https://github.com/lisphilar/covid19-sir/issues/1265
         Validator(X, name="X", accept_none=False).dataframe(time_index=True, empty_ok=False)
         model = pca(n_components=n_components, normalize=True, random_state=self._seed, verbose=config.logger_level)
         return {**model.fit_transform(X), "model": model}

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -82,7 +82,11 @@ class Evaluator(object):
             raise UnExpectedValueError("metric", metric, candidates=list(self._METRICS_DICT.keys()))
         # Calculate score
         try:
-            return float(self._METRICS_DICT[metric.upper()][0](self._true.values, self._pred.values))
+            return float(
+                self._METRICS_DICT[metric.upper()][0](
+                    float(self._true.values), float(self._pred.values)
+                )
+            )
         except ValueError:
             raise ValueError(
                 f"When the targets have multiple columns or negative values, we cannot select {metric}.") from None

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -32,7 +32,7 @@ class Evaluator(object):
         "MSLE": (lambda x1, x2: np.mean(np.square(np.log1p(x2) - np.log1p(x1))), True),
         "MAPE": (lambda x1, x2: np.mean(np.abs((x2 - x1) / x1)) * 100, True),
         "RMSE": (lambda x1, x2: np.sqrt(np.mean(np.square(x2 - x1))), True),
-        "RMSLE": (lambda x1, x2: np.sqrt(np.mean(np.square(np.log(x2 + 1) - np.log(x1 + 1)))), True),
+        "RMSLE": (lambda x1, x2: np.sqrt(np.mean(np.square(np.log(x2 + 1.0) - np.log(x1 + 1.0)))), True),
         "R2": (lambda x1, x2: np.corrcoef(x1, x2)[0, 1]**2, False),
     }
 

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -17,10 +17,6 @@ class Evaluator(object):
 
     Raises:
         NAFoundError: either @y_true or @pred has NA values
-
-    Note:
-        Evaluation with metrics will be done with sklearn.metrics package.
-        https://scikit-learn.org/stable/modules/model_evaluation.html
     """
     # Names
     _A = "_actual"
@@ -56,13 +52,12 @@ class Evaluator(object):
         self._true = all_df.loc[:, [f"{col}{self._A}" for col in true_df.columns]]
         self._pred = all_df.loc[:, [f"{col}{self._P}" for col in pred_df.columns]]
 
-    def score(self, metric=None, metrics="RMSLE"):
+    def score(self, metric="RMSLE"):
         """
         Calculate score with specified metric.
 
         Args:
-            metric (str or None): ME, MAE, MSE, MSLE, MAPE, RMSE, RMSLE, R2 or None (use @metrics)
-            metrics (str): alias of @metric
+            metric (str): ME, MAE, MSE, MSLE, MAPE, RMSE, RMSLE, R2
 
         Raises:
             UnExpectedValueError: un-expected metric was applied
@@ -80,18 +75,14 @@ class Evaluator(object):
             RMSE: root mean squared error
             RMSLE: root mean squared logarithmic error
             R2: the coefficient of determination
-
-        Note:
-            When @metric is None, @metrics will be used as @metric. Default value is "RMSLE".
         """
         warnings.filterwarnings("ignore", category=RuntimeWarning)
-        metric = (metric or metrics).upper()
         # Check metric name
-        if metric not in self._METRICS_DICT:
+        if metric.upper() not in self._METRICS_DICT:
             raise UnExpectedValueError("metric", metric, candidates=list(self._METRICS_DICT.keys()))
         # Calculate score
         try:
-            return float(self._METRICS_DICT[metric][0](self._true.values, self._pred.values))
+            return float(self._METRICS_DICT[metric.upper()][0](self._true.values, self._pred.values))
         except ValueError:
             raise ValueError(
                 f"When the targets have multiple columns or negative values, we cannot select {metric}.") from None
@@ -107,22 +98,19 @@ class Evaluator(object):
         return list(cls._METRICS_DICT.keys())
 
     @classmethod
-    def smaller_is_better(cls, metric=None, metrics="RMSLE"):
+    def smaller_is_better(cls, metric="RMSLE"):
         """
         Whether smaller value of the metric is better or not.
 
         Args:
-            metric (str or None): ME, MAE, MSE, MSLE, MAPE, RMSE, RMSLE, R2 or None (use @metrics)
-            metrics (str): alias of @metric
+            metric (str): ME, MAE, MSE, MSLE, MAPE, RMSE, RMSLE, R2
 
         Returns:
             bool: whether smaller value is better or not
         """
-        metric = (metric or metrics).upper()
-        # Check metric name
-        if metric not in cls._METRICS_DICT:
+        if metric.upper() not in cls._METRICS_DICT:
             raise UnExpectedValueError("metric", metric, candidates=list(cls._METRICS_DICT.keys()))
-        return cls._METRICS_DICT[metric][1]
+        return cls._METRICS_DICT[metric.upper()][1]
 
     @classmethod
     def best_one(cls, candidate_dict, **kwargs):

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -29,7 +29,7 @@ class Evaluator(object):
         "MSLE": (lambda x1, x2: np.mean(np.square(np.log1p(x2) - np.log1p(x1))), True),
         "MAPE": (lambda x1, x2: np.mean(np.abs((x2 - x1) / x1)) * 100, True),
         "RMSE": (lambda x1, x2: np.sqrt(np.mean(np.square(x2 - x1))), True),
-        "RMSLE": (lambda x1, x2: np.sqrt(np.mean(np.square(np.log(x2 + 1.0) - np.log(x1 + 1.0)))), True),
+        "RMSLE": (lambda x1, x2: np.sqrt(np.mean(np.square(np.log1p(x2) - np.log1p(x1)))), True),
         "R2": (lambda x1, x2: np.corrcoef(x1, x2)[0, 1]**2, False),
     }
 

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -81,15 +81,11 @@ class Evaluator(object):
         if metric.upper() not in self._METRICS_DICT:
             raise UnExpectedValueError("metric", metric, candidates=list(self._METRICS_DICT.keys()))
         # Calculate score
+        outputs = self._METRICS_DICT[metric.upper()][0](float(self._true.values), float(self._pred.values))
         try:
-            return float(
-                self._METRICS_DICT[metric.upper()][0](
-                    float(self._true.values), float(self._pred.values)
-                )
-            )
-        except ValueError:
-            raise ValueError(
-                f"When the targets have multiple columns or negative values, we cannot select {metric}.") from None
+            return float(outputs)
+        except TypeError:
+            return float(np.average(outputs))
 
     @classmethod
     def metrics(cls):

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -85,7 +85,7 @@ class Evaluator(object):
         try:
             return float(func(self._true.values, self._pred.values))
         except TypeError:
-            outputs = float(func(self._true.values.float(), self._pred.values.float()))
+            outputs = float(func(self._true.values.astype(np.float64), self._pred.values.astype(np.float64)))
             return float(np.average(outputs))
 
     @classmethod

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -1,3 +1,4 @@
+import warnings
 import numpy as np
 import pandas as pd
 from covsirphy.util.error import UnExpectedValueError, NAFoundError
@@ -83,6 +84,7 @@ class Evaluator(object):
         Note:
             When @metric is None, @metrics will be used as @metric. Default value is "RMSLE".
         """
+        warnings.filterwarnings("ignore", category=RuntimeWarning)
         metric = (metric or metrics).upper()
         # Check metric name
         if metric not in self._METRICS_DICT:

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -81,10 +81,11 @@ class Evaluator(object):
         if metric.upper() not in self._METRICS_DICT:
             raise UnExpectedValueError("metric", metric, candidates=list(self._METRICS_DICT.keys()))
         # Calculate score
-        outputs = self._METRICS_DICT[metric.upper()][0](float(self._true.values), float(self._pred.values))
+        func = self._METRICS_DICT[metric.upper()][0]
         try:
-            return float(outputs)
+            return float(func(self._true.values, self._pred.values))
         except TypeError:
+            outputs = float(func(self._true.values.float(), self._pred.values.float()))
             return float(np.average(outputs))
 
     @classmethod

--- a/covsirphy/util/evaluator.py
+++ b/covsirphy/util/evaluator.py
@@ -1,6 +1,5 @@
 import numpy as np
 import pandas as pd
-import sklearn.metrics
 from covsirphy.util.error import UnExpectedValueError, NAFoundError
 from covsirphy.util.validator import Validator
 
@@ -27,14 +26,14 @@ class Evaluator(object):
     _P = "_predicted"
     # Metrics: {name: (function(x1, x2), whether smaller is better or not)}
     _METRICS_DICT = {
-        "ME": (sklearn.metrics.max_error, True),
-        "MAE": (sklearn.metrics.mean_absolute_error, True),
-        "MSE": (sklearn.metrics.mean_squared_error, True),
-        "MSLE": (sklearn.metrics.mean_squared_log_error, True),
-        "MAPE": (sklearn.metrics.mean_absolute_percentage_error, True),
-        "RMSE": (lambda x1, x2: sklearn.metrics.mean_squared_error(x1, x2, squared=False), True),
-        "RMSLE": (lambda x1, x2: np.sqrt(sklearn.metrics.mean_squared_log_error(x1, x2)), True),
-        "R2": (sklearn.metrics.r2_score, False),
+        "ME": (lambda x1, x2: np.max(np.abs(x2 - x1)), True),
+        "MAE": (lambda x1, x2: np.mean(np.abs(x2 - x1)), True),
+        "MSE": (lambda x1, x2: np.mean(np.square(x2 - x1)), True),
+        "MSLE": (lambda x1, x2: np.mean(np.square(np.log1p(x2) - np.log1p(x1))), True),
+        "MAPE": (lambda x1, x2: np.mean(np.abs((x2 - x1) / x1)) * 100, True),
+        "RMSE": (lambda x1, x2: np.sqrt(np.mean(np.square(x2 - x1))), True),
+        "RMSLE": (lambda x1, x2: np.sqrt(np.mean(np.square(np.log(x2 + 1) - np.log(x1 + 1)))), True),
+        "R2": (lambda x1, x2: np.corrcoef(x1, x2)[0, 1]**2, False),
     }
 
     def __init__(self, y_true, y_pred, how="inner", on=None):

--- a/poetry.lock
+++ b/poetry.lock
@@ -2432,6 +2432,14 @@ docs = ["myst-parser", "pydata-sphinx-theme", "sphinx"]
 test = ["pre-commit", "pytest"]
 
 [[package]]
+name = "tuna"
+version = "0.5.11"
+description = "Visualize Python performance profiles"
+category = "dev"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
 name = "typing-extensions"
 version = "4.4.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
@@ -2539,7 +2547,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "b927c5270f1e3b6fe4d3488a9c17d3484146df43c32c42f917d46aa623001885"
+content-hash = "0dea78acd53e89db5325e110700d10042b25b2a1aa27992622105e04d24c3dfc"
 
 [metadata.files]
 alabaster = [
@@ -4218,6 +4226,10 @@ tqdm = [
 traitlets = [
     {file = "traitlets-5.5.0-py3-none-any.whl", hash = "sha256:1201b2c9f76097195989cdf7f65db9897593b0dfd69e4ac96016661bb6f0d30f"},
     {file = "traitlets-5.5.0.tar.gz", hash = "sha256:b122f9ff2f2f6c1709dab289a05555be011c87828e911c0cf4074b85cb780a79"},
+]
+tuna = [
+    {file = "tuna-0.5.11-py3-none-any.whl", hash = "sha256:ab352a6d836014ace585ecd882148f1f7c68be9ea4bf9e9298b7127594dab2ef"},
+    {file = "tuna-0.5.11.tar.gz", hash = "sha256:d47f3e39e80af961c8df016ac97d1643c3c60b5eb451299da0ab5fe411d8866c"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.4.0-py3-none-any.whl", hash = "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -2547,7 +2547,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.11"
-content-hash = "0dea78acd53e89db5325e110700d10042b25b2a1aa27992622105e04d24c3dfc"
+content-hash = "c0efe32df4c8b98a62e34e33feede316a1d9ef771858667e838e0ed9b5b0d64f"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,7 @@ pyright = "^1.1.275"
 pytest = "^7.1.3"
 pytest-profiling = "^1.7.0"
 pytest-cov = "^3.0.0"
+tuna = "^0.5.11"
 
 [tool.poetry.group.docs]
 # poetry install --with docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -90,7 +90,7 @@ filterwarnings = ["error"]
 addopts = "--cov=covsirphy --cov-report=xml --cov-report=term-missing -vv --no-cov-on-fail -p no:cacheprovider --durations=1 --maxfail=1"
 
 [tool.deptry]
-ignore_obsolete = ['pyarrow', 'tabulate', 'requests']
+ignore_obsolete = ['pyarrow', 'tabulate', 'requests', 'scikit-learn']
 exclude = ['tests', '.venv', 'example', 'docs']
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ pandas = "^1.5.1"
 pyarrow = "^9.0.0"
 tabulate = "^0.9.0"
 scipy = ">=1.8.1"
-scikit-learn = "^1.1.2"
 ruptures = "^1.1.7"
 matplotlib = "^3.6.1"
 country-converter = "^0.7.7"
@@ -90,7 +89,7 @@ filterwarnings = ["error"]
 addopts = "--cov=covsirphy --cov-report=xml --cov-report=term-missing -vv --no-cov-on-fail -p no:cacheprovider --durations=1 --maxfail=1"
 
 [tool.deptry]
-ignore_obsolete = ['pyarrow', 'tabulate', 'requests', 'scikit-learn']
+ignore_obsolete = ['pyarrow', 'tabulate', 'requests']
 exclude = ['tests', '.venv', 'example', 'docs']
 
 [tool.pyright]

--- a/tests/test_util/test_evaluator.py
+++ b/tests/test_util/test_evaluator.py
@@ -10,9 +10,7 @@ def test_score_series(metric):
     true = pd.Series([5, 10, 8, 6])
     pred = pd.Series([8, 12, 6, 5])
     evaluator = Evaluator(true, pred, on=None)
-    score_metric = evaluator.score(metric=metric)
-    score_metrics = evaluator.score(metrics=metric)
-    assert score_metric == score_metrics
+    assert isinstance(evaluator.score(metric=metric), float)
     assert isinstance(Evaluator.smaller_is_better(metric=metric), bool)
     best_tuple = Evaluator.best_one({"A": 1.0, "B": 1.5, "C": 2.0}, metric=metric)
     if metric == "R2":
@@ -38,10 +36,6 @@ def test_score_dataframe(metric, how, on):
         }
     )
     evaluator = Evaluator(true, pred, how=how, on=on)
-    if metric == "ME" and (how == "all" or on is None):
-        with pytest.raises(ValueError):
-            evaluator.score(metric=metric)
-        return
     assert isinstance(evaluator.score(metric=metric), float)
 
 


### PR DESCRIPTION
## Related issues
#1265, #1290, #1291

## What was changed
- Close #1265 by using `numpy` instead of `sklearn.metrics` in `Evaluator` class, and import `autots` and `pca` inside methods because they have `sklearn` as a dependency, making importing time slow.
- Close #1290 by adding `make importtime` command as a development tool.
- Close #1291 by removing `metrics` argument of `Evaluator().score()` because `metrics` exist.