### PR TITLE
Fix errors regarding pandas version 2.1.0 release

### DIFF
--- a/covsirphy/downloading/_db_covid19dh.py
+++ b/covsirphy/downloading/_db_covid19dh.py
@@ -67,7 +67,6 @@ class _COVID19dh(_DataBase):
             url=url, suffix="_level1", columns=list(self.COL_DICT.keys()), date="date", date_format="%Y-%m-%d")
         # ships will be regarded as provinces of "Others" country
         ships = df.loc[df[self.ISO3].isna(), self.COUNTRY].unique()
-        print(df.info())
         for ship in ships:
             df.loc[df[self.COUNTRY] == ship, [self.ISO3, self.PROVINCE]] = [self.OTHERS, ship]
         return df

--- a/covsirphy/downloading/_db_covid19dh.py
+++ b/covsirphy/downloading/_db_covid19dh.py
@@ -67,6 +67,7 @@ class _COVID19dh(_DataBase):
             url=url, suffix="_level1", columns=list(self.COL_DICT.keys()), date="date", date_format="%Y-%m-%d")
         # ships will be regarded as provinces of "Others" country
         ships = df.loc[df[self.ISO3].isna(), self.COUNTRY].unique()
+        print(df.info())
         for ship in ships:
             df.loc[df[self.COUNTRY] == ship, [self.ISO3, self.PROVINCE]] = [self.OTHERS, ship]
         return df

--- a/covsirphy/downloading/_db_covid19dh.py
+++ b/covsirphy/downloading/_db_covid19dh.py
@@ -66,6 +66,7 @@ class _COVID19dh(_DataBase):
         df = self._provide(
             url=url, suffix="_level1", columns=list(self.COL_DICT.keys()), date="date", date_format="%Y-%m-%d")
         # ships will be regarded as provinces of "Others" country
+        df[self.PROVINCE] = df[self.PROVINCE].astype(object)
         ships = df.loc[df[self.ISO3].isna(), self.COUNTRY].unique()
         for ship in ships:
             df.loc[df[self.COUNTRY] == ship, [self.ISO3, self.PROVINCE]] = [self.OTHERS, ship]

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,10 +520,8 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
-        print(df)
-        print(est_dict)
+        df[self.RUNTIME] = df[self.RUNTIME].astype(str)
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
-        print(df)
         return df
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,8 +520,10 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
-        df[self.RUNTIME] = df[self.RUNTIME].astype(str)
+        print(df)
+        print(est_dict)
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
+        print(df)
         return df
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,6 +520,7 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         for column in [metric, self.TRIALS, self.RUNTIME]:
+            df[column] = df[column].astype("object")
             df.loc[df.index[0], column] = est_dict[column]
         return df
 

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -519,8 +519,8 @@ class Dynamics(Term):
         df.loc[df.index[0], model._PARAMETERS] = pd.Series(model_instance.settings()["param_dict"])
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
-        est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
-        df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
+        for column in [metric, self.TRIALS, self.RUNTIME]:
+            df.loc[df.index[0], column] = est_dict[column]
         return df
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,12 +520,7 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
-        if self.RUNTIME not in df:
-            df[self.RUNTIME] = np.nan
-        print(df.info())
-        print(df)
-        df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
-        print(df.info())
+        df.astype(object).loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
         return df
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,6 +520,7 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
+        df[self.RUNTIME] = df[self.RUNTIME].astype(str)
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
         return df
 

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -519,10 +519,8 @@ class Dynamics(Term):
         df.loc[df.index[0], model._PARAMETERS] = pd.Series(model_instance.settings()["param_dict"])
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
-        for column in [metric, self.TRIALS, self.RUNTIME]:
-            if column in df:
-                df[column] = df[column].astype("object")
-            df.loc[df.index[0], column] = est_dict[column]
+        est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
+        df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
         return df
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -522,7 +522,10 @@ class Dynamics(Term):
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
         if self.RUNTIME in df:
             df[self.RUNTIME] = df[self.RUNTIME].astype(str)
