### PR TITLE
Catch up with the change of compressed file format of population data

### DIFF
--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -1,5 +1,4 @@
 import pandas as pd
-from pyarrow.lib import ArrowKeyError
 from covsirphy.util.term import Term
 from covsirphy.downloading._db import _DataBase
 

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -45,7 +45,7 @@ class _WPP(_DataBase):
         df = df.rename({"countryiso3code": Term.ISO3})
         df[self.PROVINCE] = self.NA
         df[self.CITY] = self.NA
-        df[self.N] = df[self.N] * 1_000
+        df[self.N] = df["value"]
         return df.dropna(how="any").loc[:, self.ALL_COLS]
 
     def _province(self, country):

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -20,7 +20,7 @@ class _WPP(_DataBase):
     ALL_COLS = [Term.DATE, Term.ISO3, Term.PROVINCE, Term.CITY, Term.N]
     # Stdout when downloading (shown at most one time)
     STDOUT = "Retrieving datasets from World Population Prospects https://population.un.org/wpp/"
-    # Citation
+    # Citations
     CITATION = 'United Nations, Department of Economic and Social Affairs,' \
         ' Population Division (2022). World Population Prospects 2022, Online Edition.'
 
@@ -38,7 +38,7 @@ class _WPP(_DataBase):
                     - City (object): NAs
                     - Population (numpy.float64): population values
         """
-        url = f"{self.TOP_URL}WPP2022_TotalPopulationBySex.zip"
+        url = f"{self.TOP_URL}WPP2022_TotalPopulationBySex.csv.gz"
         df = self._provide(url=url, suffix="_level1", columns=list(self.COL_DICT.keys()))
         df[self.DATE] = pd.to_datetime(df["Year"], format="%Y") + pd.offsets.DateOffset(months=6)
         df[self.PROVINCE] = self.NA

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -42,7 +42,7 @@ class _WPP(_DataBase):
         url = f"{self.TOP_URL}country/all/indicator/SP.POP.TOTL?per_page=20000"
         df = pd.read_xml(url,  parser="etree")
         df[self.DATE] = pd.to_datetime(df["date"], format="%Y") + pd.offsets.DateOffset(months=6)
-        df = df.rename({"countryiso3code": Term.ISO3})
+        df = df.rename(columns={"countryiso3code": Term.ISO3})
         df[self.PROVINCE] = self.NA
         df[self.CITY] = self.NA
         df[self.N] = df["value"]

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -8,8 +8,9 @@ class _WPP(_DataBase):
     """
     Access "World Population Prospects by United nations" server.
     https://population.un.org/wpp/
+    https://datahelpdesk.worldbank.org/knowledgebase/articles/898581-api-basic-call-structures
     """
-    TOP_URL = "https://population.un.org/wpp/Download/Files/1_Indicators%20(Standard)/CSV_FILES/"
+    TOP_URL = "https://api.worldbank.org/v2/"
     # File title without extensions and suffix
     TITLE = "world-population-prospects"
     # Dictionary of column names
@@ -39,13 +40,10 @@ class _WPP(_DataBase):
                     - City (object): NAs
                     - Population (numpy.float64): population values
         """
-        url = f"{self.TOP_URL}WPP2024_TotalPopulationBySex.csv.gz"
-        try:
-            df = self._provide(url=url, suffix="_level1", columns=list(self.COL_DICT.keys()))
-        except ArrowKeyError:
-            df = self._provide(url=url, suffix="_level1", columns=None)
-            df = df.rename(self.COL_DICT.keys())
-        df[self.DATE] = pd.to_datetime(df["Year"], format="%Y") + pd.offsets.DateOffset(months=6)
+        url = f"{self.TOP_URL}country/all/indicator/SP.POP.TOTLL?per_page=30000"
+        df = pd.read_xml(url,  parser="etree")
+        df[self.DATE] = pd.to_datetime(df["date"], format="%Y") + pd.offsets.DateOffset(months=6)
+        df = df.rename({"countryiso3code": Term.ISO3})
         df[self.PROVINCE] = self.NA
         df[self.CITY] = self.NA
         df[self.N] = df[self.N] * 1_000

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -1,4 +1,5 @@
 import pandas as pd
+from pyarrow.lib import ArrowKeyError
 from covsirphy.util.term import Term
 from covsirphy.downloading._db import _DataBase
 
