### PR TITLE
Delegate error handling of colormap to Matplotlib

### DIFF
--- a/covsirphy/visualization/scatter_plot.py
+++ b/covsirphy/visualization/scatter_plot.py
@@ -46,13 +46,8 @@ class ScatterPlot(LinePlot):
             kwargs: keyword arguments of pandas.DataFrame.plot()
         """
         self._data = Validator(data, "data").dataframe(columns=["x", "y"])
-        # Color
         color_args = self._plot_colors(data.columns, colormap=colormap, color_dict=color_dict)
-        # Set plotting
-        try:
-            self._ax = data.plot.scatter(x="x", y="y", **color_args, **kwargs)
-        except KeyError as e:
-            raise KeyError(e.args[0]) from None
+        self._ax = data.plot.scatter(x="x", y="y", **color_args, **kwargs)
 
     def line_straight(self, p1=None, p2=None, color="black", linestyle=":"):
         """Connect the points with a straight line.

--- a/tests/test_visualization/test_scatter.py
+++ b/tests/test_visualization/test_scatter.py
@@ -22,10 +22,3 @@ def test_error(japan_df, imgfile):
             sp.legend()
         with pytest.raises(NotImplementedError):
             sp.legend_hide()
-
-
-def test_colormap(japan_df, imgfile):
-    df = japan_df.rename(columns={"Positive": "x", "Discharged": "y"})
-    with ScatterPlot(filename=imgfile) as sp:
-        with pytest.raises(KeyError):
-            sp.plot(data=df, colormap="unknown")


### PR DESCRIPTION
## Related issues
#1309

## What was changed
Close #1309 by delegating error handling of colormap to Matplotlib.