+        print(df.info())
+        print(df)
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
+        print(df.info())
         return df
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,8 +520,8 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
-        if self.RUNTIME in df:
-            df[self.RUNTIME] = df[self.RUNTIME].astype(str)
+        if self.RUNTIME not in df:
+            df[self.RUNTIME] = np.nan
         print(df.info())
         print(df)
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -512,7 +512,7 @@ class Dynamics(Term):
                 Trials (int): the number of trials
                 Runtime (str): runtime of optimization, like 0 min 10 sec
         """
-        df = phase_df.astype(object)
+        df = phase_df.copy()
         # ODE parameter optimization
         model_instance = model.from_data_with_optimization(
             data=df.reset_index(), tau=tau, metric=metric, digits=digits, **kwargs)
@@ -521,7 +521,7 @@ class Dynamics(Term):
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
-        return df.convert_dtypes()
+        return df
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:
         """Return minimum date and maximum date of the phases.

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -512,7 +512,7 @@ class Dynamics(Term):
                 Trials (int): the number of trials
                 Runtime (str): runtime of optimization, like 0 min 10 sec
         """
-        df = phase_df.copy()
+        df = phase_df.astype(object)
         # ODE parameter optimization
         model_instance = model.from_data_with_optimization(
             data=df.reset_index(), tau=tau, metric=metric, digits=digits, **kwargs)
@@ -521,7 +521,7 @@ class Dynamics(Term):
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
-        return df
+        return df.convert_dtypes()
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:
         """Return minimum date and maximum date of the phases.

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,7 +520,7 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
-        df.astype(object).loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
+        df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
         return df
 
     def parse_phases(self, phases: list[str] | None = None) -> tuple[pd.Timestamp, pd.Timestamp]:

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,6 +520,7 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
+        warnings.filterwarnings("ignore", category=FutureWarning)
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
         return df
 
@@ -541,6 +542,8 @@ class Dynamics(Term):
         all_df[self._PH], _ = all_df[self._PH].factorize()
         phase_numbers = [all_df[self._PH].max() if ph == "last" else self.str2num(ph) for ph in phases]
         df = all_df.loc[all_df[self._PH].isin(phase_numbers)]
+        # FutureWarning to be fixed by pandas version 3.0.0 release
+        warnings.filterwarnings("ignore", category=FutureWarning)
         return df.index.min(), df.index.max()
 
     def parse_days(self, days: int, ref: pd.Timestamp | str | None = "last") -> tuple[pd.Timestamp, pd.Timestamp]:

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,7 +520,8 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         est_dict = {k: v for k, v in est_dict.items() if k in {metric, self.TRIALS, self.RUNTIME}}
-        df[self.RUNTIME] = df[self.RUNTIME].astype(str)
+        if self.RUNTIME in df:
+            df[self.RUNTIME] = df[self.RUNTIME].astype(str)
         df.loc[df.index[0], list(est_dict.keys())] = pd.Series(est_dict)
         return df
 

--- a/covsirphy/dynamics/dynamics.py
+++ b/covsirphy/dynamics/dynamics.py
@@ -520,7 +520,8 @@ class Dynamics(Term):
         # Get information regarding optimization
         est_dict = model_instance.settings(with_estimation=True)["estimation_dict"]
         for column in [metric, self.TRIALS, self.RUNTIME]:
-            df[column] = df[column].astype("object")
+            if column in df:
+                df[column] = df[column].astype("object")
             df.loc[df.index[0], column] = est_dict[column]
         return df
 

--- a/covsirphy/engineering/_cleaner.py
+++ b/covsirphy/engineering/_cleaner.py
@@ -62,7 +62,7 @@ class _DataCleaner(Term):
             end = Validator(
                 end_date, name="the second date of @date_range").date(default=df[self._date].max(), value_range=(start, None))
             df = df[df[self._date].between(start, end, inclusive="both")]
-        grouped = df.set_index(self._date).groupby(self._layers, as_index=False)
+        grouped = df.set_index(self._date).groupby(self._layers, as_index=False, observed=True)
         df = grouped.resample("D").ffill()
         self._df = df.reset_index().drop("level_0", errors="ignore", axis=1)
 
@@ -72,5 +72,5 @@ class _DataCleaner(Term):
         df = self._df.copy()
         df[self._layers] = df.loc[:, self._layers].astype(str).fillna(self.NA)
         for col in set(df.columns) - set(self._id_cols):
-            df[col] = df.groupby(self._layers)[col].ffill().fillna(0)
+            df[col] = df.groupby(self._layers, observed=True)[col].ffill().fillna(0)
         self._df = df.copy()