@@ -39,7 +40,11 @@ class _WPP(_DataBase):
                     - Population (numpy.float64): population values
         """
         url = f"{self.TOP_URL}WPP2024_TotalPopulationBySex.csv.gz"
-        df = self._provide(url=url, suffix="_level1", columns=list(self.COL_DICT.keys()))
+        try:
+            df = self._provide(url=url, suffix="_level1", columns=list(self.COL_DICT.keys()))
+        except ArrowKeyError:
+            df = self._provide(url=url, suffix="_level1", columns=None)
+            df = df.rename(self.COL_DICT.keys())
         df[self.DATE] = pd.to_datetime(df["Year"], format="%Y") + pd.offsets.DateOffset(months=6)
         df[self.PROVINCE] = self.NA
         df[self.CITY] = self.NA

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -46,7 +46,7 @@ class _WPP(_DataBase):
         df[self.PROVINCE] = self.NA
         df[self.CITY] = self.NA
         df[self.N] = df["value"]
-        return df.dropna(how="any").loc[:, self.ALL_COLS]
+        return df.loc[:, self.ALL_COLS].dropna(how="any")
 
     def _province(self, country):
         """Returns province-level data.

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -39,9 +39,8 @@ class _WPP(_DataBase):
                     - City (object): NAs
                     - Population (numpy.float64): population values
         """
-        url = f"{self.TOP_URL}country/all/indicator/SP.POP.TOTLL?per_page=30000"
+        url = f"{self.TOP_URL}country/all/indicator/SP.POP.TOTL?per_page=20000"
         df = pd.read_xml(url,  parser="etree")
-        print(df.columns)
         df[self.DATE] = pd.to_datetime(df["date"], format="%Y") + pd.offsets.DateOffset(months=6)
         df = df.rename({"countryiso3code": Term.ISO3})
         df[self.PROVINCE] = self.NA

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -41,6 +41,7 @@ class _WPP(_DataBase):
         """
         url = f"{self.TOP_URL}country/all/indicator/SP.POP.TOTLL?per_page=30000"
         df = pd.read_xml(url,  parser="etree")
+        print(df.columns)
         df[self.DATE] = pd.to_datetime(df["date"], format="%Y") + pd.offsets.DateOffset(months=6)
         df = df.rename({"countryiso3code": Term.ISO3})
         df[self.PROVINCE] = self.NA

--- a/covsirphy/downloading/_db_wpp.py
+++ b/covsirphy/downloading/_db_wpp.py
@@ -38,7 +38,7 @@ class _WPP(_DataBase):
                     - City (object): NAs
                     - Population (numpy.float64): population values
         """
-        url = f"{self.TOP_URL}WPP2022_TotalPopulationBySex.csv.gz"
+        url = f"{self.TOP_URL}WPP2024_TotalPopulationBySex.csv.gz"
         df = self._provide(url=url, suffix="_level1", columns=list(self.COL_DICT.keys()))
         df[self.DATE] = pd.to_datetime(df["Year"], format="%Y") + pd.offsets.DateOffset(months=6)
         df[self.PROVINCE] = self.NA

--- a/covsirphy/downloading/_provider.py
+++ b/covsirphy/downloading/_provider.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from urllib3 import PoolManager
 from urllib3.util.ssl_ import create_urllib3_context
 import warnings
-from zipfile import ZipFile,BadZipFile
+from zipfile import ZipFile, BadZipFile
 import numpy as np
 import pandas as pd
 from unidecode import unidecode

--- a/covsirphy/downloading/_provider.py
+++ b/covsirphy/downloading/_provider.py
@@ -7,7 +7,7 @@ from urllib.parse import urlparse
 from urllib3 import PoolManager
 from urllib3.util.ssl_ import create_urllib3_context
 import warnings
-from zipfile import ZipFile
+from zipfile import ZipFile,BadZipFile
 import numpy as np
 import pandas as pd
 from unidecode import unidecode
@@ -104,10 +104,12 @@ class _DataProvider(Term):
             "header": 0, "usecols": columns, "encoding": "utf-8", "engine": "pyarrow",
             "parse_dates": None if date is None else [date], "date_format": date_format,
         }
-        if urlparse(path).scheme:
-            kwargs["storage_options"] = {"User-Agent": "Mozilla/5.0"}
         try:
-            df = pd.read_csv(path, **kwargs)
+            df = pd.read_csv(
+                path,
+                storage_options={"User-Agent": "Mozilla/5.0"} if urlparse(path).scheme else None,
+                **kwargs
+            )
         except URLError:
             ctx = create_urllib3_context()
             ctx.load_default_certs()
@@ -115,9 +117,12 @@ class _DataProvider(Term):
             ctx.options |= 0x4
             with PoolManager(ssl_context=ctx) as http:
                 r = http.request("GET", path)
-                with ZipFile(io.BytesIO(r.data), "r") as fh:
-                    text = fh.read(f"{Path(path).stem}.csv")
-            df = pd.read_csv(io.StringIO(text.decode("utf-8")))
+                try:
+                    with ZipFile(io.BytesIO(r.data), "r") as fh:
+                        text = fh.read(f"{Path(path).stem}.csv")
+                        df = pd.read_csv(io.StringIO(text.decode("utf-8")), **kwargs)
+                except BadZipFile:
+                    df = pd.read_csv(io.BytesIO(r.data), **kwargs)
         for col in df:
             with contextlib.suppress(TypeError):
                 df[col] = df[col].apply(lambda x: unidecode(x) if len(x) else np.nan)


### PR DESCRIPTION
## Related issues
fix #1720

## What was changed
Catch up with the change of compressed file format from .zip to .csv.gz regarding population data.

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses issue #1720 by updating the URL for downloading World Population Prospects data to reflect the change in file format from .zip to .csv.gz. Additionally, a minor correction was made to the citation comment.

- **Bug Fixes**:
    - Updated the URL for downloading World Population Prospects data to reflect the change in file format from .zip to .csv.gz.

<!-- Generated by sourcery-ai[bot]: end summary -->