### PR TITLE
Replace GitHub Action tool to work

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -134,11 +134,15 @@ jobs:
     steps:
       - uses: actions/checkout@main
       - name: Setup conda
-        uses: s-weigand/setup-conda@main
+        uses: conda-incubator/setup-miniconda@main
         with:
-          update-conda: true
           python-version: ${{ matrix.python-version }}
-          conda-channels: anaconda, conda-forge
+          auto-activate-base: true
+          activate-environment: true
+          channels: conda-forge
+          miniforge-version: 24.3.0-0
+          show-channel-urls: true
+          use-only-tar-bz2: false
 
       - name: installation of CovsirPhy
         run: |


### PR DESCRIPTION
## Related issues
Close #1754

## What was changed
Replace GitHub Action tool to work.

## Summary by Sourcery

Update the GitHub Actions workflow to use 'conda-incubator/setup-miniconda' for setting up conda, replacing the previous 's-weigand/setup-conda' action.

CI:
- Replace the GitHub Action for setting up conda from 's-weigand/setup-conda' to 'conda-incubator/setup-miniconda' in the test workflow.