--- a/covsirphy/engineering/_complement.py
+++ b/covsirphy/engineering/_complement.py
@@ -430,5 +430,6 @@ class _ComplementHandler(Term):
                 Columns
                     Confirmed, Fatal, Recovered
         """
-        df[self.C] = df[[self.C, self.F, self.R]].apply(lambda x: max(x[0], x[1] + x[2]), axis=1)
+        df[self.C] = df[[self.C, self.F, self.R]].apply(
+            lambda x: max(x.iloc[0], x.iloc[1] + x.iloc[2]), axis=1)
         return df

--- a/covsirphy/engineering/_transformer.py
+++ b/covsirphy/engineering/_transformer.py
@@ -72,7 +72,7 @@ class _DataTransformer(Term):
         """
         df = Validator(self._df, "raw data").dataframe(columns=[column])
         new_column = f"{column}{suffix}"
-        new_df = df.set_index(self._date).groupby(self._layers).shift(freq=freq)
+        new_df = df.set_index(self._date).groupby(self._layers, observed=True).shift(freq=freq)
         new_df = new_df.loc[:, [column, *self._layers]].rename(columns={column: new_column})
         df = df.merge(new_df, how="left", on=[*self._layers, self._date])
         df[new_column] = (df[column] - df[new_column]).fillna(0)

--- a/covsirphy/gis/_layer.py
+++ b/covsirphy/gis/_layer.py
@@ -121,7 +121,10 @@ class _LayerAdjuster(Term):
         df[self._layers] = df[self._layers].astype("string").fillna(self.NA)
         # Locations
         loc_df = df.loc[:, self._layers]
-        loc_df = pd.concat([self._loc_df, loc_df], axis=0, ignore_index=True)
+        with warnings.catch_warnings():
+            warnings.filterwarnings("ignore", category=FutureWarning)
+            # From Python 3.11: `warnings.catch_warnings(action="ignore", category=FutureWarning):`
+            loc_df = pd.concat([self._loc_df, loc_df], axis=0, ignore_index=True)
         loc_df.drop_duplicates(subset=self._layers, keep="first", ignore_index=True, inplace=True)
         loc_df.loc[loc_df[self._ID].isna(), self._ID] = f"id{len(loc_df)}-" + \
             loc_df[loc_df[self._ID].isna()].index.astype("str")

--- a/covsirphy/gis/gis.py
+++ b/covsirphy/gis/gis.py
@@ -165,7 +165,7 @@ class GIS(Term):
             raise NotRegisteredError(
                 "GIS.register()", details=f"No records have been registered at the layer yet from {start_date} to {end_date}")
         # Get representative records for dates
-        df = df.groupby([*self._layers, self._date], dropna=True).first()
+        df = df.groupby([*self._layers, self._date], dropna=True, observed=True).first()
         return df.reset_index().convert_dtypes()
 
     def to_geopandas(self, geo=None, on=None, variables=None, directory=None, natural_earth=None):
@@ -203,7 +203,7 @@ class GIS(Term):
             raise ValueError("This cannot be done because country layer is not included in the dataset.")
         df = self.layer(geo=geo, variables=variables)
         if on is None:
-            df = df.sort_values(self._date, ascending=True).groupby(self._layers).last().reset_index()
+            df = df.sort_values(self._date, ascending=True).groupby(self._layers, observed=True).last().reset_index()
         else:
             df = df.loc[df[self._date] == Validator(on).date()]
         focused_layer = [layer for layer in self._layers if df[layer][df[layer] != self.NA].nunique() > 0][-1]
@@ -306,7 +306,7 @@ class GIS(Term):
         # Get representative records for dates
         with contextlib.suppress(IndexError, KeyError):
             df = df.drop(self._layers[1:], axis=1)
-        df = df.groupby([self._layers[0], self._date], dropna=True).first().reset_index(level=self._date)
+        df = df.groupby([self._layers[0], self._date], dropna=True, observed=True).first().reset_index(level=self._date)
         return df.groupby(self._date, as_index=False).sum().convert_dtypes()
 
     @classmethod


### PR DESCRIPTION
## Related issues
#1511, #1513, #1514, #1515

## What was changed
- Close #1511 by ignoring FutureWarning.
- Close #1513 by adding `.iloc`
- Close #1514 by adding `observed=True` to `.groupby()`
- Close #1515 by casting province column from `float64` to `object` and suppressing the warning (to be fixed by pandas version 3.0.0 release)