### PR TITLE
test: fix test error with TypeError: '>=' not supported between instances of 'float' and 'Timestamp'

### DIFF
--- a/covsirphy/engineering/_cleaner.py
+++ b/covsirphy/engineering/_cleaner.py
@@ -64,7 +64,10 @@ class _DataCleaner(Term):
             df = df[df[self._date].between(start, end, inclusive="both")]
         grouped = df.set_index(self._date).groupby(self._layers, as_index=False, observed=True)
         df = grouped[list(set(df.columns) - set([self._date]))].resample("D").ffill()
-        self._df = df.drop("Country", errors="ignore", axis=1).reset_index().drop("level_0", errors="ignore", axis=1)
+        try:
+            self._df = df.reset_index().drop("level_0", errors="ignore", axis=1)
+        except ValueError:
+            self._df = df.drop("Country", errors="ignore", axis=1).reset_index().drop("level_0", errors="ignore", axis=1)
 
     def fillna(self):
         """Fill NA values with '-' (layers) and the previous values and 0.

--- a/tests/test_engineering/test_engineer.py
+++ b/tests/test_engineering/test_engineer.py
@@ -72,7 +72,7 @@ def test_variables_alias():
 def test_resample_with_date_range():
     eng = DataEngineer(layers=["Country"], country=["Country"])
     eng.download(databases=["wpp"])
-    eng.clean(kinds=["resample"], date_range=("01Jan2024", "19Sep2024"))
+    eng.clean(kinds=["resample"], date_range=("01Jan2021", "12Dec2024"))
     df = eng.all()
-    assert df["Date"].min() >= pd.to_datetime("01Jan2024")
-    assert df["Date"].max() <= pd.to_datetime("19Sep2024")
+    assert df["Date"].min() >= pd.to_datetime("01Jan2021")
+    assert df["Date"].max() <= pd.to_datetime("12Dec2024")

--- a/tests/test_engineering/test_engineer.py
+++ b/tests/test_engineering/test_engineer.py
@@ -74,5 +74,6 @@ def test_resample_with_date_range():
     eng.download(databases=["wpp"])
     eng.clean(kinds=["resample"], date_range=("01Jan2022", "19Sep2022"))
     df = eng.all()
+    print(df)
     assert df["Date"].min() >= pd.to_datetime("01Jan2022")
     assert df["Date"].max() <= pd.to_datetime("19Sep2022")

--- a/tests/test_engineering/test_engineer.py
+++ b/tests/test_engineering/test_engineer.py
@@ -72,8 +72,7 @@ def test_variables_alias():
 def test_resample_with_date_range():
     eng = DataEngineer(layers=["Country"], country=["Country"])
     eng.download(databases=["wpp"])
-    eng.clean(kinds=["resample"], date_range=("01Jan2022", "19Sep2022"))
+    eng.clean(kinds=["resample"], date_range=("01Jan2024", "19Sep2024"))
     df = eng.all()
-    print(df)
-    assert df["Date"].min() >= pd.to_datetime("01Jan2022")
-    assert df["Date"].max() <= pd.to_datetime("19Sep2022")
+    assert df["Date"].min() >= pd.to_datetime("01Jan2024")
+    assert df["Date"].max() <= pd.to_datetime("19Sep2024")

--- a/tests/test_engineering/test_engineer.py
+++ b/tests/test_engineering/test_engineer.py
@@ -74,5 +74,5 @@ def test_resample_with_date_range():
     eng.download(databases=["wpp"])
     eng.clean(kinds=["resample"], date_range=("01Jan2022", "19Sep2022"))
     df = eng.all()
-    assert pd.to_datetime(df["Date"].min()) >= pd.to_datetime("01Jan2022")
-    assert pd.to_datetime(df["Date"].max()) <= pd.to_datetime("19Sep2022")
+    assert df["Date"].min() >= pd.to_datetime("01Jan2022")
+    assert df["Date"].max() <= pd.to_datetime("19Sep2022")

--- a/tests/test_engineering/test_engineer.py
+++ b/tests/test_engineering/test_engineer.py
@@ -74,5 +74,5 @@ def test_resample_with_date_range():
     eng.download(databases=["wpp"])
     eng.clean(kinds=["resample"], date_range=("01Jan2022", "19Sep2022"))
     df = eng.all()
-    assert df["Date"].min() >= pd.to_datetime("01Jan2022")
-    assert df["Date"].max() <= pd.to_datetime("19Sep2022")
+    assert pd.to_datetime(df["Date"].min()) >= pd.to_datetime("01Jan2022")
+    assert pd.to_datetime(df["Date"].max()) <= pd.to_datetime("19Sep2022")


### PR DESCRIPTION
## Related issues
#1823

## What was changed
Close #1823

## Summary by Sourcery

Fix type comparison issue in date range test by explicitly converting DataFrame date column to datetime

Bug Fixes:
- Resolve TypeError when comparing float and Timestamp by using pd.to_datetime() conversion on DataFrame date column

Tests:
- Update date range assertion in test_resample_with_date_range to ensure correct datetime comparison