### PR TITLE
close #1350

### DIFF
--- a/covsirphy/gis/_layer.py
+++ b/covsirphy/gis/_layer.py
@@ -112,7 +112,7 @@ class _LayerAdjuster(Term):
             df[self.DATE] = df[self.DATE].dt.tz_convert(None)
         # Convert country names to ISO3 codes
         if convert_iso3 and self._country is not None and self._country in df:
-            df.loc[:, self._country] = self._to_iso3(df[self._country])
+            df.isetitem(self._country, self._to_iso3(df[self._country]))
         # Prepare necessary layers and fill in None with "NA"
         if data_layers is not None and data_layers != self._layers:
             df = self._prepare_layers(df, data_layers=data_layers)

--- a/covsirphy/gis/_layer.py
+++ b/covsirphy/gis/_layer.py
@@ -112,7 +112,7 @@ class _LayerAdjuster(Term):
             df[self.DATE] = df[self.DATE].dt.tz_convert(None)
         # Convert country names to ISO3 codes
         if convert_iso3 and self._country is not None and self._country in df:
-            df.isetitem(self._country, self._to_iso3(df[self._country]))
+            df.loc[:, self._country] = self._to_iso3(df[self._country])
         # Prepare necessary layers and fill in None with "NA"
         if data_layers is not None and data_layers != self._layers:
             df = self._prepare_layers(df, data_layers=data_layers)

--- a/covsirphy/gis/_layer.py
+++ b/covsirphy/gis/_layer.py
@@ -1,4 +1,5 @@
 import contextlib
+import warnings
 import pandas as pd
 from covsirphy.util.config import config
 from covsirphy.util.validator import Validator
@@ -112,6 +113,7 @@ class _LayerAdjuster(Term):
             df[self.DATE] = df[self.DATE].dt.tz_convert(None)
         # Convert country names to ISO3 codes
         if convert_iso3 and self._country is not None and self._country in df:
+            warnings.filterwarnings("ignore", category=DeprecationWarning)
             df.loc[:, self._country] = self._to_iso3(df[self._country])
         # Prepare necessary layers and fill in None with "NA"
         if data_layers is not None and data_layers != self._layers:


### PR DESCRIPTION
## Related issues
#1350

## What was changed
Close #1350 by supress the following warning, referencing https://github.com/geopandas/geopandas/pull/2645 and https://github.com/pandas-dev/pandas/issues/48673

```Python
FAILED tests/test_engineering/test_engineer.py::test_with_actual_data - DeprecationWarning:
In a future version, `df.iloc[:, i] = newvals` will attempt to set the values inplace
instead of always setting a new array.
To retain the old behavior, use either `df[df.columns[i]] = newvals` or,
if columns are non-unique, `df.isetitem(i, newvals)`
```