### PR TITLE
docs: add BibTeX format citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ cs.__citation__
 BibTeX format citation is here.
 
 ```
-@misc{github_repo,
+@misc{covsirphy_repo,
 author = {Hirokazu Takaya and CovsirPhy Development Team},
 title = {CovsirPhy version [version number]: Python library for COVID-19 analysis with phase-dependent SIR-derived ODE models},
 year = {2020},

--- a/data/README.md
+++ b/data/README.md
@@ -150,7 +150,7 @@ Kindly cite this dataset under CC BY-4.0 license as follows.
 BibTeX format citation is here.
 
 ```
-@misc{github_repo,
+@misc{covid19_jp_repo,
 author = {Hirokazu Takaya},
 title = {COVID-19 dataset in Japan},
 year = {2020},


### PR DESCRIPTION
## Related issues
Close #1764.

## What was changed
Add BibTeX format citations of CovsirPhy and COVID-19 dataset in Japan.

## Summary by Sourcery

Documentation:
- Add BibTeX format citations for CovsirPhy and the COVID-19 dataset in Japan to the documentation.